### PR TITLE
Issue 2165 take icon_show_prev_msg's height into account in setInputTextHeightManuallyIfNeeded()

### DIFF
--- a/extension/js/common/composer.ts
+++ b/extension/js/common/composer.ts
@@ -339,7 +339,8 @@ export class Composer {
       }
       const attListHeight = $("#att_list").height() || 0;
       const inputTextVerticalPadding = parseInt(this.S.cached('input_text').css('padding-top')) + parseInt(this.S.cached('input_text').css('padding-bottom'));
-      this.S.cached('input_text').css('height', this.refBodyHeight - cellHeightExceptText - attListHeight - inputTextVerticalPadding);
+      const iconShowPrevMsgHeight = this.S.cached('icon_show_prev_msg').outerHeight(true) || 0;
+      this.S.cached('input_text').css('height', this.refBodyHeight - cellHeightExceptText - attListHeight - inputTextVerticalPadding - iconShowPrevMsgHeight);
     }
   }
 


### PR DESCRIPTION
Closes #2165 

This small node was forgotten in `setInputTextHeightManuallyIfNeeded()`:

![image](https://user-images.githubusercontent.com/6059356/68288559-4bc7de80-008d-11ea-8488-825a781687a9.png)
