### PR TITLE
Reload reply iframe instead of removing it

### DIFF
--- a/extension/js/common/composer.ts
+++ b/extension/js/common/composer.ts
@@ -299,7 +299,6 @@ export class Composer {
     }, this.getErrHandlers(`change footer`)));
     $('.delete_draft').click(Ui.event.handle(async () => {
       await this.draftDelete();
-
       // Reload iframe so we don't leave users without a reply UI.
       window.location.reload();
     }, this.getErrHandlers('delete draft')));

--- a/extension/js/common/composer.ts
+++ b/extension/js/common/composer.ts
@@ -299,7 +299,9 @@ export class Composer {
     }, this.getErrHandlers(`change footer`)));
     $('.delete_draft').click(Ui.event.handle(async () => {
       await this.draftDelete();
-      this.app.closeMsg();
+
+      // Reload iframe so we don't leave users without a reply UI.
+      window.location.reload();
     }, this.getErrHandlers('delete draft')));
     this.S.cached('body').bind({ drop: Ui.event.stop(), dragover: Ui.event.stop() }); // prevents files dropped out of the intended drop area to screw up the page
     this.S.cached('icon_sign').click(Ui.event.handle(() => this.toggleSignIcon(), this.getErrHandlers(`enable/disable signing`)));

--- a/extension/js/common/composer.ts
+++ b/extension/js/common/composer.ts
@@ -300,7 +300,8 @@ export class Composer {
     $('.delete_draft').click(Ui.event.handle(async () => {
       await this.draftDelete();
       // Reload iframe so we don't leave users without a reply UI.
-      window.location.reload();
+      this.v.skipClickPrompt = false;
+      window.location.href = Env.urlCreate(window.location.protocol + '//' + window.location.hostname + window.location.pathname, this.v);
     }, this.getErrHandlers('delete draft')));
     this.S.cached('body').bind({ drop: Ui.event.stop(), dragover: Ui.event.stop() }); // prevents files dropped out of the intended drop area to screw up the page
     this.S.cached('icon_sign').click(Ui.event.handle(() => this.toggleSignIcon(), this.getErrHandlers(`enable/disable signing`)));


### PR DESCRIPTION
Fixes https://github.com/FlowCrypt/flowcrypt-browser/issues/1564

Note that this UX differs from that of deleting a normal gmail reply:
Normal reply --> delete draft --> editor closes and user needs to click reply again
Secure reply --> delete draft --> text disappears, any extra recipients disappear, but editor stays open.

This was the ask in https://github.com/FlowCrypt/flowcrypt-browser/issues/1564, and I think it's a fine UX, just wanted to make the difference explicit.