### PR TITLE
[2h] Issue #1452 test signed messages

### DIFF
--- a/test/source/mock/strategies/send-message-strategy.ts
+++ b/test/source/mock/strategies/send-message-strategy.ts
@@ -13,7 +13,6 @@ class SignedMessageTestStrategy implements ITestMsgStrategy {
     const decrypted = await PgpMsg.decrypt({ kisWithPp: keyInfo!, encryptedData: Buf.fromUtfStr(mimeMsg.text) });
     if (decrypted.success && decrypted.signature) {
       const content = decrypted.content.toUtfStr();
-      console.log(content);
       if (!content.includes(this.expectedText)) {
         throw new HttpClientErr(`Error: Contents don't match. Expected: '${this.expectedText}' but got: '${content}'.`);
       }

--- a/test/source/mock/strategies/send-message-strategy.ts
+++ b/test/source/mock/strategies/send-message-strategy.ts
@@ -1,9 +1,27 @@
 import { UnsuportableStrategyError, ITestMsgStrategy } from './strategy-base.js';
 import { ParsedMail, AddressObject } from 'mailparser';
 import { HttpClientErr } from '../api.js';
-import { PgpMsg } from "../../core/pgp.js";
+import { PgpMsg, Pgp } from "../../core/pgp.js";
 import { Buf } from '../../core/buf.js';
 import { Config } from '../../util/index.js';
+
+class SignedMessageTestStrategy implements ITestMsgStrategy {
+  private readonly expectedText = 'New Signed Message (Mock Test)';
+
+  async test(mimeMsg: ParsedMail) {
+    const keyInfo = Config.secrets.keyInfo.find(k => k.email === 'flowcrypt.compatibility@gmail.com')!.key;
+    const decrypted = await PgpMsg.decrypt({ kisWithPp: keyInfo!, encryptedData: Buf.fromUtfStr(mimeMsg.text) });
+    if (decrypted.success && decrypted.signature) {
+      const content = decrypted.content.toUtfStr();
+      console.log(content);
+      if (!content.includes(this.expectedText)) {
+        throw new HttpClientErr(`Error: Contents don't match. Expected: '${this.expectedText}' but got: '${content}'.`);
+      }
+    } else {
+      throw new HttpClientErr(`Error: The message isn't signed.`);
+    }
+  }
+}
 
 class PlainTextMessageTestStrategy implements ITestMsgStrategy {
   private readonly expectedText = 'New Plain Message';
@@ -67,6 +85,8 @@ export class TestBySubjectStrategyContext {
       this.strategy = new NewMessageCCAndBCCTestStrategy();
     } else if (subject.includes('New Plain Message')) {
       this.strategy = new PlainTextMessageTestStrategy();
+    } else if (subject.includes('New Signed Message (Mock Test)')) {
+      this.strategy = new SignedMessageTestStrategy();
     } else {
       throw new UnsuportableStrategyError(`There isn't any strategy for this subject: ${subject}`);
     }

--- a/test/source/tests/page_recipe.ts
+++ b/test/source/tests/page_recipe.ts
@@ -445,7 +445,7 @@ export class ComposePageRecipe extends PageRecipe {
     if (password) {
       await composePage.waitAndType('@input-password', 'test-pass');
     }
-    await composePage.waitAndClick('@action-send', { delay: 0.5 });
+    await composePage.waitAndClick('@action-send', { delay: 1 });
     await Promise.race([
       composePage.waitForSelTestState('closed', timeout), // in case this was a new message compose
       composePage.waitAny('@container-reply-msg-successful', { timeout }) // in case of reply

--- a/test/source/tests/page_recipe.ts
+++ b/test/source/tests/page_recipe.ts
@@ -412,8 +412,7 @@ export class ComposePageRecipe extends PageRecipe {
     if (subject) {
       await composePageOrFrame.click('@input-subject');
       await Util.sleep(1);
-      subject = `Automated puppeteer test: ${subject}`;
-      await composePageOrFrame.type('@input-subject', subject);
+      await composePageOrFrame.type('@input-subject', `Automated puppeteer test: ${subject}`);
     }
     const body = `This is an automated puppeteer test: ${subject || '(no-subject)'}`;
     await composePageOrFrame.type('@input-body', body);

--- a/test/source/tests/tests/compose.ts
+++ b/test/source/tests/tests/compose.ts
@@ -440,7 +440,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithNewBrowser:
       expect(await PageRecipe.getElementPropertyJson((await contacts.$('ul li:first-child'))!, 'textContent')).to.eq('contact.test@flowcrypt.com');
     }));
 
-    ava.default.only('[compose[global:compatibility] - standalone - new signed message, verification in mock', testWithSemaphoredGlobalBrowser('compatibility', async (t, browser) => {
+    ava.default('[compose[global:compatibility] - standalone - new signed message, verification in mock', testWithSemaphoredGlobalBrowser('compatibility', async (t, browser) => {
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
       await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'New Signed Message (Mock Test)', 'signed');
       await ComposePageRecipe.sendAndClose(composePage);

--- a/test/source/tests/tests/compose.ts
+++ b/test/source/tests/tests/compose.ts
@@ -440,6 +440,12 @@ export const defineComposeTests = (testVariant: TestVariant, testWithNewBrowser:
       expect(await PageRecipe.getElementPropertyJson((await contacts.$('ul li:first-child'))!, 'textContent')).to.eq('contact.test@flowcrypt.com');
     }));
 
+    ava.default.only('[compose[global:compatibility] - standalone - new signed message, verification in mock', testWithSemaphoredGlobalBrowser('compatibility', async (t, browser) => {
+      const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
+      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'New Signed Message (Mock Test)', 'signed');
+      await ComposePageRecipe.sendAndClose(composePage);
+    }));
+
     ava.todo('compose[global:compose] - reply - new gmail threadId fmt');
 
     ava.todo('compose[global:compose] - reply - skip click prompt');


### PR DESCRIPTION
Issue #1452 
Time Spent: 1h 40m

When I finished writing the test and I ran it, unfortunately, it didn't pass, I didn't know why because the test was written correctly. The problem was because of `email-mime-codec` `foldLines` method, it added a new line symbol and the message changed.

Could you please explain to me why do we need this method?