### PR TITLE
Fixes 1414 - add a 'show original' button to fc inbox

### DIFF
--- a/extension/chrome/settings/inbox/inbox.htm
+++ b/extension/chrome/settings/inbox/inbox.htm
@@ -37,6 +37,7 @@
 
         <div class="line left header">
           <h1></h1>
+          <span class="action_see_original_message" style="display:none; text-transform: uppercase;font-size: 9.5px;color: white;background: #31A217;padding: 2px 3px 2px 3px;border-radius: 2px;cursor: default;">See Original</span>
         </div>
         <div class="threads block"></div>
         <div class="thread block"></div>

--- a/extension/chrome/settings/inbox/inbox.ts
+++ b/extension/chrome/settings/inbox/inbox.ts
@@ -21,7 +21,7 @@ Catch.try(async () => {
   const acctEmail = Env.urlParamRequire.string(uncheckedUrlParams, 'acctEmail');
   const labelId = uncheckedUrlParams.labelId ? String(uncheckedUrlParams.labelId) : 'INBOX';
   const threadId = Env.urlParamRequire.optionalString(uncheckedUrlParams, 'threadId');
-  const showOriginal = Env.urlParamRequire.optionalString(uncheckedUrlParams, 'showOriginal') === 'true' ? true : false;
+  const showOriginal = uncheckedUrlParams.showOriginal === true;
   let threadHasPGPMessage = false;
 
   let emailProvider;
@@ -350,15 +350,9 @@ Catch.try(async () => {
 
       if (threadHasPGPMessage) {
         $(".action_see_original_message").css('display', 'inline-block');
+        $(".action_see_original_message").click(Ui.event.handle(() => loadUrl({ acctEmail, threadId, showOriginal: !showOriginal })));
         if (showOriginal) {
           $(".action_see_original_message").text('See Decrypted');
-          $(".action_see_original_message").click(Ui.event.prevent('double', async (self) => {
-            loadUrl({ "acctEmail": acctEmail, "threadId": threadId });
-          }));
-        } else {
-          $(".action_see_original_message").click(Ui.event.prevent('double', async (self) => {
-            loadUrl({ "acctEmail": acctEmail, "threadId": threadId, "showOriginal": "true" });
-          }));
         }
       }
 

--- a/extension/chrome/settings/inbox/inbox.ts
+++ b/extension/chrome/settings/inbox/inbox.ts
@@ -21,7 +21,7 @@ Catch.try(async () => {
   const acctEmail = Env.urlParamRequire.string(uncheckedUrlParams, 'acctEmail');
   const labelId = uncheckedUrlParams.labelId ? String(uncheckedUrlParams.labelId) : 'INBOX';
   const threadId = Env.urlParamRequire.optionalString(uncheckedUrlParams, 'threadId');
-  let showOriginal = Env.urlParamRequire.optionalString(uncheckedUrlParams, 'showOriginal') === 'true' ? true : false;
+  const showOriginal = Env.urlParamRequire.optionalString(uncheckedUrlParams, 'showOriginal') === 'true' ? true : false;
   let threadHasPGPMessage = false;
 
   let emailProvider;
@@ -361,7 +361,6 @@ Catch.try(async () => {
           }));
         }
       }
-
 
       renderReplyBox(threadId, thread.messages[thread.messages.length - 1].id, thread.messages[thread.messages.length - 1]);
       // await Google.gmail.threadModify(acctEmail, threadId, [LABEL.UNREAD], []); // missing permission https://github.com/FlowCrypt/flowcrypt-browser/issues/1304


### PR DESCRIPTION
- Adds a 'Show Original' button to the FlowCrypt inbox
- Only shows the button if there are PGP messages in the thread
- When button is click:
  - page is reloaded with a 'showOriginal' url param set to 'true'
  - PGP blocks are not rendered but instead shown as text wrapped in a pre tag
  - The button is changed to show 'See Decrypted' now
  - When 'See Decrypted' is clicked page is reloaded again but with the 'showOriginal' url param omitted