### PR TITLE
Improve the responsiveness of attachments

### DIFF
--- a/extension/chrome/elements/shared/attach.template.htm
+++ b/extension/chrome/elements/shared/attach.template.htm
@@ -24,7 +24,7 @@
       <span class="qq-upload-file-selector qq-upload-file"></span>
       <span class="upload-size" style="display:none;">1kb</span>
       <span class="qq-upload-size-selector qq-upload-size"></span>
-      <button type="button" class="qq-btn qq-upload-cancel-selector qq-upload-cancel"><img
+      <button type="button" class="qq-btn qq-upload-cancel-selector qq-upload-cancel" tabindex="5"><img
           src="/img/svgs/close-icon-black.svg" alt="close" class="close-icon svg" width="14px" /></button>
       <button type="button" class="qq-btn qq-upload-retry-selector qq-upload-retry"></button>
       <button type="button" class="qq-btn qq-upload-delete-selector qq-upload-delete">Delete</button>

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -458,12 +458,12 @@ table#compose #fineuploader .qq-total-progress-bar-container { display: none; he
 table#compose #fineuploader .qq-upload-list {overflow-x: hidden; }
 table#compose #fineuploader .qq-upload-list::-webkit-scrollbar {  width: 0 !important;}
 table#compose #fineuploader .qq-upload-list li { border: none; background: #fff; opacity: 1; margin-left: 12px; padding: 5px 30px 5px 24px; }
-table#compose #fineuploader .qq-upload-list li .qq-upload-file { line-height: 18px; color: black; }
+table#compose #fineuploader .qq-upload-list li .qq-upload-file { line-height: 1em; height: 1.1em; color: black; }
 table#compose #fineuploader .qq-upload-list [class^="qq-file-id"] { background: #f3f3f3; border: 1px solid #ccc; margin: 3px 0px 3px 10px ; position: relative;
   border-left: 4px solid #31A217; background-image: url("/img/svgs/locked-icon-green.svg"); background-repeat: no-repeat; background-size: 9px;
-  background-position-x: 8px; background-position-y: 8px; }
+  background-position-x: 8px; background-position-y: center; }
 table#compose #fineuploader .qq-upload-list .not-encrypted { border-left: 1px solid #ccc !important; background-image: none !important; padding-left: 8px; }
-table#compose #fineuploader .qq-upload-cancel  {background: transparent; border:0; box-shadow: none; }
+table#compose #fineuploader .qq-upload-cancel { top: 50%; margin-top: -7px; background: transparent; border:0; box-shadow: none; }
 
 body.full_window table#compose { position: relative;}
 


### PR DESCRIPTION
Closes #2142

This was my oversight from #2043

Also, fixed the `tabindex` of attachment buttons, so they are just before the Send button.

![1](https://user-images.githubusercontent.com/6059356/67495867-38c41000-f684-11e9-9d28-845183a1801c.gif)

@tomholub this behavior is opinionated, in Gmail those buttons are actually inaccessible with keyboard so it might be unusual for users. Let me know if you think attachments should be after the Send button in the taborder.