### PR TITLE
Remove setting padding-top and padding-bottom to 0 in Firefox

### DIFF
--- a/extension/js/common/composer.ts
+++ b/extension/js/common/composer.ts
@@ -900,9 +900,6 @@ export class Composer {
   private renderComposeTable = async () => {
     this.debugFocusEvents('input_text', 'send_btn', 'input_to', 'input_subject');
     this.S.cached('compose_table').css('display', 'table');
-    if (Catch.browser().name === 'firefox') { // the padding cause issues in firefox where user cannot click on the message password
-      this.S.cached('input_text').css({ 'padding-top': 0, 'padding-bottom': 0 });
-    }
     this.S.cached('body').keydown(Ui.escape(() => !this.composeWindowIsMinimized && !this.urlParams.isReplyBox && $('.close_new_message').click()));
     this.S.cached('body').keypress(Ui.ctrlEnter(() => !this.composeWindowIsMinimized && this.extractProcessSendMsg()));
     this.S.cached('send_btn').click(Ui.event.prevent('double', () => this.extractProcessSendMsg()));

--- a/extension/js/common/composer.ts
+++ b/extension/js/common/composer.ts
@@ -668,7 +668,8 @@ export class Composer {
         this.refBodyHeight = this.S.cached('body').height() || 605;
       }
       const attListHeight = $("#att_list").height() || 0;
-      this.S.cached('input_text').css('height', this.refBodyHeight - cellHeightExceptText - attListHeight);
+      const inputTextVerticalPadding = parseInt(this.S.cached('input_text').css('padding-top')) + parseInt(this.S.cached('input_text').css('padding-bottom'));
+      this.S.cached('input_text').css('height', this.refBodyHeight - cellHeightExceptText - attListHeight - inputTextVerticalPadding);
     }
   }
 


### PR DESCRIPTION
Closes #1902 

I wasn't able to find the original PR adding this workaround, probably because it was added long ago and not needed anymore.

```js
// the padding cause issues in firefox where user cannot click on the message password
```

I guess "the message password" is this one:

![image](https://user-images.githubusercontent.com/6059356/62944501-7fc09a00-bde5-11e9-8382-68cb7f27626f.png)

I manually tested it with changes from this PR, works nicely (Firefox 68)
