### PR TITLE
Make the 'Recepients' field accessible with keyboard

### DIFF
--- a/extension/chrome/elements/compose.htm
+++ b/extension/chrome/elements/compose.htm
@@ -47,7 +47,7 @@
       </tr>
       <tr>
         <td class="input recipients-inputs">
-          <div id="input_addresses_container" tabindex="0" style="display: none;">
+          <div id="input_addresses_container" class="invisible">
             <!-- to -->
             <div id="input-container-to" data-sending-type="to" data-test="container-to">
               <span class="recipients recipients-to"></span>
@@ -71,7 +71,7 @@
                 autocomplete="false" />
             </div>
           </div>
-          <div class="collapsed" data-test="action-expand-cc-bcc-fields" style="display: flex;">
+          <div id="recipients_placeholder" class="collapsed" data-test="action-expand-cc-bcc-fields" style="display: flex;">
             <span class="placeholder">Recipients</span>
             <div class="email_preview"></div>
           </div>

--- a/extension/chrome/elements/compose.htm
+++ b/extension/chrome/elements/compose.htm
@@ -54,8 +54,8 @@
               <input id="input_to" spellcheck="false" tabindex="1" placeholder="Add Recipient" data-test="input-to"
                 data-sending-type="to" autocomplete="false" />
               <span class="email-copy-actions" data-test="action_open_input">
-                <span class="cc">cc</span>
-                <span class="bcc">bcc</span>
+                <button id="cc" class="cc" tabindex="20">cc</button>
+                <button id="bcc" class="bcc" tabindex="21">bcc</button>
               </span>
             </div>
             <!-- cc -->

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -335,7 +335,7 @@ table#compose td.input .collapsed .email_preview .rest.no_pgp { border-color: #9
 table#compose td.input .collapsed .email_preview .email_address.no_pgp { background-color: #989898; }
 table#compose.sign td.input .collapsed .email_preview .email_address { border: none !important; background-color: #f0f0f0 !important; color: black !important; }
 table#compose td.recipients-inputs { vertical-align: middle; }
-table#compose td.recipients-inputs > div#input_addresses_container { outline: none; }
+table#compose td.recipients-inputs > div#input_addresses_container.invisible { height: 0; overflow: hidden; }
 table#compose td.recipients-inputs > div#input_addresses_container > div { position: relative; }
 table#compose td.recipients-inputs > div#input_addresses_container div { width: 100%; overflow: hidden; cursor: text; }
 table#compose td.recipients-inputs > div#input_addresses_container div input { vertical-align: middle; height: 34px; font-size: 1em; font-family: Arial, sans-serif; }

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -363,12 +363,11 @@ table#compose td.recipients-inputs > div#input_addresses_container div .recipien
 table#compose td.recipients-inputs > div#input_addresses_container div .recipients > span.failed .close-icon { opacity: 1; }
 table#compose td.recipients-inputs > div#input_addresses_container div .recipients i.drag-cursor { width: 2px; height: 20px; display: inline-block; vertical-align: middle; margin-left: 3px; background-color: #5588EE; }
 table#compose td.recipients-inputs > div#input_addresses_container div span.email-copy-actions { position: absolute; right: 8px; bottom: 8px; white-space: nowrap; color: #636c72; }
-table#compose td.recipients-inputs > div#input_addresses_container div span.email-copy-actions span,
-table#compose td.recipients-inputs > div#input_addresses_container div span.email-copy-actions img { cursor: pointer; }
-table#compose td.recipients-inputs > div#input_addresses_container div span.email-copy-actions img { opacity: 0.6; width: 8px; height: 15px; vertical-align: middle; margin-left: 3px;  }
+table#compose td.recipients-inputs > div#input_addresses_container div span.email-copy-actions button { font-size: 1em; color: #636c72; background: none; cursor: pointer; border: 0; }
+table#compose td.recipients-inputs > div#input_addresses_container div span.email-copy-actions img { opacity: 0.6; width: 8px; height: 15px; vertical-align: middle; margin-left: 3px; cursor: pointer; }
 table#compose td.recipients-inputs > div#input_addresses_container div span.email-copy-actions img#show_sender_aliases_options { transform: rotate(270deg) }
-table#compose td.recipients-inputs > div#input_addresses_container div span.email-copy-actions span:hover { text-decoration: underline; }
-table#compose td.recipients-inputs > div#input_addresses_container div span.email-copy-actions img:hover { opacity: 0.8 }
+table#compose td.recipients-inputs > div#input_addresses_container div span.email-copy-actions button:hover { text-decoration: underline; }
+table#compose td.recipients-inputs > div#input_addresses_container div span.email-copy-actions img:hover { opacity: 0.8; }
 table#compose.sign .recipients span { border: none !important; background-color: #f0f0f0 !important; color: black !important; }
 table#compose.sign .recipients span.wrong { background: #A44 !important; color: white !important; }
 table#compose.sign .recipients span.wrong .close-icon { display: inline-block !important; }

--- a/extension/js/common/composer.ts
+++ b/extension/js/common/composer.ts
@@ -72,6 +72,8 @@ export class Composer {
     recipients_inputs: '#input_addresses_container input',
     attached_files: 'table#compose #fineuploader .qq-upload-list li',
     email_copy_actions: '#input_addresses_container .email-copy-actions',
+    cc: '#cc',
+    bcc: '#bcc',
     sending_options_container: 'div.sending-options-container'
   });
 

--- a/extension/js/common/composer.ts
+++ b/extension/js/common/composer.ts
@@ -45,7 +45,7 @@ export class Composer {
     input_subject: '#input_subject',
     input_password: '#input_password',
     input_intro: '.input_intro',
-    collapsed: '.collapsed',
+    recipients_placeholder: '#recipients_placeholder',
     all_cells_except_text: 'table#compose > tbody > tr > :not(.text)',
     add_intro: '.action_add_intro',
     add_their_pubkey: '.add_pubkey',
@@ -1125,7 +1125,7 @@ export class Composer {
   private windowResized = async () => {
     this.resizeComposeBox();
     this.setInputTextHeightManuallyIfNeeded(true);
-    if (this.S.cached('collapsed').is(':visible')) {
+    if (this.S.cached('recipients_placeholder').is(':visible')) {
       await this.composerContacts.setEmailsPreview(this.getRecipients());
     }
   }
@@ -1229,7 +1229,7 @@ export class Composer {
     } else {
       this.S.cached('icon_popout').attr('src', '/img/svgs/maximize.svg');
     }
-    if (this.S.cached('collapsed').is(':visible')) {
+    if (this.S.cached('recipients_placeholder').is(':visible')) {
       await this.composerContacts.setEmailsPreview(this.composerContacts.getRecipients());
     }
     this.composeWindowIsMaximized = !this.composeWindowIsMaximized;

--- a/extension/js/common/composer/composer-contacts.ts
+++ b/extension/js/common/composer/composer-contacts.ts
@@ -125,9 +125,9 @@ export class ComposerContacts extends ComposerComponent {
       }
       this.composer.setInputTextHeightManuallyIfNeeded();
     });
-    this.composer.S.cached('input_to').on('focus', focusRecipients)
-    this.composer.S.cached('cc').on('focus', focusRecipients)
-    this.composer.S.cached('bcc').on('focus', focusRecipients)
+    this.composer.S.cached('input_to').on('focus', focusRecipients);
+    this.composer.S.cached('cc').on('focus', focusRecipients);
+    this.composer.S.cached('bcc').on('focus', focusRecipients);
     this.composer.S.cached('compose_table').click(Ui.event.handle(() => this.hideContacts(), this.composer.getErrHandlers(`hide contact box`)));
     this.composer.S.cached('add_their_pubkey').click(Ui.event.handle(() => {
       const noPgpRecipients = this.addedRecipients.filter(r => r.element.className.includes('no_pgp'));

--- a/extension/js/common/composer/composer-contacts.ts
+++ b/extension/js/common/composer/composer-contacts.ts
@@ -107,14 +107,16 @@ export class ComposerContacts extends ComposerComponent {
         this.composer.resizeComposeBox();
         this.composer.setInputTextHeightManuallyIfNeeded();
       }));
-    this.composer.S.cached('collapsed').on('click', Ui.event.handle((target) => {
-      target.style.display = 'none';
-      this.composer.S.cached('input_addresses_container_outer').css('display', 'block');
+    this.composer.S.cached('recipients_placeholder').on('click', Ui.event.handle((target) => {
+      this.composer.S.cached('input_to').focus();
+    }));
+    this.composer.S.cached('input_to').on('focus', Ui.event.handle(() => {
+      this.composer.S.cached('recipients_placeholder').hide();
+      this.composer.S.cached('input_addresses_container_outer').removeClass('invisible');
       this.composer.resizeComposeBox();
       if (this.urlParams.isReplyBox) {
         this.composer.resizeInput();
       }
-      this.composer.S.cached('input_to').focus();
       this.composer.setInputTextHeightManuallyIfNeeded();
     }));
     this.composer.S.cached('compose_table').click(Ui.event.handle(() => this.hideContacts(), this.composer.getErrHandlers(`hide contact box`)));
@@ -611,13 +613,13 @@ export class ComposerContacts extends ComposerComponent {
   */
   public setEmailsPreview = async (recipients: RecipientElement[]): Promise<void> => {
     if (recipients.length) {
-      this.composer.S.cached('collapsed').find('.placeholder').css('display', 'none');
+      this.composer.S.cached('recipients_placeholder').find('.placeholder').css('display', 'none');
     } else {
-      this.composer.S.cached('collapsed').find('.placeholder').css('display', 'block');
-      this.composer.S.cached('collapsed').find('.email_preview').empty();
+      this.composer.S.cached('recipients_placeholder').find('.placeholder').css('display', 'block');
+      this.composer.S.cached('recipients_placeholder').find('.email_preview').empty();
       return;
     }
-    const container = this.composer.S.cached('collapsed').find('.email_preview');
+    const container = this.composer.S.cached('recipients_placeholder').find('.email_preview');
     if (recipients.find(r => r.status === RecipientStatuses.EVALUATING)) {
       container.append(`<span id="r_loader">Loading Reciepients ${Ui.spinner('green')}</span>`); // xss-direct
       await Promise.all(recipients.filter(r => r.evaluating).map(r => r.evaluating!));
@@ -738,8 +740,8 @@ export class ComposerContacts extends ComposerComponent {
         return;
       }
       this.showHideCcAndBccInputsIfNeeded();
-      this.composer.S.cached('input_addresses_container_outer').css('display', 'none');
-      this.composer.S.cached('collapsed').css('display', 'flex');
+      this.composer.S.cached('input_addresses_container_outer').addClass('invisible');
+      this.composer.S.cached('recipients_placeholder').css('display', 'flex');
       await this.setEmailsPreview(this.addedRecipients);
       this.hideContacts();
       this.composer.setInputTextHeightManuallyIfNeeded();

--- a/extension/js/common/composer/composer-contacts.ts
+++ b/extension/js/common/composer/composer-contacts.ts
@@ -93,24 +93,30 @@ export class ComposerContacts extends ComposerComponent {
         target.focus();
       }
     }));
-    this.composer.S.cached('email_copy_actions').find('span')
-      .on('click', Ui.event.handle((target, event) => {
-        const newContainer = this.composer.S.cached('input_addresses_container_outer').find(`div#input-container-${target.className}`);
-        const buttonsContainer = target.parentElement!;
-        const curentContainer = buttonsContainer.parentElement!;
-        const input = newContainer.find('input');
-        curentContainer.removeChild(buttonsContainer);
-        newContainer.append(buttonsContainer); // xss-safe-value
-        newContainer.css('display', 'block');
-        target.style.display = 'none';
-        input.focus();
-        this.composer.resizeComposeBox();
-        this.composer.setInputTextHeightManuallyIfNeeded();
-      }));
+    const handleCopyActionsClick = (target: HTMLElement, newContainer: JQuery<HTMLElement>) => {
+      const buttonsContainer = target.parentElement!;
+      const curentContainer = buttonsContainer.parentElement!;
+      const input = newContainer.find('input');
+      curentContainer.removeChild(buttonsContainer);
+      newContainer.append(buttonsContainer); // xss-safe-value
+      newContainer.css('display', 'block');
+      target.style.display = 'none';
+      input.focus();
+      this.composer.resizeComposeBox();
+      this.composer.setInputTextHeightManuallyIfNeeded();
+    };
+    this.composer.S.cached('cc').on('click', Ui.event.handle((target) => {
+      const newContainer = this.composer.S.cached('input_addresses_container_outer').find(`#input-container-cc`);
+      handleCopyActionsClick(target, newContainer);
+    }));
+    this.composer.S.cached('bcc').on('click', Ui.event.handle((target) => {
+      const newContainer = this.composer.S.cached('input_addresses_container_outer').find(`#input-container-bcc`);
+      handleCopyActionsClick(target, newContainer);
+    }));
     this.composer.S.cached('recipients_placeholder').on('click', Ui.event.handle((target) => {
       this.composer.S.cached('input_to').focus();
     }));
-    this.composer.S.cached('input_to').on('focus', Ui.event.handle(() => {
+    const focusRecipients = Ui.event.handle(() => {
       this.composer.S.cached('recipients_placeholder').hide();
       this.composer.S.cached('input_addresses_container_outer').removeClass('invisible');
       this.composer.resizeComposeBox();
@@ -118,7 +124,10 @@ export class ComposerContacts extends ComposerComponent {
         this.composer.resizeInput();
       }
       this.composer.setInputTextHeightManuallyIfNeeded();
-    }));
+    });
+    this.composer.S.cached('input_to').on('focus', focusRecipients)
+    this.composer.S.cached('cc').on('focus', focusRecipients)
+    this.composer.S.cached('bcc').on('focus', focusRecipients)
     this.composer.S.cached('compose_table').click(Ui.event.handle(() => this.hideContacts(), this.composer.getErrHandlers(`hide contact box`)));
     this.composer.S.cached('add_their_pubkey').click(Ui.event.handle(() => {
       const noPgpRecipients = this.addedRecipients.filter(r => r.element.className.includes('no_pgp'));
@@ -726,9 +735,9 @@ export class ComposerContacts extends ComposerComponent {
     const copyActionsContainer = this.composer.S.cached('email_copy_actions');
     copyActionsContainer.parent()[0].removeChild(copyActionsContainer[0]);
     this.composer.S.cached('input_addresses_container_outer').find(`#input-container-cc`).css('display', isThere.cc ? '' : 'none');
-    copyActionsContainer.find(`span.cc`).css('display', isThere.cc ? 'none' : '');
+    this.composer.S.cached('cc').css('display', isThere.cc ? 'none' : '');
     this.composer.S.cached('input_addresses_container_outer').find(`#input-container-bcc`).css('display', isThere.bcc ? '' : 'none');
-    copyActionsContainer.find(`span.bcc`).css('display', isThere.bcc ? 'none' : '');
+    this.composer.S.cached('bcc').css('display', isThere.bcc ? 'none' : '');
     this.composer.S.cached('input_addresses_container_outer').children(`:not([style="display: none;"])`).last().append(copyActionsContainer); // xss-safe-value
   }
 

--- a/test/source/browser/controllable.ts
+++ b/test/source/browser/controllable.ts
@@ -132,7 +132,15 @@ abstract class ControllableBase {
       throw Error(`Element not found: ${selector}`);
     }
     this.log(`click:4:${selector}`);
-    await e.click();
+    try {
+      await e.click();
+    } catch (e) {
+      if (e instanceof Error) {
+        e.stack += ` SELECTOR: ${selector}`;
+        await Util.sleep(60);
+      }
+      throw e;
+    }
     this.log(`click:5:${selector}`);
   }
 

--- a/test/source/tests/page_recipe.ts
+++ b/test/source/tests/page_recipe.ts
@@ -416,7 +416,7 @@ export class ComposePageRecipe extends PageRecipe {
   }
 
   private static fillRecipients = async (composePageOrFrame: Controllable, recipients: Recipients) => {
-    await composePageOrFrame.click('@action-expand-cc-bcc-fields');
+    await composePageOrFrame.waitAndClick('@action-expand-cc-bcc-fields');
     for (const key in recipients) {
       if (recipients.hasOwnProperty(key)) {
         const sendingType = key as RecipientType;

--- a/test/source/tests/tests/compose.ts
+++ b/test/source/tests/tests/compose.ts
@@ -39,7 +39,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithNewBrowser:
     ava.default('[standalone] compose - can load contact based on name', testWithNewBrowser(async (t, browser) => {
       await BrowserRecipe.setUpCommonAcct(t, browser, 'compose');
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compose');
-      await composePage.click('@action-expand-cc-bcc-fields');
+      await composePage.waitAndClick('@action-expand-cc-bcc-fields');
       await composePage.type('@input-to', 'human'); // test loading of contacts
       await composePage.waitAll(['@container-contacts', '@action-select-contact(human@flowcrypt.com)']);
     }));
@@ -48,7 +48,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithNewBrowser:
       await BrowserRecipe.setUpCommonAcct(t, browser, 'compose');
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compose');
       // composePage.enable_debugging('choose-contact');
-      await composePage.click('@action-expand-cc-bcc-fields');
+      await composePage.waitAndClick('@action-expand-cc-bcc-fields');
       await composePage.type('@input-to', 'human'); // test loading of contacts
       await composePage.waitAll(['@container-contacts', '@action-select-contact(human@flowcrypt.com)'], { timeout: 30 });
       await composePage.waitAndClick('@action-select-contact(human@flowcrypt.com)', { retryErrs: true, confirmGone: true, delay: 0 });
@@ -248,7 +248,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithNewBrowser:
       ].join('\n'));
     }));
 
-    ava.default('compose[global:compatibility] - reply - signed message', testWithSemaphoredGlobalBrowser('compatibility', async (t, browser) => {
+    ava.default.only('compose[global:compatibility] - reply - signed message', testWithSemaphoredGlobalBrowser('compatibility', async (t, browser) => {
       const appendUrl = 'threadId=15f7f5face7101db&skipClickPrompt=___cu_false___&ignoreDraft=___cu_false___&threadMsgId=15f7f5face7101db';
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility', { appendUrl, hasReplyPrompt: true });
       await composePage.waitAndClick('@action-accept-reply-prompt', { delay: 1 });
@@ -297,7 +297,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithNewBrowser:
       testWithSemaphoredGlobalBrowser('compatibility', async (t, browser) => {
         const appendUrl = 'draftId=r-8909860425873898730';
         const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility', { appendUrl });
-        await composePage.click('@action-expand-cc-bcc-fields');
+        await composePage.waitAndClick('@action-expand-cc-bcc-fields');
         await expectRecipientElements(composePage, { to: ['flowcryptcompatibility@gmail.com'], cc: ['flowcrypt.compatibility@gmail.com'], bcc: ['human@flowcrypt.com'] });
         const subjectElem = await composePage.waitAny('@input-subject');
         expect(await (await subjectElem.getProperty('value')).jsonValue()).to.equal('Test Draft - New Message');
@@ -314,7 +314,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithNewBrowser:
         chrome.storage.local.set({ 'cryptup_flowcryptcompatibilitygmailcom_drafts_reply': { '16cfa9001baaac0a': 'r-1543309186581841785' } });
       };
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility', { appendUrl, hasReplyPrompt: true, skipClickPropt: true, initialScript });
-      await composePage.click('@action-expand-cc-bcc-fields');
+      await composePage.waitAndClick('@action-expand-cc-bcc-fields');
       await expectRecipientElements(composePage, { to: ['flowcryptcompatibility@gmail.com'] });
       expect(await composePage.read('@input-body')).to.include('Test Draft Reply (Do not delete, tests is using this draft)');
     }));


### PR DESCRIPTION
Closes #2044

Also, in scope of this PR I made `cc` and `bcc` buttons accessible with keyboard (they are at the end of taborder)

As discussed per email conversation I changed some lines in JS side to use IDs instead of tag names or classnames:

- `recipients_placeholder: '#recipients_placeholder'`
- `cc: '#cc'`
- `bcc: '#bcc'`

@michael-volynets @tomholub this practice is bad and should be avoided in future:

```js
this.composer.S.cached('email_copy_actions').find('span')
```

The reason why it's bad is that JS should not rely on tag names at all. In this PR I was changing `<span>`s to `<button>`s and was not expecting to break something on the JS side by doing that.

Copy-pasting the good practice suggested by @tomholub here:

> - tags only have html structure significance, and not used anywhere else
> - css file will only contain references to classes, not ids nor tags
> - both classes and ids may be used in JS, with preference to ids when there is just one thing to refer to
> - only data-test attrs should be used for tests, where possible (we already do this)