### PR TITLE
fixes #929 : Use Gmail api to fetch user email aliases

### DIFF
--- a/extension/js/common/api/api.ts
+++ b/extension/js/common/api/api.ts
@@ -194,8 +194,8 @@ export namespace R { // responses
   export type GmailDraftUpdate = {};
   export type GmailDraftGet = { id: string, message: GmailMsg };
   export type GmailDraftSend = {};
-  export type GmailAliases = { sendAs: GmailAlias[] };
-  export type GmailAlias = { sendAsEmail: string, displayName: string, replyToAddress: string, signature: string, isDefault: boolean, treatAsAlias: boolean, verificationStatus: string };
+  export type GmailAliases = { sendAs: GmailAliases$sendAs[] };
+  type GmailAliases$sendAs = { sendAsEmail: string, displayName: string, replyToAddress: string, signature: string, isDefault: boolean, treatAsAlias: boolean, verificationStatus: string };
 
   export type OpenId = { // 'name' is the full name, picture is url
     at_hash: string; exp: number; iat: number; sub: string; aud: string; azp: string; iss: "https://accounts.google.com";

--- a/extension/js/common/api/api.ts
+++ b/extension/js/common/api/api.ts
@@ -194,6 +194,8 @@ export namespace R { // responses
   export type GmailDraftUpdate = {};
   export type GmailDraftGet = { id: string, message: GmailMsg };
   export type GmailDraftSend = {};
+  export type GmailAliases = { sendAs: GmailAlias[] };
+  export type GmailAlias = { sendAsEmail: string, displayName: string, replyToAddress: string, signature: string, isDefault: boolean, treatAsAlias: boolean, verificationStatus: string };
 
   export type OpenId = { // 'name' is the full name, picture is url
     at_hash: string; exp: number; iat: number; sub: string; aud: string; azp: string; iss: "https://accounts.google.com";

--- a/extension/js/common/api/google.ts
+++ b/extension/js/common/api/google.ts
@@ -355,6 +355,7 @@ export class Google extends Api {
         }
       }
     },
+    fetchAcctAliases: async (acctEmail: string): Promise<R.GmailAliases> => Google.gmailCall(acctEmail, 'GET', 'settings/sendAs', {}),
     fetchMsgsHeadersBasedOnQuery: async (acctEmail: string, q: string, headerNames: string[], msgLimit: number) => {
       const { messages } = await Google.gmail.msgList(acctEmail, q, false);
       return await Google.extractHeadersFromMsgs(acctEmail, messages || [], headerNames, msgLimit);

--- a/extension/js/common/settings.ts
+++ b/extension/js/common/settings.ts
@@ -21,18 +21,13 @@ export class Settings {
   private static ignoreEmailAliases = ['nobody@google.com'];
 
   static fetchAcctAliasesFromGmail = async (acctEmail: string) => {
-    let query = 'newer_than:1y in:sent -from:"calendar-notification@google.com" -from:"drive-shares-noreply@google.com"';
-    const results = [];
-    while (true) {
-      const headers = await Google.gmail.fetchMsgsHeadersBasedOnQuery(acctEmail, query, ['from'], 1);
-      if (!headers.from.length) {
-        return results.filter(email => !Value.is(email).in(Settings.ignoreEmailAliases));
-      }
-      for (const from of headers.from) {
-        results.push(Str.parseEmail(from).email);
-        query += ' -from:"' + Str.parseEmail(from).email + '"';
-      }
-    }
+    const response = await Google.gmail.fetchAcctAliases(acctEmail);
+
+    const aliases = response.sendAs.map(alias => {
+      return alias.sendAsEmail;
+    });
+
+    return aliases.filter(email => !Value.is(email).in(Settings.ignoreEmailAliases));
   }
 
   static evalPasswordStrength = (passphrase: string) => {

--- a/extension/js/common/settings.ts
+++ b/extension/js/common/settings.ts
@@ -18,16 +18,11 @@ declare const zxcvbn: Function; // tslint:disable-line:ban-types
 
 export class Settings {
 
-  private static ignoreEmailAliases = ['nobody@google.com'];
-
   static fetchAcctAliasesFromGmail = async (acctEmail: string) => {
     const response = await Google.gmail.fetchAcctAliases(acctEmail);
-
-    const aliases = response.sendAs.map(alias => {
-      return alias.sendAsEmail;
-    });
-
-    return aliases.filter(email => !Value.is(email).in(Settings.ignoreEmailAliases));
+    return response.sendAs
+      .filter(alias => alias.isDefault || alias.verificationStatus === 'accepted')
+      .map(alias => alias.sendAsEmail);
   }
 
   static evalPasswordStrength = (passphrase: string) => {


### PR DESCRIPTION
Anything that needs to be done to setup tests so I can write some? I get:
`Error: ENOENT: no such file or directory, open 'test/test-secrets.json'`

Also, we could filter out emails on "verificationStatus" (user might not have validated his alias) or leave that to users to decide. What do you think?