### PR TITLE
Add launch.json with the config to debug chrome_consumer_live_gmail

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug chrome_consumer_live_gmail",
+      "preLaunchTask": "npm: pretest",
+      "program": "${workspaceFolder}/node_modules/ava/profile.js",
+      "args": [
+        "build/test/test/source/test.js",
+        "CONSUMER-LIVE-GMAIL"
+      ],
+      "skipFiles": [
+        "<node_internals>/**/*.js"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
With this configuration it's possible to debug `chrome_consumer_live_gmail` tests by using breakpoins (either `debugger` or VSCode breakpoins):

![image](https://user-images.githubusercontent.com/6059356/69994130-e1a03d80-1555-11ea-944f-fdebb1fca873.png)

Using the VSCode debugger over `console.log` will save us a ton of time when writing tests.

Docs on setting up debug configuration in AVA: https://github.com/avajs/ava/blob/master/docs/recipes/debugging-with-vscode.md
Common docs on debugging in VSCode: https://code.visualstudio.com/docs/editor/debugging