### PR TITLE
"typescript.tsdk": "node_modules/typescript/lib"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,1 +1,3 @@
-{}
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}


### PR DESCRIPTION
Connected to #2297

VSCode is still shipped with TS 3.6, in order to tell it to use TS 3.7 this setting should be there.

Alternatively, we can remove `.vscode/settings.json` from the repo at all. Let me know @tomholub wdyt