### PR TITLE
Allow a draft to be saved if body or subject has changed

### DIFF
--- a/extension/js/common/composer.ts
+++ b/extension/js/common/composer.ts
@@ -127,6 +127,7 @@ export class Composer {
   private FC_WEB_URL = 'https://flowcrypt.com'; // todo - should use Api.url()
 
   private lastDraft = '';
+  private lastSubject = '';
   private canReadEmails: boolean;
   private lastReplyBoxTableHeight = 0;
   private contactSearchInProgress = false;
@@ -406,7 +407,7 @@ export class Composer {
   }
 
   private draftSave = async (forceSave: boolean = false): Promise<void> => {
-    if (this.shouldSaveDraft(this.S.cached('input_text').text()) || forceSave) {
+    if (this.hasBodyChanged(this.S.cached('input_text').text()) || this.hasSubjectChanged(String(this.S.cached('input_subject').val())) || forceSave) {
       this.currentlySavingDraft = true;
       try {
         this.S.cached('send_btn_note').text('Saving');
@@ -1550,13 +1551,20 @@ export class Composer {
     }
   }
 
-  private shouldSaveDraft = (msgBody: string) => {
+  private hasBodyChanged = (msgBody: string) => {
     if (msgBody && msgBody !== this.lastDraft) {
       this.lastDraft = msgBody;
       return true;
-    } else {
-      return false;
     }
+    return false;
+  }
+
+  private hasSubjectChanged = (subject: string) => {
+    if (subject && subject !== this.lastSubject) {
+      this.lastSubject = subject;
+      return true;
+    }
+    return false;
   }
 
   private fmtPwdProtectedEmail = (shortId: string, encryptedBody: SendableMsgBody, armoredPubkeys: string[], atts: Att[], lang: 'DE' | 'EN') => {


### PR DESCRIPTION
Applies feature for #813 In the `draftSave` function, which is executed every 3 seconds, I added a test for ensuring the subject line has changed. If the subject line OR the message body have changed, then the daftSave function is executed.

I am tracking the subject line in a variable called `lastSubject`, which is changed to the new subject line when the function `hasSubjectChanged` has been executed.

The function for testing whether the messageBody has changed was also modified slightly because the `else` seemed redundant. This function was renamed to `hasBodyChanged`, and was copied to `hasSubjectChanged` for testing changes to the subject line.