### PR TITLE
Fix initializing lastDraftBody

### DIFF
--- a/extension/js/common/composer/composer-draft.ts
+++ b/extension/js/common/composer/composer-draft.ts
@@ -20,7 +20,7 @@ export class ComposerDraft extends ComposerComponent {
 
   private currentlySavingDraft = false;
   private saveDraftInterval?: number;
-  private lastDraftBody = '';
+  private lastDraftBody?: string;
   private lastDraftSubject = '';
 
   private SAVE_DRAFT_FREQUENCY = 3000;
@@ -202,6 +202,10 @@ export class ComposerDraft extends ComposerComponent {
   }
 
   private hasBodyChanged = (msgBody: string) => {
+    if (this.lastDraftBody === undefined) { // first check
+      this.lastDraftBody = msgBody;
+      return false;
+    }
     if (msgBody && msgBody !== this.lastDraftBody) {
       this.lastDraftBody = msgBody;
       return true;


### PR DESCRIPTION
Fixes #2274 

The initial value of `lastDraftBody` isn't always `''`. In case the account has a signature (footer), the initial value of `lastDraftBody` should be the user's signature so `hasBodyChanged()` will return the correct result.