### PR TITLE
check if password box etc. should be removed recipient deletion via backspace

### DIFF
--- a/extension/js/common/composer.ts
+++ b/extension/js/common/composer.ts
@@ -989,6 +989,7 @@ export class Composer {
     const keys = Env.keyCodes();
     if (!value && inputToKeydownEvent.which === keys.backspace) {
       $('.recipients span').last().remove();
+      this.showHidePwdOrPubkeyContainerAndColorSendBtn();
     } else if (value && (inputToKeydownEvent.which === keys.enter || inputToKeydownEvent.which === keys.tab)) {
       this.S.cached('input_to').blur();
       if (this.S.cached('contacts').css('display') === 'block') {


### PR DESCRIPTION
Solves https://github.com/FlowCrypt/flowcrypt-browser/issues/1001

Considered using `this.removeReceiver(htmlElement)` but it expects the recipient close "x" element to be passed which is a bit clunky, and`this.showHidePwdOrPubkeyContainerAndColorSendBtn();` is already used a few times in the same manner.