### PR TITLE
Issue 2077 fix cc bcc drag and drop

### DIFF
--- a/extension/js/common/composer/composer-contacts.ts
+++ b/extension/js/common/composer/composer-contacts.ts
@@ -446,7 +446,9 @@ export class ComposerContacts extends ComposerComponent {
       Xss.sanitizeAppend(container.find('.recipients'), recipientsHtml);
       const element = document.getElementById(recipientId)!;
       $(element).on('blur', Ui.event.handle(async (elem, event) => {
-        await this.collapseIpnutsIfNeeded(event.relatedTarget);
+        if (!this.dragged) {
+          await this.collapseIpnutsIfNeeded(event.relatedTarget);
+        }
       }));
       this.addDraggableEvents(element);
       const recipient = { email, element, id: recipientId, sendingType, status };
@@ -743,6 +745,7 @@ export class ComposerContacts extends ComposerComponent {
       this.dragged = undefined;
       newInput.focus();
     };
+    element.ondragend = () => Catch.setHandledTimeout(() => this.dragged = undefined, 0);
   }
 
   private insertCursorBefore = (element: HTMLElement | Element, append?: boolean) => {

--- a/extension/js/common/composer/composer-contacts.ts
+++ b/extension/js/common/composer/composer-contacts.ts
@@ -724,7 +724,7 @@ export class ComposerContacts extends ComposerComponent {
     };
     element.ondragover = (ev) => {
       ev.preventDefault();
-    }
+    };
     element.ondrop = () => {
       this.removeCursor(element.parentElement!);
       // The position won't be changed so we don't need to do any manipulations


### PR DESCRIPTION
Issue #2077 
Time Spent 2h 30m,

The reason why that wasn't working is because Chromium triggers the`dragend` event before `drop` event when we use it in Gmail webmail, maybe it's their bug or what but it should have been vice versa. 
At the first, I just removed `dragend` event but it caused me more problems so I decided to cover the body of `dragend` event in `Catch.setHandeledTimeout` and it started working correctly.

About firefox, when we start drag&drop - then triggers blur event on `recipientElement` and it hides our inputs. 
I added `if` statement to check whether it was triggered by drag&drop or not, if no then do collapse