### PR TITLE
Issue #2062, Remove .blur().focus() trick and run parseRenderRecipients() directly

### DIFF
--- a/extension/js/common/composer.ts
+++ b/extension/js/common/composer.ts
@@ -1041,6 +1041,14 @@ export class Composer {
     }));
     this.S.cached('body').keypress(Ui.ctrlEnter(() => !this.composeWindowIsMinimized && this.extractProcessSendMsg()));
     this.S.cached('send_btn').click(Ui.event.prevent('double', () => this.extractProcessSendMsg()));
+    if (!String(this.S.cached('input_to').val()).length) {
+      // focus on recipients, but only if empty (user has not started typing yet)
+      // this is particularly important to skip if CI tests are already typing the recipient in
+      this.debug(`renderComposeTable -> calling input_to.focus() when input_to.val(${this.S.cached('input_to').val()})`);
+      // Firefox needs an iframe to be focused before focusing its content
+      BrowserMsg.send.focusFrame(this.urlParams.parentTabId, { frameId: this.urlParams.frameId });
+      this.S.cached('input_to').focus();
+    }
     this.composerContacts.initActions();
     this.S.cached('input_to').bind('paste', Ui.event.handle(async (elem, event) => {
       if (event.originalEvent instanceof ClipboardEvent && event.originalEvent.clipboardData) {
@@ -1088,14 +1096,6 @@ export class Composer {
       this.setInputTextHeightManuallyIfNeeded();
       this.resizeComposeBox();
     });
-    if (!String(this.S.cached('input_to').val()).length) {
-      // focus on recipients, but only if empty (user has not started typing yet)
-      // this is particularly important to skip if CI tests are already typing the recipient in
-      this.debug(`renderComposeTable -> calling input_to.focus() when input_to.val(${this.S.cached('input_to').val()})`);
-      // Firefox needs an iframe to be focused before focusing its content
-      BrowserMsg.send.focusFrame(this.urlParams.parentTabId, { frameId: this.urlParams.frameId });
-      this.S.cached('input_to').focus();
-    }
     if (this.urlParams.isReplyBox) {
       if (this.urlParams.to.length) {
         // Firefox will not always respond to initial automatic $input_text.blur()

--- a/extension/js/common/composer.ts
+++ b/extension/js/common/composer.ts
@@ -1065,7 +1065,7 @@ export class Composer {
             }));
           }
           this.S.cached('input_to').val(keyUser.email);
-          this.composerContacts.parseRenderRecipients(this.S.cached('input_to'));
+          await this.composerContacts.parseRenderRecipients(this.S.cached('input_to'));
         } else {
           await Ui.modal.warning(`The email listed in this public key does not seem valid: ${keyUser}`);
         }

--- a/extension/js/common/composer.ts
+++ b/extension/js/common/composer.ts
@@ -1064,7 +1064,8 @@ export class Composer {
               pubkey: normalizedPub, lastCheck: Date.now(), expiresOn: await Pgp.key.dateBeforeExpiration(normalizedPub)
             }));
           }
-          this.S.cached('input_to').val(keyUser.email).blur().focus(); // Need (blur + focus) to run parseRender function
+          this.S.cached('input_to').val(keyUser.email);
+          this.composerContacts.parseRenderRecipients(this.S.cached('input_to'));
         } else {
           await Ui.modal.warning(`The email listed in this public key does not seem valid: ${keyUser}`);
         }

--- a/extension/js/common/composer.ts
+++ b/extension/js/common/composer.ts
@@ -1112,6 +1112,8 @@ export class Composer {
       }
       this.setInputTextHeightManuallyIfNeeded();
     }
+    // Firefox needs an iframe to be focused before focusing its content
+    BrowserMsg.send.focusFrame(this.urlParams.parentTabId, { frameId: this.urlParams.frameId });
     Catch.setHandledTimeout(() => { // Chrome needs async focus: https://github.com/FlowCrypt/flowcrypt-browser/issues/2056
       this.S.cached(this.urlParams.isReplyBox && this.urlParams.to.length ? 'input_text' : 'input_to').focus();
       // document.getElementById('input_text')!.focus(); // #input_text is in the template

--- a/extension/js/common/composer.ts
+++ b/extension/js/common/composer.ts
@@ -1088,14 +1088,6 @@ export class Composer {
       this.setInputTextHeightManuallyIfNeeded();
       this.resizeComposeBox();
     });
-    if (!String(this.S.cached('input_to').val()).length) {
-      // focus on recipients, but only if empty (user has not started typing yet)
-      // this is particularly important to skip if CI tests are already typing the recipient in
-      this.debug(`renderComposeTable -> calling input_to.focus() when input_to.val(${this.S.cached('input_to').val()})`);
-      // Firefox needs an iframe to be focused before focusing its content
-      BrowserMsg.send.focusFrame(this.urlParams.parentTabId, { frameId: this.urlParams.frameId });
-      this.S.cached('input_to').focus();
-    }
     if (this.urlParams.isReplyBox) {
       if (this.urlParams.to.length) {
         // Firefox will not always respond to initial automatic $input_text.blur()

--- a/extension/js/common/composer.ts
+++ b/extension/js/common/composer.ts
@@ -1041,14 +1041,6 @@ export class Composer {
     }));
     this.S.cached('body').keypress(Ui.ctrlEnter(() => !this.composeWindowIsMinimized && this.extractProcessSendMsg()));
     this.S.cached('send_btn').click(Ui.event.prevent('double', () => this.extractProcessSendMsg()));
-    if (!String(this.S.cached('input_to').val()).length) {
-      // focus on recipients, but only if empty (user has not started typing yet)
-      // this is particularly important to skip if CI tests are already typing the recipient in
-      this.debug(`renderComposeTable -> calling input_to.focus() when input_to.val(${this.S.cached('input_to').val()})`);
-      // Firefox needs an iframe to be focused before focusing its content
-      BrowserMsg.send.focusFrame(this.urlParams.parentTabId, { frameId: this.urlParams.frameId });
-      this.S.cached('input_to').focus();
-    }
     this.composerContacts.initActions();
     this.S.cached('input_to').bind('paste', Ui.event.handle(async (elem, event) => {
       if (event.originalEvent instanceof ClipboardEvent && event.originalEvent.clipboardData) {
@@ -1096,6 +1088,14 @@ export class Composer {
       this.setInputTextHeightManuallyIfNeeded();
       this.resizeComposeBox();
     });
+    if (!String(this.S.cached('input_to').val()).length) {
+      // focus on recipients, but only if empty (user has not started typing yet)
+      // this is particularly important to skip if CI tests are already typing the recipient in
+      this.debug(`renderComposeTable -> calling input_to.focus() when input_to.val(${this.S.cached('input_to').val()})`);
+      // Firefox needs an iframe to be focused before focusing its content
+      BrowserMsg.send.focusFrame(this.urlParams.parentTabId, { frameId: this.urlParams.frameId });
+      this.S.cached('input_to').focus();
+    }
     if (this.urlParams.isReplyBox) {
       if (this.urlParams.to.length) {
         // Firefox will not always respond to initial automatic $input_text.blur()


### PR DESCRIPTION
Closes #2062
