### PR TITLE
Issue #2045 make 'Send' and 'Show send options' buttons focusable

### DIFF
--- a/extension/chrome/elements/compose.htm
+++ b/extension/chrome/elements/compose.htm
@@ -120,11 +120,12 @@
           <div class="sending-container">
             <div class="sending-options-container">
             </div>
-            <div id="send_btn" class="button green" tabindex="6">
-              <span class="btn-text" data-test="action-send"><i></i>Encrypt and Send</span>
-              <div class="action-show-options-popover" data-test="action-show-options-popover">
-                <div class="icon-chevron"></div>
-              </div>
+            <button id="send_btn" class="button green" tabindex="6">
+              <span id="send_btn_text" class="btn-text" data-test="action-send"><i></i>Encrypt and Send</span>
+            </button>
+            <button id="toggle_send_options" class="action-show-options-popover button green" title="More send options" tabindex="7" data-test="action-show-options-popover">
+              <div class="icon-chevron"></div>
+            </button>
             </div>
           </div>
           <div class="icon attach" id="fineuploader_button"><img src="/img/svgs/paperclip-icon.svg" class="attach-file"

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -403,10 +403,10 @@ table#compose td.bottom div.sending-container div.sending-options-container div:
 table#compose td.bottom div.sending-container div.sending-options-container div:not(:last-child) { border-bottom: 1px solid #cfcfcf; }
 table#compose td.bottom div.sending-container div.sending-options-container div span.option-name img { height: 0.8em; margin-right: 12px; position: relative; top: 1px; }
 table#compose td.bottom div.sending-container div.sending-options-container div img.icon-tick { height: 0.8em; margin-left: 12px; }
-table#compose td.bottom div.sending-container .button { padding: 3px 10px; border-radius: 0; }
+table#compose td.bottom div.sending-container .button { padding: 3px 10px; border-radius: 0; transition: background-color .4s; }
 table#compose td.bottom div.sending-container .button::-moz-focus-inner { border: 0; }
 table#compose td.bottom #send_btn { text-transform: initial; white-space: nowrap; width: 100%; box-sizing: border-box;
-  position: relative; font-weight: 600; font-size: 0.9em; transition: .4s !important; display: flex; }
+  position: relative; font-weight: 600; font-size: 0.9em; display: flex; }
 table#compose #send_btn i { font-size: 20px; }
 table#compose .button.green:hover, table#compose td.bottom div.sending-container.popover-opened > .action-show-options-popover { cursor: pointer; background-color: #5ab445; }
 table#compose .action-show-options-popover { min-width: auto; padding: 0 10px; }

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -403,7 +403,7 @@ table#compose td.bottom div.sending-container div.sending-options-container div:
 table#compose td.bottom div.sending-container div.sending-options-container div:not(:last-child) { border-bottom: 1px solid #cfcfcf; }
 table#compose td.bottom div.sending-container div.sending-options-container div span.option-name img { height: 0.8em; margin-right: 12px; position: relative; top: 1px; }
 table#compose td.bottom div.sending-container div.sending-options-container div img.icon-tick { height: 0.8em; margin-left: 12px; }
-table#compose td.bottom div.sending-container .button.green { border-radius: 0; }
+table#compose td.bottom div.sending-container .button.green { padding: 3px 10px; border-radius: 0; }
 table#compose td.bottom div.sending-container .button.green::-moz-focus-inner { border: 0; }
 table#compose td.bottom #send_btn { text-transform: initial; white-space: nowrap; width: 100%; box-sizing: border-box;
   position: relative; font-weight: 600; font-size: 0.9em; transition: .4s !important; display: flex; }

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -404,6 +404,7 @@ table#compose td.bottom div.sending-container div.sending-options-container div:
 table#compose td.bottom div.sending-container div.sending-options-container div span.option-name img { height: 0.8em; margin-right: 12px; position: relative; top: 1px; }
 table#compose td.bottom div.sending-container div.sending-options-container div img.icon-tick { height: 0.8em; margin-left: 12px; }
 table#compose td.bottom div.sending-container .button.green { border-radius: 0; }
+table#compose td.bottom div.sending-container .button.green::-moz-focus-inner { border: 0; }
 table#compose td.bottom #send_btn { text-transform: initial; white-space: nowrap; width: 100%; box-sizing: border-box;
   position: relative; font-weight: 600; font-size: 0.9em; transition: .4s !important; display: flex; }
 table#compose #send_btn i { font-size: 20px; }

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -393,7 +393,7 @@ table#compose td.input.show_send_from #input_from_settings { position: absolute;
 table#compose td.input.show_send_from #input_from_settings:hover { opacity: 1; }
 table#compose tr.bottom { background-color: #f5f5f5; }
 table#compose td.bottom { padding: 7px 12px 1px 12px; height: 47px; border-top: 1px solid #cfcfcf;}
-table#compose td.bottom div.sending-container { position: relative; display: inline-block; }
+table#compose td.bottom div.sending-container { position: relative; display: inline-flex; }
 table#compose td.bottom div.sending-container div.sending-options-container { display: none; position: absolute; background-color: #fff; 
   border: 1px solid #dadada; border-bottom: 0px; white-space: nowrap; box-sizing: border-box; z-index: 1; 
   box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.20) }
@@ -403,21 +403,15 @@ table#compose td.bottom div.sending-container div.sending-options-container div:
 table#compose td.bottom div.sending-container div.sending-options-container div:not(:last-child) { border-bottom: 1px solid #cfcfcf; }
 table#compose td.bottom div.sending-container div.sending-options-container div span.option-name img { height: 0.8em; margin-right: 12px; position: relative; top: 1px; }
 table#compose td.bottom div.sending-container div.sending-options-container div img.icon-tick { height: 0.8em; margin-left: 12px; }
-table#compose td.bottom div#send_btn { text-transform: initial; white-space: nowrap; width: 100%; box-sizing: border-box;
-  position: relative; top: -2px; font-weight: 600; font-size: 0.9em; border: unset; border-radius: 2px;
-  -webkit-transition: .4s !important; transition: .4s !important; margin: 0; margin-right: 10px; padding: 0; display: flex; }
-table#compose td.bottom div#send_btn.gray span { cursor: default; }
-table#compose #send_btn:focus { border: unset !important; outline: none !important; box-shadow: unset !important; }
-table#compose td.bottom div.sending-container.popover-opened div#send_btn { border-top-left-radius: 0; border-top-right-radius: 0; }
+table#compose td.bottom div.sending-container .button.green { border-radius: 0; }
+table#compose td.bottom #send_btn { text-transform: initial; white-space: nowrap; width: 100%; box-sizing: border-box;
+  position: relative; font-weight: 600; font-size: 0.9em; transition: .4s !important; display: flex; }
 table#compose #send_btn i { font-size: 20px; }
-table#compose #send_btn span.btn-text { width: 100%; padding: 5px; }
-table#compose #send_btn.button.green > span:hover, table#compose #send_btn > div:hover, table#compose td.bottom div.sending-container.popover-opened #send_btn > div { cursor: pointer; 
-  background-color: #5ab445; }
-table#compose #send_btn .action-show-options-popover { width: 15px; height: 35px; padding: 0 10px; }
-table#compose #send_btn.not-ready .action-show-options-popover { display: none; }
-table#compose #send_btn .action-show-options-popover div.icon-chevron { background-image: url('/img/svgs/chevron-left-white.svg'); background-size: contain; 
-  background-repeat: no-repeat; height: 10px; transform: rotate(90deg); position: relative; top: 15px; opacity: 0.7 }
-table#compose td.bottom div.sending-container.popover-opened #send_btn .action-show-options-popover div.icon-chevron { transform: rotate(-90deg); top: 10px }
+table#compose .button.green:hover, table#compose td.bottom div.sending-container.popover-opened > .action-show-options-popover { cursor: pointer; background-color: #5ab445; }
+table#compose .action-show-options-popover { min-width: auto; padding: 0 10px; }
+table#compose .action-show-options-popover div.icon-chevron { background-image: url('/img/svgs/chevron-left-white.svg'); background-size: contain; 
+  background-repeat: no-repeat; width: 10px; height: 10px; transform: rotate(90deg); position: relative; top: 2px; opacity: 0.7 }
+table#compose td.bottom div.sending-container.popover-opened .action-show-options-popover div.icon-chevron { transform: rotate(-90deg); top: -2px; }
 table#compose td.bottom div#send_btn_note { display: inline-block; font-size: 0.8em; padding-left: 5px; opacity: 0.5; }
 table#compose td.bottom .delete-draft { width: 20px; height: 20px;}
 table#compose .bottom .icon { padding: 3px 4px; display: inline-block; border: 1px solid #f5f5f5; border-radius: 2px; opacity: 0.35; background: none; vertical-align: middle; -moz-user-focus: none; }

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -403,8 +403,8 @@ table#compose td.bottom div.sending-container div.sending-options-container div:
 table#compose td.bottom div.sending-container div.sending-options-container div:not(:last-child) { border-bottom: 1px solid #cfcfcf; }
 table#compose td.bottom div.sending-container div.sending-options-container div span.option-name img { height: 0.8em; margin-right: 12px; position: relative; top: 1px; }
 table#compose td.bottom div.sending-container div.sending-options-container div img.icon-tick { height: 0.8em; margin-left: 12px; }
-table#compose td.bottom div.sending-container .button.green { padding: 3px 10px; border-radius: 0; }
-table#compose td.bottom div.sending-container .button.green::-moz-focus-inner { border: 0; }
+table#compose td.bottom div.sending-container .button { padding: 3px 10px; border-radius: 0; }
+table#compose td.bottom div.sending-container .button::-moz-focus-inner { border: 0; }
 table#compose td.bottom #send_btn { text-transform: initial; white-space: nowrap; width: 100%; box-sizing: border-box;
   position: relative; font-weight: 600; font-size: 0.9em; transition: .4s !important; display: flex; }
 table#compose #send_btn i { font-size: 20px; }

--- a/extension/js/common/composer.ts
+++ b/extension/js/common/composer.ts
@@ -778,8 +778,10 @@ export class Composer {
     }
     if (this.getPwdValidationWarning()) {
       this.S.cached('send_btn').removeClass('green').addClass('gray');
+      this.S.cached('toggle_send_options').removeClass('green').addClass('gray');
     } else {
       this.S.cached('send_btn').removeClass('gray').addClass('green');
+      this.S.cached('toggle_send_options').removeClass('gray').addClass('green');
     }
     if (this.S.cached('input_intro').is(':visible')) {
       this.S.cached('add_intro').css('display', 'none');
@@ -829,15 +831,18 @@ export class Composer {
     if (!this.getRecipients().length || ['signed', 'plain'].includes(this.encryptionType)) { // Hide 'Add Pasword' prompt if there are no recipients or message is signed.
       this.hideMsgPwdUi();
       this.S.cached('send_btn').removeClass('gray').addClass('green');
+      this.S.cached('toggle_send_options').removeClass('gray').addClass('green');
     } else if (this.getRecipients().find(r => r.status === RecipientStatuses.NO_PGP)) {
       this.showMsgPwdUiAndColorBtn();
     } else if (this.getRecipients().find(r => [RecipientStatuses.FAILED, RecipientStatuses.WRONG].includes(r.status))) {
       this.S.now('send_btn_text').text(this.BTN_WRONG_ENTRY);
       this.S.cached('send_btn').attr('title', 'Notice the recipients marked in red: please remove them and try to enter them egain.');
       this.S.cached('send_btn').removeClass('green').addClass('gray');
+      this.S.cached('toggle_send_options').removeClass('green').addClass('gray');
     } else {
       this.hideMsgPwdUi();
       this.S.cached('send_btn').removeClass('gray').addClass('green');
+      this.S.cached('toggle_send_options').removeClass('gray').addClass('green');
     }
     if (this.urlParams.isReplyBox) {
       if (!wasPreviouslyVisible && this.S.cached('password_or_pubkey').css('display') === 'table-row') {

--- a/extension/js/common/composer/composer-contacts.ts
+++ b/extension/js/common/composer/composer-contacts.ts
@@ -566,7 +566,7 @@ export class ComposerContacts extends ComposerComponent {
     $('body').attr('data-test-state', 'working');
     for (const recipient of recipients) {
       this.composer.debug(`evaluateRecipients.email(${String(recipient.email)})`);
-      this.composer.S.now('send_btn_span').text(this.BTN_LOADING);
+      this.composer.S.now('send_btn_text').text(this.BTN_LOADING);
       this.composer.setInputTextHeightManuallyIfNeeded();
       recipient.evaluating = (async () => {
         let pubkeyLookupRes: Contact | 'fail' | 'wrong';


### PR DESCRIPTION
Fixes #2045 

I converted `<div>`s to `<button>`s. It's always a good idea to use `<button>` tags for buttons, by doing that we're getting all a11y features for free (it's built-in in browsers), e.g. this line was removed:

```js
this.S.cached('send_btn').keypress(Ui.enter(() => this.extractProcessSendMsg()));
```

`<button>`s are getting clicked automatically with `Enter` or `Spacebar`, no need in adding additional keyboard handlers.

---

Also, I removed the `border-radius: 2px` from `#send_btn` and `#toggle_send_options` in order to avoid messing around with `border-top/bottom-left/right-radius` properties. @tomholub please let me know if sharp buttons are agains design styleguide.