### PR TITLE
Updates Flowcrypt icon used in browser 

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -4,18 +4,17 @@
   "description": "Simple end-to-end encryption to secure email and attachments on Google.",
   "version": "[will be replaced during build]",
   "browser_action": {
-    "default_icon": "/img/logo/flowcrypt-logo-16-16.png",
+    "default_icon": {
+      "16": "/img/logo/flowcrypt-logo-16-16.png",
+      "19": "/img/logo/flowcrypt-logo-19-19.png",
+      "24": "/img/logo/flowcrypt-logo-24-24.png",
+      "32": "/img/logo/flowcrypt-logo-32-32.png",
+      "48": "/img/logo/flowcrypt-logo-48-48.png",
+      "64": "/img/logo/flowcrypt-logo-64-64.png",
+      "128": "/img/logo/flowcrypt-logo-128-128.png"
+    },
     "default_title": "FlowCrypt Encryption for Gmail",
     "default_popup": "/chrome/popups/default.htm"
-  },
-  "icons": {
-    "16": "/img/logo/flowcrypt-logo-16-16.png",
-    "19": "/img/logo/flowcrypt-logo-19-19.png",
-    "24": "/img/logo/flowcrypt-logo-24-24.png",
-    "32": "/img/logo/flowcrypt-logo-32-32.png",
-    "48": "/img/logo/flowcrypt-logo-48-48.png",
-    "64": "/img/logo/flowcrypt-logo-64-64.png",
-    "128": "/img/logo/flowcrypt-logo-128-128.png"
   },
   "permissions": ["storage", "tabs", "*://*/*", "unlimitedStorage", "clipboardWrite", "webRequest"],
   "content_scripts": [


### PR DESCRIPTION

<img width="155" alt="screen shot 2018-08-05 at 8 18 25 pm" src="https://user-images.githubusercontent.com/3431871/43691824-b601ae22-98ef-11e8-8216-477194ff1eb7.png">



- Replacing the `icon` property for `default_icon` , Fixes bug with higher resolution icons shown. 
https://developer.chrome.com/extensions/tut_migration_to_manifest_v2#api-checklist



<img width="502" alt="screen shot 2018-08-05 at 8 37 53 pm" src="https://user-images.githubusercontent.com/3431871/43691823-b5d74f6a-98ef-11e8-9c50-33a7a883d692.png">
