### PR TITLE
Remove ambiguity from backup option

### DIFF
--- a/extension/chrome/settings/modules/backup.htm
+++ b/extension/chrome/settings/modules/backup.htm
@@ -99,7 +99,7 @@
                 <span class="green_label colored_label short">great security</span>
               </div>
               <div class="text-left">
-                <p>Download your key as a file. Very secure option if your device is encrypted, or if you can keep a file stored securely. If you lose both your laptop and the file, your encrypted email will be unreadable, so you need to keep this file in a safe place. Regular emails will not be affected.</p>
+                <p>Download your PGP private key. This key is <i>not</i> encrypted with your pass phrase. You're in charge of your security. Good option if your device is encrypted and only you can access your files. If you lose the private key <i>and</i> your device, your encrypted email will become unreadable.</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Asked some noobs. First two mistakes:

* Assuming this key is protected with the passphrase.
* Not knowing if this is the public or private key they need to backup.

Both can be fixed by changing this explanatory sentence.