### PR TITLE
Leave empty reply empty on message send

### DIFF
--- a/extension/js/common/browser.ts
+++ b/extension/js/common/browser.ts
@@ -832,7 +832,7 @@ export class XssSafeFactory {
       const headers = this.resolveFromTo(convoParams.addresses || [], convoParams.myEmail || this.acctEmail, convoParams.replyTo);
       params.to = headers.to;
       params.from = headers.from;
-      params.subject = 'Re: ' + convoParams.subject;
+      params.subject = convoParams.subject ? 'Re: ' + convoParams.subject : '';
     }
     return this.frameSrc(this.extUrl('chrome/elements/compose.htm'), params);
   }

--- a/extension/js/common/composer.ts
+++ b/extension/js/common/composer.ts
@@ -628,7 +628,7 @@ export class Composer {
   private extractProcessSendMsg = async () => {
     try {
       const recipients = this.getRecipientsFromDom();
-      const subject = this.v.subject || String($('#input_subject').val()); // replies have subject in url params
+      const subject = this.v.subject || ($('#input_subject').val() === undefined ? '' : String($('#input_subject').val())); // replies have subject in url params
       const plaintext = this.extractAsText('input_text');
       await this.throwIfFormNotReady(recipients);
       this.S.now('send_btn_span').text('Loading');


### PR DESCRIPTION
Remove automatic adding of "Re: <subject>" in browser.ts and detect undefined and use empty string instead upon send in composer.ts