### PR TITLE
Add a button to import binary keyfile

### DIFF
--- a/extension/chrome/settings/modules/contacts.htm
+++ b/extension/chrome/settings/modules/contacts.htm
@@ -34,9 +34,9 @@
     <div id="bulk_import" style="display: none;">
       <div id="file_import">
         <div class="line">
-          <div class="button green action_binary_keyfile long">binary key file</div>
+          <div class="button green action_open_keyfile long">keyring file</div>
+          <input type="file" id="keyfile_input" style="display: none;" />
         </div>
-        <input type="file" id="binary_file" style="display:none" />
       </div>
       <div id="processed"></div>
       <div class="line">

--- a/extension/chrome/settings/modules/contacts.htm
+++ b/extension/chrome/settings/modules/contacts.htm
@@ -12,6 +12,8 @@
   <link rel="stylesheet" href="/lib/featherlight/featherlight.css" />
   <link rel="stylesheet" href="/css/mobile-menu-styling.css" />
   <link rel="icon" href="/img/logo/flowcrypt-logo-19-19.png" />
+  <link rel="stylesheet" href="/css/fine-uploader-new.css" />
+  <script type="text/template" src="/chrome/elements/hared/attach.template.htm" id="qq-template"></script>
 </head>
 
 <body id="settings">
@@ -34,8 +36,8 @@
     <div id="bulk_import" style="display: none;">
       <div id="file_import">
         <div class="line">
-          <div class="button green action_open_keyfile long">keyring file</div>
-          <input type="file" id="keyfile_input" style="display: none;" />
+          <div id="fineuploader_button" class="button green long">keyring file</div>
+          <div id="fineuploader" class="display_none"></div>
         </div>
       </div>
       <div id="processed"></div>
@@ -72,6 +74,7 @@
   <script src="/lib/purify.min.js"></script>
   <script src="/lib/jquery.min.js"></script>
   <script src="/lib/featherlight/featherlight.js"></script>
+  <script src="/lib/fine-uploader.js"></script>
   <script src="/lib/openpgp.js"></script>
   <script src="contacts.js" type="module"></script>
 </body>

--- a/extension/chrome/settings/modules/contacts.htm
+++ b/extension/chrome/settings/modules/contacts.htm
@@ -32,6 +32,12 @@
     </div>
 
     <div id="bulk_import" style="display: none;">
+      <div id="file_import">
+        <div class="line">
+          <div class="button green action_binary_keyfile long">binary key file</div>
+        </div>
+        <input type="file" id="binary_file" style="display:none" />
+      </div>
       <div id="processed"></div>
       <div class="line">
         <textarea class="input_pubkey" placeholder="Enter one or more ASCII Armored Public Keys to import"></textarea>

--- a/extension/chrome/settings/modules/contacts.htm
+++ b/extension/chrome/settings/modules/contacts.htm
@@ -14,31 +14,37 @@
   <link rel="icon" href="/img/logo/flowcrypt-logo-19-19.png" />
   <link rel="stylesheet" href="/css/fine-uploader-new.css" />
   <script type="text/template" src="/chrome/elements/hared/attach.template.htm" id="qq-template"></script>
+  <style>
+    #fineuploader_button {
+      overflow: initial !important;
+    }
+  </style>
 </head>
 
 <body id="settings">
   <div id="content" class="contacts page" data-test="page-contacts">
+
     <div class="line">
       <h1></h1>
     </div>
+
     <div class="separator"></div>
+
     <div class="line hide_when_rendering_subpage">
       You can add new contacts while composing encrypted emails. If recipient's public key<br />
       is not available, you will be prompted to enter it yourself.
     </div>
-    <div class="line hide_when_rendering_subpage actions"></div>
-    <div class="line text-center" style="margin: 0 auto;">
-      <table id="emails" class="hide_when_rendering_subpage">
 
-      </table>
+    <div class="line hide_when_rendering_subpage actions"></div>
+
+    <div class="line text-center hide_when_rendering_subpage" style="margin: 0 auto;">
+      <table id="emails"></table>
     </div>
 
     <div id="bulk_import" style="display: none;">
-      <div id="file_import">
-        <div class="line">
-          <div id="fineuploader_button" class="button green long">keyring file</div>
-          <div id="fineuploader" class="display_none"></div>
-        </div>
+      <div class="line" id="file_import">
+        <a id="fineuploader_button" href="#">Select a file</a> or paste public key(s) below:
+        <div id="fineuploader" class="display_none"></div>
       </div>
       <div id="processed"></div>
       <div class="line">

--- a/extension/chrome/settings/modules/contacts.ts
+++ b/extension/chrome/settings/modules/contacts.ts
@@ -41,6 +41,7 @@ Catch.try(async () => {
       $('#bulk_import .input_pubkey').val('').css('display', 'inline-block');
       $('#bulk_import .action_process').css('display', 'inline-block');
       $('#bulk_import #processed').text('').css('display', 'none');
+      $('#file_import .action_binary_keyfile').css('display', 'inline-block');
       $('#page_back_button').click(Ui.event.handle(() => renderContactList()));
     }));
 
@@ -106,6 +107,7 @@ Catch.try(async () => {
       $('#bulk_import .input_pubkey').val('').css('display', 'inline-block');
       $('#bulk_import .action_process').css('display', 'inline-block');
       $('#bulk_import #processed').text('').css('display', 'none');
+      $('#file_import .action_binary_keyfile').css('display', 'inline-block');
       $('#page_back_button').click(Ui.event.handle(() => renderContactList()));
     }));
 
@@ -115,7 +117,27 @@ Catch.try(async () => {
         await Ui.modal.warning('Could not find any new public keys');
       } else {
         $('#bulk_import #processed').html(replacedHtmlSafe).css('display', 'block'); // xss-safe-factory
-        $('#bulk_import .input_pubkey, #bulk_import .action_process').css('display', 'none');
+        $('#bulk_import .input_pubkey, #bulk_import .action_process, #file_import .action_binary_keyfile').css('display', 'none');
+      }
+    }));
+
+    $('#file_import .action_binary_keyfile').off().click(Ui.event.prevent('double', async target => {
+      $('#binary_file').click();
+    }));
+
+    $('#binary_file').change(Ui.event.handle(async (self, event: JQuery.Event<HTMLInputElement, null>) => {
+      if (event !== null && typeof event !== 'undefined') {
+        if (event.target.files !== null && typeof event.target.files !== 'undefined' && event.target.files.length > 0) {
+          const fileReader = new FileReader();
+          fileReader.onload = async () => {
+            if (fileReader.result instanceof ArrayBuffer) {
+              const binaryKey = new Uint8Array(fileReader.result);
+              const key = await Pgp.key.readBinary(binaryKey);
+              $('#bulk_import .input_pubkey').val(key.armor());
+            }
+          };
+          fileReader.readAsArrayBuffer(event.target.files[0]);
+        }
       }
     }));
 

--- a/extension/js/common/browser.ts
+++ b/extension/js/common/browser.ts
@@ -1239,6 +1239,14 @@ export class AttUI {
     return atts;
   }
 
+  clearAtt = (id: string) => {
+    delete this.attachedFiles[id];
+  }
+
+  clearAtts = () => {
+    this.attachedFiles  = {};
+  }
+
   private cancelAtt = (id: string) => {
     delete this.attachedFiles[id];
   }

--- a/extension/js/common/browser.ts
+++ b/extension/js/common/browser.ts
@@ -1239,10 +1239,6 @@ export class AttUI {
     return atts;
   }
 
-  clearAtt = (id: string) => {
-    delete this.attachedFiles[id];
-  }
-
   clearAtts = () => {
     this.attachedFiles  = {};
   }

--- a/extension/js/common/browser.ts
+++ b/extension/js/common/browser.ts
@@ -1239,8 +1239,8 @@ export class AttUI {
     return atts;
   }
 
-  clearAtts = () => {
-    this.attachedFiles  = {};
+  clearAllAtts = () => {
+    this.attachedFiles = {};
   }
 
   private cancelAtt = (id: string) => {

--- a/extension/js/common/browser.ts
+++ b/extension/js/common/browser.ts
@@ -1242,7 +1242,7 @@ export class AttUI {
   clearAllAtts = () => {
     this.attachedFiles = {};
   }
-  
+
   private cancelAtt = (uploadFileId: string) => {
     delete this.attachedFiles[uploadFileId];
   }

--- a/extension/js/common/core/pgp.ts
+++ b/extension/js/common/core/pgp.ts
@@ -2,7 +2,6 @@
 
 'use strict';
 
-import { VERSION } from './const.js';
 import { Catch } from '../platform/catch.js';
 import { Store } from '../platform/store.js';
 import { Value, Str } from './common.js';
@@ -15,12 +14,6 @@ import { FcAttLinkData } from './att.js';
 import { Buf } from './buf.js';
 
 const openpgp = requireOpenpgp();
-
-if (typeof openpgp !== 'undefined') { // in certain environments, eg browser content scripts, openpgp is not included (not all functions below need it)
-  openpgp.config.versionstring = `FlowCrypt ${VERSION} Gmail Encryption`;
-  openpgp.config.commentstring = 'Seamlessly send and receive encrypted email';
-  // openpgp.config.require_uid_self_cert = false;
-}
 
 export namespace PgpMsgMethod {
   export namespace Arg {

--- a/extension/js/common/core/pgp.ts
+++ b/extension/js/common/core/pgp.ts
@@ -246,10 +246,6 @@ export class Pgp {
       const { keys: [key] } = await openpgp.key.readArmored(armoredKey);
       return key;
     },
-    readBinary: async (binaryKey: Uint8Array) => {
-      const { keys: [key] } = await openpgp.key.read(binaryKey);
-      return key;
-    },
     decrypt: async (key: OpenPGP.key.Key, passphrases: string[]): Promise<boolean> => {
       try {
         return await key.decrypt(passphrases);

--- a/extension/js/common/core/pgp.ts
+++ b/extension/js/common/core/pgp.ts
@@ -246,6 +246,10 @@ export class Pgp {
       const { keys: [key] } = await openpgp.key.readArmored(armoredKey);
       return key;
     },
+    readBinary: async (binaryKey: Uint8Array) => {
+      const { keys: [key] } = await openpgp.key.read(binaryKey);
+      return key;
+    },
     decrypt: async (key: OpenPGP.key.Key, passphrases: string[]): Promise<boolean> => {
       try {
         return await key.decrypt(passphrases);

--- a/extension/js/common/platform/require.ts
+++ b/extension/js/common/platform/require.ts
@@ -21,6 +21,8 @@
  *  - add < script > tags to appropriate .htm files pointing to the js using ABSOLUTE path, unless this dep can be imported as es6 module tag, in which case use RELATIVE path
  */
 
+import { VERSION } from '../../../js/common/core/const.js';
+
 /// <reference path="../../../types/openpgp.d.ts" />
 
 const loadedTags: string[] = [];
@@ -31,6 +33,11 @@ type Codec = { encode: (text: string, mode: 'fatal' | 'html') => string, decode:
 
 export const requireOpenpgp = (): typeof OpenPGP => {
   try {
+    if (typeof openpgp !== 'undefined') { // in certain environments, eg browser content scripts, openpgp is not included (not all functions below need it)
+      openpgp.config.versionstring = `FlowCrypt ${VERSION} Gmail Encryption`;
+      openpgp.config.commentstring = 'Seamlessly send and receive encrypted email';
+      // openpgp.config.require_uid_self_cert = false;
+    }
     return openpgp;
   } catch (e) {
     // a hack for content scripts, which do not currently need openpgp, until I come up with something better

--- a/extension/js/common/platform/require.ts
+++ b/extension/js/common/platform/require.ts
@@ -33,11 +33,10 @@ type Codec = { encode: (text: string, mode: 'fatal' | 'html') => string, decode:
 
 export const requireOpenpgp = (): typeof OpenPGP => {
   try {
-    if (typeof openpgp !== 'undefined') { // in certain environments, eg browser content scripts, openpgp is not included (not all functions below need it)
-      openpgp.config.versionstring = `FlowCrypt ${VERSION} Gmail Encryption`;
-      openpgp.config.commentstring = 'Seamlessly send and receive encrypted email';
-      // openpgp.config.require_uid_self_cert = false;
-    }
+    // in certain environments, eg browser content scripts, openpgp is not included (not all functions below need it)
+    openpgp.config.versionstring = `FlowCrypt ${VERSION} Gmail Encryption`;
+    openpgp.config.commentstring = 'Seamlessly send and receive encrypted email';
+    // openpgp.config.require_uid_self_cert = false;
     return openpgp;
   } catch (e) {
     // a hack for content scripts, which do not currently need openpgp, until I come up with something better

--- a/extension/types/openpgp.d.ts
+++ b/extension/types/openpgp.d.ts
@@ -855,7 +855,7 @@ declare namespace OpenPGP {
 
     interface KeyResult {
       keys: Key[];
-      err: Error[];
+      err?: Error[];
     }
 
     type AlgorithmInfo = {

--- a/review-branch.sh
+++ b/review-branch.sh
@@ -5,5 +5,5 @@ set -euxo pipefail
 git checkout master
 git fetch
 git pull
-git checkout "remotes/origin/$1"
+git checkout -b "$1" "origin/$1"
 npm run-script run_firefox


### PR DESCRIPTION
Fixes #1134 . Adds a button to the contacts page that allows choosing a file, if the file selected is a valid PGP key file in binary format, the armored key is written to the public key input field.