### PR TITLE
Height of the minimized iframe should be equal header's height

### DIFF
--- a/extension/js/common/composer.ts
+++ b/extension/js/common/composer.ts
@@ -1002,7 +1002,7 @@ export class Composer {
     }
     BrowserMsg.send.setCss(this.urlParams.parentTabId, {
       selector: `iframe#${this.urlParams.frameId}, div#new_message`,
-      css: { height: this.composeWindowIsMinimized ? '' : '36px' },
+      css: { height: this.composeWindowIsMinimized ? '' : this.S.cached('header').css('height') },
     });
     this.composeWindowIsMinimized = !this.composeWindowIsMinimized;
   }


### PR DESCRIPTION
Closes #1929

@tomholub WDYT about adding

```css
transition: height 0.1s ease-in-out
```

to `#new_message`? To me personally, the height animation makes an impression better.