### PR TITLE
Issue #1819 custom ks

### DIFF
--- a/extension/chrome/elements/pgp_block.ts
+++ b/extension/chrome/elements/pgp_block.ts
@@ -16,8 +16,8 @@ import { Google, GmailResponseFormat, GoogleAuth } from '../../js/common/api/goo
 import { Buf } from '../../js/common/core/buf.js';
 import { BackendRes, Backend } from '../../js/common/api/backend.js';
 import { Assert } from '../../js/common/assert.js';
-import { Attester } from '../../js/common/api/attester.js';
 import { Xss } from '../../js/common/platform/xss.js';
+import { Keyserver } from '../../js/common/api/keyserver.js';
 
 Catch.try(async () => {
 
@@ -220,7 +220,7 @@ Catch.try(async () => {
           render(`Found the right pubkey ${signerLongid} on keyserver, but will not use it because you have conflicting pubkey ${senderContactByEmail.longid} loaded.`, () => undefined);
           return;
         } // ---> and user doesn't have pubkey for that email addr
-        const { pubkey, pgpClient } = await Attester.lookupEmail(senderEmail);
+        const { pubkey, pgpClient } = await Keyserver.lookupEmail(acctEmail, senderEmail);
         if (!pubkey) {
           render(`Missing pubkey ${signerLongid}`, () => undefined);
           return;
@@ -235,7 +235,7 @@ Catch.try(async () => {
         await Store.dbContactSave(undefined, await Store.dbContactObj({ email: senderEmail, pubkey, client: pgpClient })); // <= TOFU auto-import
         render('Fetched pubkey, click to verify', () => window.location.reload());
       } else { // don't know who sent it
-        const { pubkey, pgpClient } = await Attester.lookupEmail(signerLongid);
+        const { pubkey, pgpClient } = await Keyserver.lookupLongid(acctEmail, signerLongid);
         if (!pubkey) { // but can find matching pubkey by longid on keyserver
           render(`Could not find sender's pubkey anywhere: ${signerLongid}`, () => undefined);
           return;

--- a/extension/chrome/settings/modules/keyserver.htm
+++ b/extension/chrome/settings/modules/keyserver.htm
@@ -17,6 +17,9 @@
 
   <div id="content" class="pubkeys" data-test="page-attester">
     <h1>Let others encrypt for you easier</h1>
+    <br />
+    <div class="line" style="opacity: 0.7"><a href="https://flowcrypt.com/attester/" target="_blank">FlowCrypt Attester</a> keeps track of Public Keys of
+      FlowCrypt users.</div>
     <div class="line summary"></div>
   </div>
 

--- a/extension/chrome/settings/modules/keyserver.ts
+++ b/extension/chrome/settings/modules/keyserver.ts
@@ -4,7 +4,7 @@
 
 import { Catch } from '../../../js/common/platform/catch.js';
 import { Store } from '../../../js/common/platform/store.js';
-import { Value } from '../../../js/common/core/common.js';
+import { Value, Dict } from '../../../js/common/core/common.js';
 import { Ui, Env } from '../../../js/common/browser.js';
 import { BrowserMsg } from '../../../js/common/extension.js';
 import { Settings } from '../../../js/common/settings.js';
@@ -13,7 +13,8 @@ import { Attester } from '../../../js/common/api/attester.js';
 import { Pgp } from '../../../js/common/core/pgp.js';
 import { Assert } from '../../../js/common/assert.js';
 import { Xss } from '../../../js/common/platform/xss.js';
-import { AttesterRes } from '../../../js/common/api/keyserver.js';
+
+type AttKeyserverDiagnosis = { hasPubkeyMissing: boolean, hasPubkeyMismatch: boolean, results: Dict<{ pubkey?: string, match: boolean }> };
 
 Catch.try(async () => {
 
@@ -25,8 +26,8 @@ Catch.try(async () => {
 
   Xss.sanitizeRender('.summary', '<br><br><br><br>Loading from keyserver<br><br>' + Ui.spinner('green'));
 
-  const diagnoseKeyserverPubkeys = async (acctEmail: string): Promise<AttesterRes.AttKeyserverDiagnosis> => {
-    const diagnosis: AttesterRes.AttKeyserverDiagnosis = { hasPubkeyMissing: false, hasPubkeyMismatch: false, results: {} };
+  const diagnoseKeyserverPubkeys = async (acctEmail: string): Promise<AttKeyserverDiagnosis> => {
+    const diagnosis: AttKeyserverDiagnosis = { hasPubkeyMissing: false, hasPubkeyMismatch: false, results: {} };
     const { addresses } = await Store.getAcct(acctEmail, ['addresses']);
     const storedKeys = await Store.keysGet(acctEmail);
     const storedKeysLongids = storedKeys.map(ki => ki.longid);
@@ -48,7 +49,7 @@ Catch.try(async () => {
     return diagnosis;
   };
 
-  const renderDiagnosis = (diagnosis: AttesterRes.AttKeyserverDiagnosis) => {
+  const renderDiagnosis = (diagnosis: AttKeyserverDiagnosis) => {
     for (const email of Object.keys(diagnosis.results)) {
       const result = diagnosis.results[email];
       let note, action, remove, color;

--- a/extension/chrome/settings/modules/keyserver.ts
+++ b/extension/chrome/settings/modules/keyserver.ts
@@ -9,10 +9,11 @@ import { Ui, Env } from '../../../js/common/browser.js';
 import { BrowserMsg } from '../../../js/common/extension.js';
 import { Settings } from '../../../js/common/settings.js';
 import { Api } from '../../../js/common/api/api.js';
-import { Attester, AttesterRes } from '../../../js/common/api/attester.js';
+import { Attester } from '../../../js/common/api/attester.js';
 import { Pgp } from '../../../js/common/core/pgp.js';
 import { Assert } from '../../../js/common/assert.js';
 import { Xss } from '../../../js/common/platform/xss.js';
+import { AttesterRes } from '../../../js/common/api/keyserver.js';
 
 Catch.try(async () => {
 

--- a/extension/chrome/settings/setup.ts
+++ b/extension/chrome/settings/setup.ts
@@ -18,6 +18,7 @@ import { Assert } from '../../js/common/assert.js';
 import { KeyImportUi, UserAlert, KeyCanBeFixed } from '../../js/common/ui/key_import_ui.js';
 import { initPassphraseToggle } from '../../js/common/ui/passphrase_ui.js';
 import { Xss } from '../../js/common/platform/xss.js';
+import { Keyserver } from '../../js/common/api/keyserver.js';
 
 declare const openpgp: typeof OpenPGP;
 
@@ -161,7 +162,7 @@ Catch.try(async () => {
   const renderSetupDialog = async (): Promise<void> => {
     let keyserverRes, fetchedKeys;
     try {
-      keyserverRes = await Attester.lookupEmail(acctEmail);
+      keyserverRes = await Keyserver.lookupEmail(acctEmail, acctEmail);
     } catch (e) {
       return await Settings.promptToRetry('REQUIRED', e, Lang.setup.failedToCheckIfAcctUsesEncryption, () => renderSetupDialog());
     }

--- a/extension/js/common/api/attester.ts
+++ b/extension/js/common/api/attester.ts
@@ -4,7 +4,7 @@
 
 import { Api, ReqMethod } from './api.js';
 import { Dict, Str } from '../core/common.js';
-import { PubkeySearchResult, PgpClient, AttesterRes } from './keyserver.js';
+import { PubkeySearchResult, PgpClient } from './keyserver.js';
 
 export class Attester extends Api {
 
@@ -54,11 +54,11 @@ export class Attester extends Api {
     return r.responseText;
   }
 
-  public static initialLegacySubmit = (email: string, pubkey: string): Promise<AttesterRes.AttInitialLegacySugmit> => {
+  public static initialLegacySubmit = (email: string, pubkey: string): Promise<{ saved: boolean }> => {
     return Attester.jsonCall('initial/legacy_submit', { email: Str.parseEmail(email).email, pubkey: pubkey.trim() });
   }
 
-  public static testWelcome = (email: string, pubkey: string): Promise<AttesterRes.AttTestWelcome> => {
+  public static testWelcome = (email: string, pubkey: string): Promise<{ sent: boolean }> => {
     return Attester.jsonCall('test/welcome', { email, pubkey });
   }
 

--- a/extension/js/common/api/attester.ts
+++ b/extension/js/common/api/attester.ts
@@ -4,15 +4,7 @@
 
 import { Api, ReqMethod } from './api.js';
 import { Dict, Str } from '../core/common.js';
-
-export type PgpClient = 'flowcrypt' | 'pgp-other' | null;
-export type PubkeySearchResult = { pubkey: string | null; pgpClient: PgpClient };
-
-export namespace AttesterRes { // responses
-  export type AttTestWelcome = { sent: boolean };
-  export type AttInitialLegacySugmit = { saved: boolean };
-  export type AttKeyserverDiagnosis = { hasPubkeyMissing: boolean, hasPubkeyMismatch: boolean, results: Dict<{ pubkey?: string, match: boolean }> };
-}
+import { PubkeySearchResult, PgpClient, AttesterRes } from './keyserver.js';
 
 export class Attester extends Api {
 
@@ -29,7 +21,7 @@ export class Attester extends Api {
       const r = await Attester.pubCall(`pub/${email}`);
       // when requested from the content script, `getResponseHeader` will be missing because it's not a real XMLHttpRequest we are getting back
       // because it had to go through background scripts, and objects are serialized when this happens
-      // the fix would be to send back headers from bg along with response text, and parse it here
+      // the proper fix would be to send back headers from bg along with response text, and parse it here
       if (!r.getResponseHeader) {
         return { pubkey: r.responseText, pgpClient: null }; // tslint:disable-line:no-null-keyword
       }

--- a/extension/js/common/api/keyserver.ts
+++ b/extension/js/common/api/keyserver.ts
@@ -1,0 +1,53 @@
+/* © 2016-2018 FlowCrypt Limited. Limitations apply. Contact human@flowcrypt.com */
+
+'use strict';
+
+import { Rules } from '../rules.js';
+import { Attester } from './attester.js';
+import { Sks } from './sks.js';
+import { Dict } from '../core/common.js';
+
+export type PgpClient = 'flowcrypt' | 'pgp-other' | null;
+export type PubkeySearchResult = { pubkey: string | null; pgpClient: PgpClient };
+
+export namespace AttesterRes { // responses
+  export type AttTestWelcome = { sent: boolean };
+  export type AttInitialLegacySugmit = { saved: boolean };
+  export type AttKeyserverDiagnosis = { hasPubkeyMissing: boolean, hasPubkeyMismatch: boolean, results: Dict<{ pubkey?: string, match: boolean }> };
+}
+
+/**
+ * Look up public keys.
+ *
+ * Some users may have a preference to use their own keyserver. In such cases, results from their own keyserver will be preferred.
+ */
+export class Keyserver {
+
+  private static getCustomKeyserverByAcctEmail = async (acctEmail: string) => {
+    const rules = await Rules.newInstance(acctEmail);
+    return rules.canUseCustomKeyserver() ? rules.getCustomKeyserver() : undefined;
+  }
+
+  public static lookupEmail = async (acctEmail: string, email: string): Promise<PubkeySearchResult> => {
+    const customKs = await Keyserver.getCustomKeyserverByAcctEmail(acctEmail);
+    if (customKs) {
+      const res = await Sks.lookupEmail(customKs, email);
+      if (res.pubkey) {
+        return res;
+      }
+    }
+    return Attester.lookupEmail(email);
+  }
+
+  public static lookupLongid = async (acctEmail: string, longid: string): Promise<PubkeySearchResult> => {
+    const customKs = await Keyserver.getCustomKeyserverByAcctEmail(acctEmail);
+    if (customKs) {
+      const res = await Sks.lookupLongid(customKs, longid);
+      if (res.pubkey) {
+        return res;
+      }
+    }
+    return Attester.lookupLongid(longid);
+  }
+
+}

--- a/extension/js/common/api/keyserver.ts
+++ b/extension/js/common/api/keyserver.ts
@@ -5,16 +5,9 @@
 import { Rules } from '../rules.js';
 import { Attester } from './attester.js';
 import { Sks } from './sks.js';
-import { Dict } from '../core/common.js';
 
 export type PgpClient = 'flowcrypt' | 'pgp-other' | null;
 export type PubkeySearchResult = { pubkey: string | null; pgpClient: PgpClient };
-
-export namespace AttesterRes { // responses
-  export type AttTestWelcome = { sent: boolean };
-  export type AttInitialLegacySugmit = { saved: boolean };
-  export type AttKeyserverDiagnosis = { hasPubkeyMissing: boolean, hasPubkeyMismatch: boolean, results: Dict<{ pubkey?: string, match: boolean }> };
-}
 
 /**
  * Look up public keys.

--- a/extension/js/common/api/sks.ts
+++ b/extension/js/common/api/sks.ts
@@ -1,0 +1,45 @@
+/* © 2016-2018 FlowCrypt Limited. Limitations apply. Contact human@flowcrypt.com */
+
+'use strict';
+
+import { Api } from './api.js';
+import { Pgp } from '../core/pgp.js';
+import { PubkeySearchResult } from './keyserver.js';
+
+export class Sks extends Api {
+
+  private static get = async (server: string, path: string): Promise<string | undefined> => {
+    try {
+      const { responseText } = await Api.apiCall(server, path, undefined, undefined, undefined, undefined, 'xhr', 'GET') as XMLHttpRequest;
+      return responseText;
+    } catch (e) {
+      if (Api.err.isNotFound(e)) {
+        return undefined;
+      }
+      throw e;
+    }
+  }
+
+  public static lookupEmail = async (server: string, email: string): Promise<PubkeySearchResult> => {
+    const index = await Sks.get(server, `pks/lookup?search=${encodeURIComponent(email)}&fingerprint=on&exact=on&options=mr&op=index`);
+    console.log(index);
+    if (!index) {
+      return { pubkey: null, pgpClient: null }; // tslint:disable-line:no-null-keyword
+    }
+    const match = index.match(/^pub:[A-F0-9]{24}([A-F0-9]{16}):[0-9:]+:$/m); // in particular cannot end with :r, meaning revoked
+    console.log(match);
+    if (!match) {
+      return { pubkey: null, pgpClient: null }; // tslint:disable-line:no-null-keyword
+    }
+    return await Sks.lookupLongid(server, match[1]);
+  }
+
+  public static lookupLongid = async (server: string, longid: string): Promise<PubkeySearchResult> => {
+    const pubkey = await Sks.get(server, `pks/lookup?op=get&search=0x${longid}&options=mr`);
+    if (!pubkey || !pubkey.includes(String(Pgp.armor.headers('publicKey').end))) {
+      return { pubkey: null, pgpClient: null }; // tslint:disable-line:no-null-keyword
+    }
+    return { pubkey, pgpClient: 'pgp-other' };
+  }
+
+}

--- a/extension/js/common/api/sks.ts
+++ b/extension/js/common/api/sks.ts
@@ -22,12 +22,10 @@ export class Sks extends Api {
 
   public static lookupEmail = async (server: string, email: string): Promise<PubkeySearchResult> => {
     const index = await Sks.get(server, `pks/lookup?search=${encodeURIComponent(email)}&fingerprint=on&exact=on&options=mr&op=index`);
-    console.log(index);
     if (!index) {
       return { pubkey: null, pgpClient: null }; // tslint:disable-line:no-null-keyword
     }
     const match = index.match(/^pub:[A-F0-9]{24}([A-F0-9]{16}):[0-9:]+:$/m); // in particular cannot end with :r, meaning revoked
-    console.log(match);
     if (!match) {
       return { pubkey: null, pgpClient: null }; // tslint:disable-line:no-null-keyword
     }

--- a/extension/js/common/platform/store.ts
+++ b/extension/js/common/platform/store.ts
@@ -12,7 +12,7 @@ import { Env, Ui } from '../browser.js';
 import { Catch, UnreportableError } from './catch.js';
 import { storageLocalSet, storageLocalGet, storageLocalRemove } from '../api/chrome.js';
 import { GmailRes } from '../api/google.js';
-import { PgpClient } from '../api/attester.js';
+import { PgpClient } from '../api/keyserver.js';
 
 let KEY_CACHE: { [longidOrArmoredKey: string]: OpenPGP.key.Key } = {};
 let KEY_CACHE_WIPE_TIMEOUT: number;

--- a/extension/js/common/rules.ts
+++ b/extension/js/common/rules.ts
@@ -5,7 +5,7 @@
 import { Str, Dict } from './core/common.js';
 import { Pgp } from './core/pgp.js';
 
-export type DomainRule = { flags: ('NO_PRV_CREATE' | 'NO_PRV_BACKUP' | 'STRICT_GDPR')[] };
+export type DomainRule = { flags: ('NO_PRV_CREATE' | 'NO_PRV_BACKUP' | 'STRICT_GDPR' | 'ALLOW_CUSTOM_KEYSERVER')[] };
 
 export class Rules {
 
@@ -14,6 +14,7 @@ export class Rules {
   private rules: Dict<DomainRule> = {
     '745126dcac9a94a1931a3a5e03f02be3820f51d1': { flags: ['NO_PRV_CREATE', 'NO_PRV_BACKUP', 'STRICT_GDPR'] }, // n
     '77754b18ecb3f2f7c59bf20cfe06afac2a6458ec': { flags: ['NO_PRV_CREATE', 'NO_PRV_BACKUP', 'STRICT_GDPR'] }, // v
+    'e308e274e602f710349f5fe178cef094fa01c32b': { flags: ['NO_PRV_BACKUP', 'ALLOW_CUSTOM_KEYSERVER'] }, // h
     [this.other]: { flags: [] },
   };
 
@@ -36,5 +37,7 @@ export class Rules {
   canBackupKeys = () => !this.rules[this.domainHash].flags.includes('NO_PRV_BACKUP');
 
   hasStrictGdpr = () => this.rules[this.domainHash].flags.includes('STRICT_GDPR');
+
+  canUseCustomKeyserver = () => this.rules[this.domainHash].flags.includes('ALLOW_CUSTOM_KEYSERVER');
 
 }

--- a/extension/js/content_scripts/webmail/gmail_element_replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail_element_replacer.ts
@@ -6,7 +6,6 @@ import { Str, Dict } from '../../common/core/common.js';
 import { Injector } from '../../common/inject.js';
 import { Notifications } from '../../common/notifications.js';
 import { Api, AjaxError } from '../../common/api/api.js';
-import { Attester } from '../../common/api/attester.js';
 import { Pgp } from '../../common/core/pgp.js';
 import { BrowserMsg } from '../../common/extension.js';
 import { Ui, Browser } from '../../common/browser.js';
@@ -16,6 +15,7 @@ import { WebmailElementReplacer } from './setup_webmail_content_script.js';
 import { Catch } from '../../common/platform/catch.js';
 import { Google, GmailRes } from '../../common/api/google.js';
 import { Xss } from '../../common/platform/xss.js';
+import { Keyserver } from '../../common/api/keyserver.js';
 
 type JQueryEl = JQuery<HTMLElement>;
 
@@ -500,7 +500,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
               }
               if (typeof cache === 'undefined') {
                 try {
-                  const { pubkey } = await Attester.lookupEmail(email);
+                  const { pubkey } = await Keyserver.lookupEmail(this.acctEmail, email);
                   this.recipientHasPgpCache[email] = Boolean(pubkey); // true or false
                   if (!this.recipientHasPgpCache[email]) {
                     everyoneUsesEncryption = false;


### PR DESCRIPTION
#1819 4 hrs

The `Rules` class needs a sha1 implementation, which is available in OpenPGP.js, which is not available everywhere in the plugin (not available in `pgp_block.ts` for performance reasons). Since we use Rules class more in this PR, I needed to give it a native sha1 implementation that is not dependent on OpenPGP.js.

Also I took a shortcut to hardcode a keyserver into the `Rules` class instead of serving it from the backend, that should be fixed in the future.