### PR TITLE
Include #input_from to taborder

### DIFF
--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -361,7 +361,7 @@ table#compose td { border: 1px solid #cfcfcf; border-top: none;  margin: 0; }
 table#compose td input { border: none;  height: 100%; width:100%; margin: 0; padding: 6px; padding-left: 9px; background: none; outline: none; color: inherit;}
 table#compose td.input.show_send_from { height: 84px; }
 table#compose td.input.show_send_from input#input_to { height: 50%; }
-table#compose td.input.show_send_from select#input_from { height: 50%; border: none; background: none; padding: 6px; margin-top: 10px; outline: none;
+table#compose td.input.show_send_from select#input_from { height: 50%; border: none; background: none; padding: 6px; margin-top: 10px;
   margin-right: 36px; width: -moz-available; width: -webkit-fill-available; -moz-appearance:none; }
 table#compose td.input.show_send_from #input_from_settings { position: absolute; right: 10px; width: 20px; margin-top: 13px; opacity: 0.4; }
 table#compose td.input.show_send_from #input_from_settings:hover { opacity: 1; cursor: pointer; }

--- a/extension/js/common/composer.ts
+++ b/extension/js/common/composer.ts
@@ -1000,7 +1000,7 @@ export class Composer {
     if (addresses.length > 1) {
       const inputAddrContainer = $('#input_addresses_container');
       inputAddrContainer.addClass('show_send_from');
-      let selectElHtml = '<select id="input_from" tabindex="-1" data-test="input-from"></select>';
+      let selectElHtml = '<select id="input_from" tabindex="1" data-test="input-from"></select>';
       if (!this.urlParams.isReplyBox) {
         selectElHtml += '<img id="input_from_settings" src="/img/svgs/settings-icon.svg" data-test="action-open-sending-address-settings" title="Settings">';
       }


### PR DESCRIPTION
Closes #1925 

> When there is just one email in input_from, the from-select-option was hidden but I think it would still trap focus when tabbing. So you would need to double-tab to get from recipients to body. It wasn't smooth. Please test if it's still the case, and if it is, see what could be done about it.

Tested, no longer the case, because there's no `<select>` when there is just one email:

![image](https://user-images.githubusercontent.com/6059356/63148378-a8c17480-c009-11e9-95d5-7ca866a09f6d.png)
