### PR TITLE
issue #1928, Corrected margins of placeholder

### DIFF
--- a/extension/chrome/settings/modules/contact_page.htm
+++ b/extension/chrome/settings/modules/contact_page.htm
@@ -23,23 +23,27 @@
     <div class="line"></div>
     <div class="line">This allows anyone to send you encrypted messages and files from the web.</div>
     <div class="line">You will receive these in your inbox just like any other encrypted messages.</div>
-    <div class="line hide_if_active">Example: <a href="https://flowcrypt.com/me/tom" target="_blank">flowcrypt.com/me/tom</a>.
+    <div class="line hide_if_active">Example: <a href="https://flowcrypt.com/me/tom"
+        target="_blank">flowcrypt.com/me/tom</a>.
       Feel free to send me a test message.</div>
     <div class="line status"></div>
     <div class="show_if_active" style="display: none;">
       <div class="profile_photo" style="position: absolute;width: 100px; height: 150px;z-index: 10;">
-        <img src="https://flowcrypt.com/assets/imgs/svgs/vexels-silhouette.svg" style="max-width: 100px; max-height: 100px;" /><br />
+        <img src="https://flowcrypt.com/assets/imgs/svgs/vexels-silhouette.svg"
+          style="max-width: 100px; max-height: 100px;" /><br />
         <a href="#" id="select_photo" style="z-index: 20;">change picture</a>
       </div>
       <div class="line">
         <input class="input_email" type="text" disabled="disabled" style="position: relative; left: 65px;" />
       </div>
       <div class="line">
-        <span style="position: absolute;margin-top: 13px;margin-left: 77px;color: #888;z-index: 10;">Full Name:</span><input
-          class="input_name" type="text" placeholder="Your name" style="padding-left: 80px;position: relative; left: 65px;" />
+        <span style="position: absolute;margin-top: 10px;margin-left: 69px;color: #888;z-index: 10;">Full
+          Name:</span><input class="input_name" type="text" placeholder="Your name"
+          style="padding-left: 80px;position: relative; left: 65px;" />
       </div>
       <div class="line">
-        <textarea class="input_intro" placeholder="Contact page intro." style="width: 490px;height: 90px;">Use this page to send me encrypted messages and files.</textarea>
+        <textarea class="input_intro" placeholder="Contact page intro."
+          style="width: 490px;height: 90px;">Use this page to send me encrypted messages and files.</textarea>
       </div>
       <!--<div class="line">-->
       <!--flowcrypt.com/me/&nbsp;<input class="input_alias" placeholder="lowercaseonly" style="border: none; border-bottom: 1px solid #aaa;" />-->


### PR DESCRIPTION
Issue #1928,
Time Spent: 30m

Result:
![image](https://user-images.githubusercontent.com/49104848/64219686-178a4300-cecf-11e9-9b54-c1e189b9bc40.png)

I fixed alignment of `Full Name:` ​​placeholder but actually I'd like to get rid of it because we don't have any similar inputs in the extension (I haven't seen that large placeholder) and I think our users can intuitively understand that there should be their name so I think without a placeholder it would look better.