### PR TITLE
Issue #2056 Focus input_text asyncronously when replying

### DIFF
--- a/extension/js/common/composer.ts
+++ b/extension/js/common/composer.ts
@@ -1090,8 +1090,7 @@ export class Composer {
     }
     if (this.urlParams.isReplyBox) {
       if (this.urlParams.to.length) {
-        // Chrome needs async focus (#2056)
-        setTimeout(() => {
+        Catch.setHandledTimeout(() => { // Chrome needs async focus: https://github.com/FlowCrypt/flowcrypt-browser/issues/2056
           this.S.cached('input_text').focus();
           document.getElementById('input_text')!.focus(); // #input_text is in the template
         }, 100);

--- a/extension/js/common/composer.ts
+++ b/extension/js/common/composer.ts
@@ -1090,8 +1090,11 @@ export class Composer {
     }
     if (this.urlParams.isReplyBox) {
       if (this.urlParams.to.length) {
-        this.S.cached('input_text').focus();
-        document.getElementById('input_text')!.focus(); // #input_text is in the template
+        // Chrome needs async focus (#2056)
+        setTimeout(() => {
+          this.S.cached('input_text').focus();
+          document.getElementById('input_text')!.focus(); // #input_text is in the template
+        }, 100)
         // Firefox will not always respond to initial automatic $input_text.blur()
         // Recipients may be left unrendered, as standard text, with a trailing comma
         await this.composerContacts.parseRenderRecipients(this.S.cached('input_to')); // this will force firefox to render them on load
@@ -1134,7 +1137,7 @@ export class Composer {
     const sendAs = this.app.storageGetAddresses();
     if (sendAs && Object.keys(sendAs).length > 1) {
       const showAliasChevronHtml = '<img id="show_sender_aliases_options" src="/img/svgs/chevron-left.svg" title="Choose sending address">';
-      const inputAddrContainer = this.S.cached('email-copy-actions');
+      const inputAddrContainer = this.S.cached('email_copy_actions');
       Xss.sanitizeAppend(inputAddrContainer, showAliasChevronHtml);
       inputAddrContainer.find('#show_sender_aliases_options').click(Ui.event.handle((el) => {
         this.renderSenderAliasesOptions(sendAs);

--- a/extension/js/common/composer.ts
+++ b/extension/js/common/composer.ts
@@ -1094,7 +1094,7 @@ export class Composer {
         setTimeout(() => {
           this.S.cached('input_text').focus();
           document.getElementById('input_text')!.focus(); // #input_text is in the template
-        }, 100)
+        }, 100);
         // Firefox will not always respond to initial automatic $input_text.blur()
         // Recipients may be left unrendered, as standard text, with a trailing comma
         await this.composerContacts.parseRenderRecipients(this.S.cached('input_to')); // this will force firefox to render them on load

--- a/test/source/patterns.ts
+++ b/test/source/patterns.ts
@@ -41,7 +41,7 @@ const validateLine = (line: string, location: string) => {
     errsFound++;
   }
   if (line.match(/setInterval|setTimeout/) && !hasErrHandledComment(line)) {
-    console.error(`errors not handled in ${location}:\n${line}\n`);
+    console.error(`errors not handled in ${location} (make sure to use Catch.setHandledTimeout or Catch.setHandledInterval):\n${line}\n`);
     errsFound++;
   }
 };


### PR DESCRIPTION
Closes #2056 

To be honest, I do not understand what exaclty is the reason syncronous `.focus()` is not working in Chrome. It doesn't seem that something else is stealing focus from `input_text`.

The fix is a little ugly becase of so-called "magic" number `100`, I personally don't like magic numbers and try to avoid them when possible. @tomholub please let me know if it's too ugly to be in the codebase.