### PR TITLE
Implement clicking the 'Attach a file' button with a keyboard

### DIFF
--- a/extension/chrome/elements/compose.htm
+++ b/extension/chrome/elements/compose.htm
@@ -97,8 +97,7 @@
               Send</span></div>
           <button class="icon action_sign" data-test="action-switch-to-sign" tabindex="7"
             title="Sign this message instead of encrypting it"><i alt="sign"></i></button>
-          <button class="icon attach" id="fineuploader_button" tabindex="8" title="Attach a file"><img
-              src="/img/svgs/paperclip-icon.svg" class="attach-file" alt="Attach File"></button>
+          <div class="icon attach" id="fineuploader_button"><img src="/img/svgs/paperclip-icon.svg" class="attach-file" alt="Attach File"></div>
           <div id="send_btn_note"></div>
           <button class="icon right delete_draft" tabindex="11" title="Delete draft"><img
               src="/img/svgs/trash-can-icon.svg" class="delete-draft" alt="Delete Email"></button>

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -379,7 +379,7 @@ table#compose .bottom .icon { padding: 3px 4px; display: inline-block; border: 1
 table#compose .bottom .icon::-moz-focus-inner { border: 0; } /* remove dotted outline in Firefox */
 table#compose .bottom .icon img, table#compose .bottom .icon i { height: 20px; width: 20px; display: block; background-repeat: no-repeat; background-position: center; }
 table#compose .bottom .icon.right { float:right; margin-top: 3px; }
-table#compose .bottom .icon:hover, table#compose .bottom .icon:focus { outline: none !important; border-color: #dadada; opacity: 1; }
+table#compose .bottom .icon:hover, table#compose .bottom .icon:focus, table#compose .bottom .icon:focus-within { outline: none !important; border-color: #dadada; opacity: 1; }
 table#compose .bottom .icon:active { border-color: #4d90fe; }
 table#compose .bottom .icon div { height: 21px; width: 21px; vertical-align: middle; padding: 0; display: inline-block; margin-top: 4px }
 table#compose .bottom .icon.active { opacity: 1; }

--- a/extension/js/common/ui/att_ui.ts
+++ b/extension/js/common/ui/att_ui.ts
@@ -41,7 +41,15 @@ export class AttUI {
         },
       };
       this.uploader = new qq.FineUploader(config); // tslint:disable-line:no-unsafe-any
+      this.setInputAttributes();
     });
+  }
+
+  setInputAttributes = () => {
+    const input = this.uploader._buttons[0].getInput();
+    input.setAttribute('title', 'Attach a file');
+    input.setAttribute('tabindex', '8');
+    return input;
   }
 
   setAttAddedCb = (cb: (r: Att) => Promise<void>) => {
@@ -117,6 +125,8 @@ export class AttUI {
       if (typeof this.attAddedCb === 'function') {
         const a = await this.collectAtt(uploadFileId);
         await this.attAddedCb(a);
+        const input = this.setInputAttributes();
+        input.focus();
       }
     }
   }

--- a/extension/js/common/ui/att_ui.ts
+++ b/extension/js/common/ui/att_ui.ts
@@ -45,8 +45,8 @@ export class AttUI {
     });
   }
 
-  setInputAttributes = () => {
-    const input = this.uploader._buttons[0].getInput();
+  setInputAttributes = (): HTMLInputElement => {
+    const input: HTMLInputElement = this.uploader._buttons[0].getInput(); // tslint:disable-line:no-unsafe-any
     input.setAttribute('title', 'Attach a file');
     input.setAttribute('tabindex', '8');
     return input;


### PR DESCRIPTION
Fixes #1958

I made the `<input>` inside of `.icon.attach` focusable, that seems to be the only way to make it clickable with the keyboard.

Also, moved the `title` attr to `<input>`. Previously, browsers were showing the default input title instead of "Attach a file":

![image](https://user-images.githubusercontent.com/6059356/63211645-d5a58280-c102-11e9-8549-1cef5ab91630.png)
