### PR TITLE
[3h] Issue #1606, corrected Mime.decode method

### DIFF
--- a/extension/chrome/elements/pgp_block.ts
+++ b/extension/chrome/elements/pgp_block.ts
@@ -378,8 +378,10 @@ Catch.try(async () => {
         isHtml = true;
       } else if (typeof decoded.text !== 'undefined') {
         decryptedContent = decoded.text;
+      } else {
+        decryptedContent = '';
       }
-      if (decoded.subject) {
+      if (decoded.subject && isEncrypted) {
         decryptedContent = getEncryptedSubjectText(decoded.subject, isHtml) + decryptedContent;
       }
       for (const att of decoded.atts) {

--- a/extension/js/common/core/mime.ts
+++ b/extension/js/common/core/mime.ts
@@ -202,8 +202,7 @@ export class Mime {
               if (node._parentNode && node._parentNode.headers.subject) {
                 mimeContent.subject = node._parentNode.headers.subject[0].value;
               }
-            }
-            if (Mime.getNodeFilename(node)) {
+            } else {
               mimeContent.atts.push(Mime.getNodeAsAtt(node));
             }
           }

--- a/extension/js/common/core/mime.ts
+++ b/extension/js/common/core/mime.ts
@@ -192,17 +192,18 @@ export class Mime {
           for (const node of Object.values(leafNodes)) {
             if (Mime.getNodeType(node) === 'application/pgp-signature') {
               mimeContent.signature = node.rawContent;
-            } else if (Mime.getNodeType(node) === 'text/html' && !Mime.getNodeFilename(node)) {
+            } else if (Mime.getNodeType(node) === 'text/html') {
               // html content may be broken up into smaller pieces by attachments in between
               // AppleMail does this with inline attachments
               mimeContent.html = (mimeContent.html || '') + Mime.getNodeContentAsUtfStr(node);
-            } else if (Mime.getNodeType(node) === 'text/plain' && !Mime.getNodeFilename(node)) {
+            } else if (Mime.getNodeType(node) === 'text/plain') {
               mimeContent.text = Mime.getNodeContentAsUtfStr(node);
             } else if (Mime.getNodeType(node) === 'text/rfc822-headers') {
               if (node._parentNode && node._parentNode.headers.subject) {
                 mimeContent.subject = node._parentNode.headers.subject[0].value;
               }
-            } else {
+            }
+            if (Mime.getNodeFilename(node)) {
               mimeContent.atts.push(Mime.getNodeAsAtt(node));
             }
           }

--- a/extension/js/common/core/mime.ts
+++ b/extension/js/common/core/mime.ts
@@ -192,11 +192,11 @@ export class Mime {
           for (const node of Object.values(leafNodes)) {
             if (Mime.getNodeType(node) === 'application/pgp-signature') {
               mimeContent.signature = node.rawContent;
-            } else if (Mime.getNodeType(node) === 'text/html') {
+            } else if (Mime.getNodeType(node) === 'text/html' && !Mime.getNodeFilename(node)) {
               // html content may be broken up into smaller pieces by attachments in between
               // AppleMail does this with inline attachments
               mimeContent.html = (mimeContent.html || '') + Mime.getNodeContentAsUtfStr(node);
-            } else if (Mime.getNodeType(node) === 'text/plain') {
+            } else if (Mime.getNodeType(node) === 'text/plain' && !Mime.getNodeFilename(node)) {
               mimeContent.text = Mime.getNodeContentAsUtfStr(node);
             } else if (Mime.getNodeType(node) === 'text/rfc822-headers') {
               if (node._parentNode && node._parentNode.headers.subject) {


### PR DESCRIPTION
Issue #1606,
Time Spent: 2h 30m (Almost all time I was investigating why it isn't working),

I'm not sure it's the right solution but I tried to make it work as Thunderbird does.
I tried to open this message in Thunderbird and they render the attachment and the text. So I did the same. Now, FlowCrypt decrypts the message correctly.

If you approve this solution I'll start writing the tests.