### PR TITLE
Issue #1883 Leave else case empty instead of 'inherit'

### DIFF
--- a/extension/chrome/elements/pgp_pubkey.ts
+++ b/extension/chrome/elements/pgp_pubkey.ts
@@ -44,7 +44,7 @@ Catch.try(async () => {
       const [contact] = await Store.dbContactGet(undefined, [String($('.input_email').val())]);
       $('.action_add_contact')
         .text(contact && contact.has_pgp ? 'update key' : `import ${isUsableButExpired ? 'expired ' : ''}key`)
-        .css('background-color', isUsableButExpired ? '#989898' : 'inherit');
+        .css('background-color', isUsableButExpired ? '#989898' : '');
     }
   };
 


### PR DESCRIPTION
Issue #1883 
Time Spent: 20m

Yes, sorry, that was my bad,
I don't know why but I thought that `background-color: inherit;` inherits the previous color but it doesn't, it inherits something else (maybe I will investigate it later)