### PR TITLE
Issue #2055, Remove outline: none from links

### DIFF
--- a/extension/css/browser-popup.css
+++ b/extension/css/browser-popup.css
@@ -143,9 +143,6 @@ html, body {
   left: 49px;
   color: #337ab7;
 }
-a:focus {
-  outline: none;
-}
 ul {
   padding-left: 0px;
 }

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -14,7 +14,6 @@
 }
 
 a { color: #337AB7; }
-a:focus { outline: none !important; }
 .line.red, td.red, b.red, span.red { color: #d14836; }
 .line.prange, td.orange, b.orange, span.orange { color: #c27e23; }
 .line.green, td.green, b.green, span.green { color: #31A217; }

--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -12,7 +12,7 @@ body.cryptup_outlook div.webmail_notifications div.webmail_notification { margin
 
 /* buttons body.cryptup_inbox */
 body.cryptup_gmail_new .new_message_button:before { background-image: url("/img/logo/logo.svg");}
-body.cryptup_inbox div.new_message_button { position: relative; width: 40px; box-sizing: content-box; cursor: pointer; outline: none;
+body.cryptup_inbox div.new_message_button { position: relative; width: 40px; box-sizing: content-box; cursor: pointer;
   border: none; -webkit-user-drag: none; margin-right: 8px; background: white; }
 body.cryptup_inbox div.new_message_button > img { width: 28px; padding: 6px; padding-top: 10px; }
 body.cryptup_inbox .pgp_message_container .nk .tq:first-child { display: none !important; } /* reply, reply all, forward in menu next to encrypted messages */


### PR DESCRIPTION
Closes #2055

`outline: none` should not be set on `a:focus` without replacing outline with some other kind of indication of the focused state.

All other occurrences of `outline: none` are fine - they are applied either for inputs where the focus can be visible by the cursor or for buttons with the alternative method of focus indication (borders + opacity).