### PR TITLE
issue 1599 stack passing fix

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,5 @@
 extension/types
 extension/js/common/core/types
 test/source/core/types
+build/
+extension/lib

--- a/conf/tslint.yaml
+++ b/conf/tslint.yaml
@@ -58,4 +58,5 @@ rules: #
     oneliner-object-literal: true
     no-direct-ajax: true
     no-return-any: true
+    await-returned-promise: true
 ...

--- a/extension/chrome/elements/composer/composer-storage.ts
+++ b/extension/chrome/elements/composer/composer-storage.ts
@@ -186,10 +186,10 @@ export class ComposerStorage extends ComposerComponent {
     }
   }
 
-  whenMasterPassphraseEntered = (secondsTimeout?: number): Promise<string | undefined> => {
-    return new Promise(resolve => {
-      clearInterval(this.passphraseInterval);
-      const timeoutAt = secondsTimeout ? Date.now() + secondsTimeout * 1000 : undefined;
+  whenMasterPassphraseEntered = async (secondsTimeout?: number): Promise<string | undefined> => {
+    clearInterval(this.passphraseInterval);
+    const timeoutAt = secondsTimeout ? Date.now() + secondsTimeout * 1000 : undefined;
+    return await new Promise(resolve => {
       this.passphraseInterval = Catch.setHandledInterval(async () => {
         const passphrase = await this.passphraseGet();
         if (typeof passphrase !== 'undefined') {

--- a/extension/chrome/elements/composer/formatters/encrypted-mail-msg-formatter.ts
+++ b/extension/chrome/elements/composer/formatters/encrypted-mail-msg-formatter.ts
@@ -42,7 +42,7 @@ export class EncryptedMsgMailFormatter extends BaseMailFormatter implements Mail
       await this.addReplyTokenToMsgBodyIfNeeded(authInfo, newMsg, subscription);
       let atts = await this.composer.atts.attach.collectEncryptAtts(this.armoredPubkeys.map(p => p.pubkey), newMsg.pwd);
       if (newMsg.pwd && atts.length) { // these will be password encrypted attachments
-        this.composer.sendBtn.btnUpdateTimeout = Catch.setHandledTimeout(() => this.composer.S.now('send_btn_text').text(SendBtnTexts.BTN_SENDING), 500);
+        this.composer.sendBtn.btnUpdateTimeout = Catch.setHandledTimeout(() => { this.composer.S.now('send_btn_text').text(SendBtnTexts.BTN_SENDING); }, 500);
         await this.uploadAttsToFc(authInfo, atts); // must strictly be preceeding the next function, because it's setting att.url
         newMsg.plaintext = this.addUploadedFileLinksToMsgBody(newMsg.plaintext, atts);
       }

--- a/extension/chrome/elements/pgp_block_modules/pgp_block_render_module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp_block_render_module.ts
@@ -80,7 +80,7 @@ export class PgpBlockViewRenderModule {
       }));
     }
     this.resizePgpBlockFrame(); // resize window now
-    Catch.setHandledTimeout(() => $(window).resize(this.view.setHandlerPrevent('spree', () => this.resizePgpBlockFrame())), 1000); // start auto-resizing the window after 1s
+    Catch.setHandledTimeout(() => { $(window).resize(this.view.setHandlerPrevent('spree', () => this.resizePgpBlockFrame())); }, 1000); // start auto-resizing the window after 1s
   }
 
   public setFrameColor = (color: 'red' | 'green' | 'gray') => {

--- a/extension/chrome/settings/inbox/inbox.ts
+++ b/extension/chrome/settings/inbox/inbox.ts
@@ -88,10 +88,10 @@ Catch.try(async () => {
     await webmailCommon.addOrRemoveEndSessionBtnIfNeeded();
   };
 
-  Catch.setHandledTimeout(() => $('#banner a').css('color', 'red'), 500);
-  Catch.setHandledTimeout(() => $('#banner a').css('color', ''), 1000);
-  Catch.setHandledTimeout(() => $('#banner a').css('color', 'red'), 1500);
-  Catch.setHandledTimeout(() => $('#banner a').css('color', ''), 2000);
+  Catch.setHandledTimeout(() => { $('#banner a').css('color', 'red'); }, 500);
+  Catch.setHandledTimeout(() => { $('#banner a').css('color', ''); }, 1000);
+  Catch.setHandledTimeout(() => { $('#banner a').css('color', 'red'); }, 1500);
+  Catch.setHandledTimeout(() => { $('#banner a').css('color', ''); }, 2000);
   BrowserMsg.addListener('notification_show', notificationShowHandler);
   BrowserMsg.addListener('close_new_message', async () => {
     $('div.new_message').remove();

--- a/extension/js/background_page/bgutils.ts
+++ b/extension/js/background_page/bgutils.ts
@@ -30,8 +30,8 @@ export class BgUtils {
     }
   }
 
-  public static getFcSettingsTabIdIfOpen = (): Promise<number | undefined> => {
-    return new Promise(resolve => {
+  public static getFcSettingsTabIdIfOpen = async (): Promise<number | undefined> => {
+    return await new Promise(resolve => {
       chrome.tabs.query({ currentWindow: true }, tabs => {
         const extensionUrl = chrome.runtime.getURL('/');
         for (const tab of tabs) {

--- a/extension/js/common/api/api.ts
+++ b/extension/js/common/api/api.ts
@@ -35,13 +35,13 @@ export type ProgressCbs = { upload?: ProgressCb | null, download?: ProgressCb | 
 export class Api {
 
   public static download = async (url: string, progress?: ProgressCb): Promise<Buf> => {
-    const request = new XMLHttpRequest();
-    request.open('GET', url, true);
-    request.responseType = 'arraybuffer';
-    if (typeof progress === 'function') {
-      request.onprogress = (evt) => progress(evt.lengthComputable ? Math.floor((evt.loaded / evt.total) * 100) : undefined, evt.loaded, evt.total);
-    }
     return await new Promise((resolve, reject) => {
+      const request = new XMLHttpRequest();
+      request.open('GET', url, true);
+      request.responseType = 'arraybuffer';
+      if (typeof progress === 'function') {
+        request.onprogress = (evt) => progress(evt.lengthComputable ? Math.floor((evt.loaded / evt.total) * 100) : undefined, evt.loaded, evt.total);
+      }
       request.onerror = progressEvent => {
         if (!progressEvent.target) {
           reject(new Error(`Api.download(${url}) failed with a null progressEvent.target`));

--- a/extension/js/common/api/attester.ts
+++ b/extension/js/common/api/attester.ts
@@ -9,12 +9,12 @@ import { ApiErr } from './error/api-error.js';
 
 export class Attester extends Api {
 
-  private static jsonCall = (path: string, values?: Dict<any>, method: ReqMethod = 'POST'): Promise<any> => {
-    return Api.apiCall('https://flowcrypt.com/attester/', path, values, 'JSON', undefined, { 'api-version': '3' }, 'json', method);
+  private static jsonCall = async <RT>(path: string, values?: Dict<any>, method: ReqMethod = 'POST'): Promise<RT> => {
+    return await Api.apiCall('https://flowcrypt.com/attester/', path, values, 'JSON', undefined, { 'api-version': '3' }, 'json', method) as RT;
   }
 
-  private static pubCall = (resource: string, method: ReqMethod = 'GET', data?: string | undefined): Promise<{ responseText: string, getResponseHeader: (n: string) => string | null }> => {
-    return Api.apiCall('https://flowcrypt.com/attester/', resource, data, typeof data === 'string' ? 'TEXT' : undefined, undefined, undefined, 'xhr', method);
+  private static pubCall = async (resource: string, method: ReqMethod = 'GET', data?: string | undefined): Promise<{ responseText: string, getResponseHeader: (n: string) => string | null }> => {
+    return await Api.apiCall('https://flowcrypt.com/attester/', resource, data, typeof data === 'string' ? 'TEXT' : undefined, undefined, undefined, 'xhr', method);
   }
 
   public static lookupEmail = async (email: string): Promise<PubkeySearchResult> => {
@@ -43,8 +43,8 @@ export class Attester extends Api {
     return results;
   }
 
-  public static lookupLongid = (longid: string) => {
-    return Attester.lookupEmail(longid); // the api accepts either email or longid
+  public static lookupLongid = async (longid: string) => {
+    return await Attester.lookupEmail(longid); // the api accepts either email or longid
   }
 
   public static replacePubkey = async (email: string, pubkey: string): Promise<string> => { // replace key assigned to a certain email with a different one
@@ -57,12 +57,12 @@ export class Attester extends Api {
     return r.responseText;
   }
 
-  public static initialLegacySubmit = (email: string, pubkey: string): Promise<{ saved: boolean }> => {
-    return Attester.jsonCall('initial/legacy_submit', { email: Str.parseEmail(email).email, pubkey: pubkey.trim() });
+  public static initialLegacySubmit = async (email: string, pubkey: string): Promise<{ saved: boolean }> => {
+    return await Attester.jsonCall<{ saved: boolean }>('initial/legacy_submit', { email: Str.parseEmail(email).email, pubkey: pubkey.trim() });
   }
 
-  public static testWelcome = (email: string, pubkey: string): Promise<{ sent: boolean }> => {
-    return Attester.jsonCall('test/welcome', { email, pubkey });
+  public static testWelcome = async (email: string, pubkey: string): Promise<{ sent: boolean }> => {
+    return await Attester.jsonCall<{ sent: boolean }>('test/welcome', { email, pubkey });
   }
 
 }

--- a/extension/js/common/api/attester.ts
+++ b/extension/js/common/api/attester.ts
@@ -7,13 +7,15 @@ import { Dict, Str } from '../core/common.js';
 import { PubkeySearchResult, PgpClient } from './keyserver.js';
 import { ApiErr } from './error/api-error.js';
 
+type PubCallRes = { responseText: string, getResponseHeader: (n: string) => string | null };
+
 export class Attester extends Api {
 
   private static jsonCall = async <RT>(path: string, values?: Dict<any>, method: ReqMethod = 'POST'): Promise<RT> => {
     return await Api.apiCall('https://flowcrypt.com/attester/', path, values, 'JSON', undefined, { 'api-version': '3' }, 'json', method) as RT;
   }
 
-  private static pubCall = async (resource: string, method: ReqMethod = 'GET', data?: string | undefined): Promise<{ responseText: string, getResponseHeader: (n: string) => string | null }> => {
+  private static pubCall = async (resource: string, method: ReqMethod = 'GET', data?: string | undefined): Promise<PubCallRes> => {
     return await Api.apiCall('https://flowcrypt.com/attester/', resource, data, typeof data === 'string' ? 'TEXT' : undefined, undefined, undefined, 'xhr', method);
   }
 

--- a/extension/js/common/api/backend.ts
+++ b/extension/js/common/api/backend.ts
@@ -223,10 +223,10 @@ export class Backend extends Api {
 
   public static s3Upload = async (items: AwsS3UploadItem[], progressCb: ProgressCb) => {
     const progress = Value.arr.zeroes(items.length);
-    const promises: Promise<void>[] = [];
     if (!items.length) {
-      return await Promise.resolve([]);
+      return [];
     }
+    const promises: Promise<void>[] = [];
     for (const i of items.keys()) {
       const fields = items[i].fields;
       fields.file = new Att({ name: 'encrypted_attachment', type: 'application/octet-stream', data: items[i].att.getData() });

--- a/extension/js/common/api/email_provider/gmail/gmail.ts
+++ b/extension/js/common/api/email_provider/gmail/gmail.ts
@@ -37,48 +37,48 @@ export class Gmail extends EmailProviderApi implements EmailProviderInterface {
   }
 
   threadGet = async (threadId: string, format?: GmailResponseFormat, progressCb?: ProgressCb): Promise<GmailRes.GmailThread> => {
-    return await Google.gmailCall(this.acctEmail, 'GET', `threads/${threadId}`, { format }, { download: progressCb }) as GmailRes.GmailThread;
+    return await Google.gmailCall<GmailRes.GmailThread>(this.acctEmail, 'GET', `threads/${threadId}`, { format }, { download: progressCb });
   }
 
   threadList = async (labelId: string): Promise<GmailRes.GmailThreadList> => {
-    return await Google.gmailCall(this.acctEmail, 'GET', `threads`, {
+    return await Google.gmailCall<GmailRes.GmailThreadList>(this.acctEmail, 'GET', `threads`, {
       labelIds: labelId !== 'ALL' ? labelId : undefined,
       includeSpamTrash: Boolean(labelId === 'SPAM' || labelId === 'TRASH'),
       // pageToken: page_token,
       // q,
       // maxResults
-    }) as GmailRes.GmailThreadList;
+    });
   }
 
   threadModify = async (id: string, rmLabels: string[], addLabels: string[]): Promise<GmailRes.GmailThread> => {
-    return await Google.gmailCall(this.acctEmail, 'POST', `threads/${id}/modify`, {
+    return await Google.gmailCall<GmailRes.GmailThread>(this.acctEmail, 'POST', `threads/${id}/modify`, {
       removeLabelIds: rmLabels || [], // todo - insufficient permission - need https://github.com/FlowCrypt/flowcrypt-browser/issues/1304
       addLabelIds: addLabels || [],
-    }) as GmailRes.GmailThread;
+    });
   }
 
   draftCreate = async (mimeMsg: string, threadId: string): Promise<GmailRes.GmailDraftCreate> => {
-    return await Google.gmailCall(this.acctEmail, 'POST', 'drafts', { message: { raw: Buf.fromUtfStr(mimeMsg).toBase64UrlStr(), threadId } }) as GmailRes.GmailDraftCreate;
+    return await Google.gmailCall<GmailRes.GmailDraftCreate>(this.acctEmail, 'POST', 'drafts', { message: { raw: Buf.fromUtfStr(mimeMsg).toBase64UrlStr(), threadId } });
   }
 
   draftDelete = async (id: string): Promise<GmailRes.GmailDraftDelete> => {
-    return await Google.gmailCall(this.acctEmail, 'DELETE', 'drafts/' + id, undefined) as GmailRes.GmailDraftDelete;
+    return await Google.gmailCall<GmailRes.GmailDraftDelete>(this.acctEmail, 'DELETE', 'drafts/' + id, undefined);
   }
 
   draftUpdate = async (id: string, mimeMsg: string): Promise<GmailRes.GmailDraftUpdate> => {
-    return await Google.gmailCall(this.acctEmail, 'PUT', `drafts/${id}`, { message: { raw: Buf.fromUtfStr(mimeMsg).toBase64UrlStr() } }) as GmailRes.GmailDraftUpdate;
+    return await Google.gmailCall<GmailRes.GmailDraftUpdate>(this.acctEmail, 'PUT', `drafts/${id}`, { message: { raw: Buf.fromUtfStr(mimeMsg).toBase64UrlStr() } });
   }
 
   draftGet = async (id: string, format: GmailResponseFormat = 'full'): Promise<GmailRes.GmailDraftGet> => {
-    return await Google.gmailCall(this.acctEmail, 'GET', `drafts/${id}`, { format }) as GmailRes.GmailDraftGet;
+    return await Google.gmailCall<GmailRes.GmailDraftGet>(this.acctEmail, 'GET', `drafts/${id}`, { format });
   }
 
   draftList = async (): Promise<GmailRes.GmailDraftList> => {
-    return await Google.gmailCall(this.acctEmail, 'GET', 'drafts', undefined) as GmailRes.GmailDraftList;
+    return await Google.gmailCall<GmailRes.GmailDraftList>(this.acctEmail, 'GET', 'drafts', undefined);
   }
 
   draftSend = async (id: string): Promise<GmailRes.GmailDraftSend> => {
-    return await Google.gmailCall(this.acctEmail, 'POST', 'drafts/send', { id }) as GmailRes.GmailDraftSend;
+    return await Google.gmailCall<GmailRes.GmailDraftSend>(this.acctEmail, 'POST', 'drafts/send', { id });
   }
 
   msgSend = async (message: SendableMsg, progressCb?: ProgressCb): Promise<GmailRes.GmailMsgSend> => {
@@ -93,11 +93,11 @@ export class Gmail extends EmailProviderApi implements EmailProviderInterface {
     message.headers.Subject = message.subject;
     const mimeMsg = await Mime.encode(message.body, message.headers, message.atts, message.mimeRootType, message.sign);
     const request = Google.encodeAsMultipartRelated({ 'application/json; charset=UTF-8': JSON.stringify({ threadId: message.thread }), 'message/rfc822': mimeMsg });
-    return await Google.gmailCall(this.acctEmail, 'POST', 'messages/send', request.body, { upload: progressCb || Value.noop }, request.contentType) as GmailRes.GmailMsgSend;
+    return await Google.gmailCall<GmailRes.GmailMsgSend>(this.acctEmail, 'POST', 'messages/send', request.body, { upload: progressCb || Value.noop }, request.contentType);
   }
 
   msgList = async (q: string, includeDeleted: boolean = false, pageToken?: string): Promise<GmailRes.GmailMsgList> => {
-    return await Google.gmailCall(this.acctEmail, 'GET', 'messages', { q, includeSpamTrash: includeDeleted, pageToken }) as GmailRes.GmailMsgList;
+    return await Google.gmailCall<GmailRes.GmailMsgList>(this.acctEmail, 'GET', 'messages', { q, includeSpamTrash: includeDeleted, pageToken });
   }
 
   /**
@@ -106,20 +106,20 @@ export class Gmail extends EmailProviderApi implements EmailProviderInterface {
    * as a Buf instead of a string.
    */
   msgGet = async (msgId: string, format: GmailResponseFormat, progressCb?: ProgressCb): Promise<GmailRes.GmailMsg> => {
-    return await Google.gmailCall(this.acctEmail, 'GET', `messages/${msgId}`, { format: format || 'full' }, { download: progressCb }) as GmailRes.GmailMsg;
+    return await Google.gmailCall<GmailRes.GmailMsg>(this.acctEmail, 'GET', `messages/${msgId}`, { format: format || 'full' }, { download: progressCb });
   }
 
   msgsGet = async (msgIds: string[], format: GmailResponseFormat): Promise<GmailRes.GmailMsg[]> => {
-    return Promise.all(msgIds.map(id => this.msgGet(id, format)));
+    return await Promise.all(msgIds.map(id => this.msgGet(id, format)));
   }
 
   labelsGet = async (): Promise<GmailRes.GmailLabels> => {
-    return await Google.gmailCall(this.acctEmail, 'GET', `labels`, {}) as GmailRes.GmailLabels;
+    return await Google.gmailCall<GmailRes.GmailLabels>(this.acctEmail, 'GET', `labels`, {});
   }
 
   attGet = async (msgId: string, attId: string, progressCb?: ProgressCb): Promise<GmailRes.GmailAtt> => {
     type RawGmailAttRes = { attachmentId: string, size: number, data: string };
-    const { attachmentId, size, data } = await Google.gmailCall(this.acctEmail, 'GET', `messages/${msgId}/attachments/${attId}`, {}, { download: progressCb }) as RawGmailAttRes;
+    const { attachmentId, size, data } = await Google.gmailCall<RawGmailAttRes>(this.acctEmail, 'GET', `messages/${msgId}/attachments/${attId}`, {}, { download: progressCb });
     return { attachmentId, size, data: Buf.fromBase64UrlStr(data) }; // data should be a Buf for ease of passing to/from bg page
   }
 
@@ -218,27 +218,25 @@ export class Gmail extends EmailProviderApi implements EmailProviderInterface {
     const loadedAr: Array<number> = [];
     // 1.33 is a coefficient we need to multiply because total size we need to download is larger than all files together
     const total = atts.map(x => x.length).reduce((a, b) => a + b) * 1.33;
-    const responses = await Promise.all(atts.map((a, index) => {
-      return this.attGet(a.msgId!, a.id!, (_, loaded, s) => {
-        if (progressCb) {
-          loadedAr[index] = loaded || 0;
-          const totalLoaded = loadedAr.reduce((a, b) => a + b);
-          const progressPercent = Math.round((totalLoaded * 100) / total);
-          if (progressPercent !== lastProgressPercent) {
-            lastProgressPercent = progressPercent;
-            progressCb(progressPercent, totalLoaded, total);
-          }
+    const responses = await Promise.all(atts.map((a, index) => this.attGet(a.msgId!, a.id!, (_, loaded, s) => {
+      if (progressCb) {
+        loadedAr[index] = loaded || 0;
+        const totalLoaded = loadedAr.reduce((a, b) => a + b);
+        const progressPercent = Math.round((totalLoaded * 100) / total);
+        if (progressPercent !== lastProgressPercent) {
+          lastProgressPercent = progressPercent;
+          progressCb(progressPercent, totalLoaded, total);
         }
-      });
-    }));
+      }
+    })));
     for (const i of responses.keys()) {
       atts[i].setData(responses[i].data);
     }
   }
 
   /**
-  * This will keep triggering callback with new emails as they are being discovered
-  */
+   * This will keep triggering callback with new emails as they are being discovered
+   */
   guessContactsFromSentEmails = async (userQuery: string, knownContacts: Contact[], chunkedCb: ChunkedCb): Promise<void> => {
     let gmailQuery = `is:sent ${this.GMAIL_USELESS_CONTACTS_FILTER} `;
     if (userQuery) {

--- a/extension/js/common/api/email_provider/gmail/gmail.ts
+++ b/extension/js/common/api/email_provider/gmail/gmail.ts
@@ -36,49 +36,49 @@ export class Gmail extends EmailProviderApi implements EmailProviderInterface {
     }
   }
 
-  threadGet = (threadId: string, format?: GmailResponseFormat, progressCb?: ProgressCb): Promise<GmailRes.GmailThread> => {
-    return Google.gmailCall(this.acctEmail, 'GET', `threads/${threadId}`, { format }, { download: progressCb });
+  threadGet = async (threadId: string, format?: GmailResponseFormat, progressCb?: ProgressCb): Promise<GmailRes.GmailThread> => {
+    return await Google.gmailCall(this.acctEmail, 'GET', `threads/${threadId}`, { format }, { download: progressCb }) as GmailRes.GmailThread;
   }
 
-  threadList = (labelId: string): Promise<GmailRes.GmailThreadList> => {
-    return Google.gmailCall(this.acctEmail, 'GET', `threads`, {
+  threadList = async (labelId: string): Promise<GmailRes.GmailThreadList> => {
+    return await Google.gmailCall(this.acctEmail, 'GET', `threads`, {
       labelIds: labelId !== 'ALL' ? labelId : undefined,
       includeSpamTrash: Boolean(labelId === 'SPAM' || labelId === 'TRASH'),
       // pageToken: page_token,
       // q,
       // maxResults
-    });
+    }) as GmailRes.GmailThreadList;
   }
 
-  threadModify = (id: string, rmLabels: string[], addLabels: string[]): Promise<GmailRes.GmailThread> => {
-    return Google.gmailCall(this.acctEmail, 'POST', `threads/${id}/modify`, {
+  threadModify = async (id: string, rmLabels: string[], addLabels: string[]): Promise<GmailRes.GmailThread> => {
+    return await Google.gmailCall(this.acctEmail, 'POST', `threads/${id}/modify`, {
       removeLabelIds: rmLabels || [], // todo - insufficient permission - need https://github.com/FlowCrypt/flowcrypt-browser/issues/1304
       addLabelIds: addLabels || [],
-    });
+    }) as GmailRes.GmailThread;
   }
 
-  draftCreate = (mimeMsg: string, threadId: string): Promise<GmailRes.GmailDraftCreate> => {
-    return Google.gmailCall(this.acctEmail, 'POST', 'drafts', { message: { raw: Buf.fromUtfStr(mimeMsg).toBase64UrlStr(), threadId } });
+  draftCreate = async (mimeMsg: string, threadId: string): Promise<GmailRes.GmailDraftCreate> => {
+    return await Google.gmailCall(this.acctEmail, 'POST', 'drafts', { message: { raw: Buf.fromUtfStr(mimeMsg).toBase64UrlStr(), threadId } }) as GmailRes.GmailDraftCreate;
   }
 
-  draftDelete = (id: string): Promise<GmailRes.GmailDraftDelete> => {
-    return Google.gmailCall(this.acctEmail, 'DELETE', 'drafts/' + id, undefined);
+  draftDelete = async (id: string): Promise<GmailRes.GmailDraftDelete> => {
+    return await Google.gmailCall(this.acctEmail, 'DELETE', 'drafts/' + id, undefined) as GmailRes.GmailDraftDelete;
   }
 
-  draftUpdate = (id: string, mimeMsg: string): Promise<GmailRes.GmailDraftUpdate> => {
-    return Google.gmailCall(this.acctEmail, 'PUT', `drafts/${id}`, { message: { raw: Buf.fromUtfStr(mimeMsg).toBase64UrlStr() } });
+  draftUpdate = async (id: string, mimeMsg: string): Promise<GmailRes.GmailDraftUpdate> => {
+    return await Google.gmailCall(this.acctEmail, 'PUT', `drafts/${id}`, { message: { raw: Buf.fromUtfStr(mimeMsg).toBase64UrlStr() } }) as GmailRes.GmailDraftUpdate;
   }
 
-  draftGet = (id: string, format: GmailResponseFormat = 'full'): Promise<GmailRes.GmailDraftGet> => {
-    return Google.gmailCall(this.acctEmail, 'GET', `drafts/${id}`, { format });
+  draftGet = async (id: string, format: GmailResponseFormat = 'full'): Promise<GmailRes.GmailDraftGet> => {
+    return await Google.gmailCall(this.acctEmail, 'GET', `drafts/${id}`, { format }) as GmailRes.GmailDraftGet;
   }
 
-  draftList = (): Promise<GmailRes.GmailDraftList> => {
-    return Google.gmailCall(this.acctEmail, 'GET', 'drafts', undefined);
+  draftList = async (): Promise<GmailRes.GmailDraftList> => {
+    return await Google.gmailCall(this.acctEmail, 'GET', 'drafts', undefined) as GmailRes.GmailDraftList;
   }
 
-  draftSend = (id: string): Promise<GmailRes.GmailDraftSend> => {
-    return Google.gmailCall(this.acctEmail, 'POST', 'drafts/send', { id });
+  draftSend = async (id: string): Promise<GmailRes.GmailDraftSend> => {
+    return await Google.gmailCall(this.acctEmail, 'POST', 'drafts/send', { id }) as GmailRes.GmailDraftSend;
   }
 
   msgSend = async (message: SendableMsg, progressCb?: ProgressCb): Promise<GmailRes.GmailMsgSend> => {
@@ -93,11 +93,11 @@ export class Gmail extends EmailProviderApi implements EmailProviderInterface {
     message.headers.Subject = message.subject;
     const mimeMsg = await Mime.encode(message.body, message.headers, message.atts, message.mimeRootType, message.sign);
     const request = Google.encodeAsMultipartRelated({ 'application/json; charset=UTF-8': JSON.stringify({ threadId: message.thread }), 'message/rfc822': mimeMsg });
-    return Google.gmailCall(this.acctEmail, 'POST', 'messages/send', request.body, { upload: progressCb || Value.noop }, request.contentType);
+    return await Google.gmailCall(this.acctEmail, 'POST', 'messages/send', request.body, { upload: progressCb || Value.noop }, request.contentType) as GmailRes.GmailMsgSend;
   }
 
-  msgList = (q: string, includeDeleted: boolean = false, pageToken?: string): Promise<GmailRes.GmailMsgList> => {
-    return Google.gmailCall(this.acctEmail, 'GET', 'messages', { q, includeSpamTrash: includeDeleted, pageToken });
+  msgList = async (q: string, includeDeleted: boolean = false, pageToken?: string): Promise<GmailRes.GmailMsgList> => {
+    return await Google.gmailCall(this.acctEmail, 'GET', 'messages', { q, includeSpamTrash: includeDeleted, pageToken }) as GmailRes.GmailMsgList;
   }
 
   /**
@@ -106,15 +106,15 @@ export class Gmail extends EmailProviderApi implements EmailProviderInterface {
    * as a Buf instead of a string.
    */
   msgGet = async (msgId: string, format: GmailResponseFormat, progressCb?: ProgressCb): Promise<GmailRes.GmailMsg> => {
-    return Google.gmailCall(this.acctEmail, 'GET', `messages/${msgId}`, { format: format || 'full' }, { download: progressCb });
+    return await Google.gmailCall(this.acctEmail, 'GET', `messages/${msgId}`, { format: format || 'full' }, { download: progressCb }) as GmailRes.GmailMsg;
   }
 
-  msgsGet = (msgIds: string[], format: GmailResponseFormat): Promise<GmailRes.GmailMsg[]> => {
+  msgsGet = async (msgIds: string[], format: GmailResponseFormat): Promise<GmailRes.GmailMsg[]> => {
     return Promise.all(msgIds.map(id => this.msgGet(id, format)));
   }
 
-  labelsGet = (): Promise<GmailRes.GmailLabels> => {
-    return Google.gmailCall(this.acctEmail, 'GET', `labels`, {});
+  labelsGet = async (): Promise<GmailRes.GmailLabels> => {
+    return await Google.gmailCall(this.acctEmail, 'GET', `labels`, {}) as GmailRes.GmailLabels;
   }
 
   attGet = async (msgId: string, attId: string, progressCb?: ProgressCb): Promise<GmailRes.GmailAtt> => {
@@ -123,17 +123,17 @@ export class Gmail extends EmailProviderApi implements EmailProviderInterface {
     return { attachmentId, size, data: Buf.fromBase64UrlStr(data) }; // data should be a Buf for ease of passing to/from bg page
   }
 
-  attGetChunk = (msgId: string, attId: string): Promise<Buf> => {
-    return new Promise((resolve, reject) => {
-      if (Env.isContentScript()) {
-        // content script CORS not allowed anymore, have to drag it through background page
-        // https://www.chromestatus.com/feature/5629709824032768
-        BrowserMsg.send.bg.await.ajaxGmailAttGetChunk({ acctEmail: this.acctEmail, msgId, attId }).then(({ chunk }) => resolve(chunk)).catch(reject);
-        return;
-      }
-      const stack = Catch.stackTrace();
-      const minBytes = 1000;
-      let processed = 0;
+  attGetChunk = async (msgId: string, attId: string): Promise<Buf> => {
+    if (Env.isContentScript()) {
+      // content script CORS not allowed anymore, have to drag it through background page
+      // https://www.chromestatus.com/feature/5629709824032768
+      const { chunk } = await BrowserMsg.send.bg.await.ajaxGmailAttGetChunk({ acctEmail: this.acctEmail, msgId, attId });
+      return chunk;
+    }
+    const stack = Catch.stackTrace();
+    const minBytes = 1000;
+    let processed = 0;
+    return await new Promise((resolve, reject) => {
       const processChunkAndResolve = (chunk: string) => {
         if (!processed++) {
           // make json end guessing easier
@@ -316,7 +316,7 @@ export class Gmail extends EmailProviderApi implements EmailProviderInterface {
   }
 
   fetchAcctAliases = async (): Promise<GmailRes.GmailAliases> => {
-    return Google.gmailCall(this.acctEmail, 'GET', 'settings/sendAs', {});
+    return await Google.gmailCall(this.acctEmail, 'GET', 'settings/sendAs', {}) as GmailRes.GmailAliases;
   }
 
   fetchMsgsHeadersBasedOnQuery = async (q: string, headerNames: string[], msgLimit: number) => {

--- a/extension/js/common/api/email_provider/gmail/gmail.ts
+++ b/extension/js/common/api/email_provider/gmail/gmail.ts
@@ -314,7 +314,7 @@ export class Gmail extends EmailProviderApi implements EmailProviderInterface {
   }
 
   fetchAcctAliases = async (): Promise<GmailRes.GmailAliases> => {
-    return await Google.gmailCall(this.acctEmail, 'GET', 'settings/sendAs', {}) as GmailRes.GmailAliases;
+    return await Google.gmailCall<GmailRes.GmailAliases>(this.acctEmail, 'GET', 'settings/sendAs', {});
   }
 
   fetchMsgsHeadersBasedOnQuery = async (q: string, headerNames: string[], msgLimit: number) => {

--- a/extension/js/common/api/google-auth.ts
+++ b/extension/js/common/api/google-auth.ts
@@ -163,8 +163,8 @@ export class GoogleAuth {
     return await GoogleAuth.newAuthPopup({ acctEmail, scopes: GoogleAuth.defaultScopes('openid'), save: false });
   }
 
-  private static waitForOauthWindowClosed = (oauthWinId: number, acctEmail: string | undefined): Promise<AuthRes> => {
-    return new Promise(resolve => {
+  private static waitForOauthWindowClosed = async (oauthWinId: number, acctEmail: string | undefined): Promise<AuthRes> => {
+    return await new Promise(resolve => {
       const onOauthWinClosed = (closedWinId: number) => {
         if (closedWinId === oauthWinId) {
           chrome.windows.onRemoved.removeListener(onOauthWinClosed);
@@ -270,30 +270,30 @@ export class GoogleAuth {
     await Store.setAcct(acctEmail, toSave);
   }
 
-  private static googleAuthGetTokens = (code: string) => {
-    return Api.ajax({
+  private static googleAuthGetTokens = async (code: string) => {
+    return await Api.ajax({
       url: Url.create(GoogleAuth.OAUTH.url_tokens, { grant_type: 'authorization_code', code, client_id: GoogleAuth.OAUTH.client_id, redirect_uri: GoogleAuth.OAUTH.url_redirect }),
       method: 'POST',
       crossDomain: true,
       async: true,
-    }, Catch.stackTrace()) as any as Promise<GoogleAuthTokensResponse>;
+    }, Catch.stackTrace()) as any as GoogleAuthTokensResponse;
   }
 
-  private static googleAuthRefreshToken = (refreshToken: string) => {
-    return Api.ajax({
+  private static googleAuthRefreshToken = async (refreshToken: string) => {
+    return await Api.ajax({
       url: Url.create(GoogleAuth.OAUTH.url_tokens, { grant_type: 'refresh_token', refreshToken, client_id: GoogleAuth.OAUTH.client_id }),
       method: 'POST',
       crossDomain: true,
       async: true,
-    }, Catch.stackTrace()) as any as Promise<GoogleAuthTokensResponse>;
+    }, Catch.stackTrace()) as any as GoogleAuthTokensResponse;
   }
 
-  private static googleAuthCheckAccessToken = (accessToken: string) => {
-    return Api.ajax({
+  private static googleAuthCheckAccessToken = async (accessToken: string) => {
+    return await Api.ajax({
       url: Url.create(`${GOOGLE_API_HOST}/oauth2/v1/tokeninfo`, { access_token: accessToken }),
       crossDomain: true,
       async: true,
-    }, Catch.stackTrace()) as any as Promise<GoogleAuthTokenInfo>;
+    }, Catch.stackTrace()) as any as GoogleAuthTokenInfo;
   }
 
   /**

--- a/extension/js/common/api/google.ts
+++ b/extension/js/common/api/google.ts
@@ -17,7 +17,9 @@ export class Google {
     return `https://mail.google.com/mail/u/${acctEmail}`;
   }
 
-  public static gmailCall = async <RT>(acctEmail: string, method: ReqMethod, path: string, params: Dict<Serializable> | string | undefined, progress?: ProgressCbs, contentType?: string): Promise<RT> => {
+  public static gmailCall = async <RT>(
+    acctEmail: string, method: ReqMethod, path: string, params: Dict<Serializable> | string | undefined, progress?: ProgressCbs, contentType?: string
+  ): Promise<RT> => {
     progress = progress || {};
     let data, url;
     if (typeof progress.upload === 'function') {

--- a/extension/js/common/api/google.ts
+++ b/extension/js/common/api/google.ts
@@ -17,7 +17,7 @@ export class Google {
     return `https://mail.google.com/mail/u/${acctEmail}`;
   }
 
-  public static gmailCall = async (acctEmail: string, method: ReqMethod, path: string, params: Dict<Serializable> | string | undefined, progress?: ProgressCbs, contentType?: string) => {
+  public static gmailCall = async <RT>(acctEmail: string, method: ReqMethod, path: string, params: Dict<Serializable> | string | undefined, progress?: ProgressCbs, contentType?: string): Promise<RT> => {
     progress = progress || {};
     let data, url;
     if (typeof progress.upload === 'function') {
@@ -35,7 +35,7 @@ export class Google {
     const headers = { 'Authorization': await GoogleAuth.googleApiAuthHeader(acctEmail) };
     const xhr = Api.getAjaxProgressXhrFactory(progress);
     const request = { xhr, url, method, data, headers, crossDomain: true, contentType, async: true };
-    return await GoogleAuth.apiGoogleCallRetryAuthErrorOneTime(acctEmail, request);
+    return await GoogleAuth.apiGoogleCallRetryAuthErrorOneTime(acctEmail, request) as RT;
   }
 
   public static contactsGet = async (acctEmail: string, query?: string, progress?: ProgressCbs, max: number = 10, start: number = 0) => {

--- a/extension/js/common/api/keyserver.ts
+++ b/extension/js/common/api/keyserver.ts
@@ -29,7 +29,7 @@ export class Keyserver {
         return res;
       }
     }
-    return Attester.lookupEmail(email);
+    return await Attester.lookupEmail(email);
   }
 
   public static lookupLongid = async (acctEmail: string, longid: string): Promise<PubkeySearchResult> => {
@@ -40,7 +40,7 @@ export class Keyserver {
         return res;
       }
     }
-    return Attester.lookupLongid(longid);
+    return await Attester.lookupLongid(longid);
   }
 
 }

--- a/extension/js/common/browser/browser-msg.ts
+++ b/extension/js/common/browser/browser-msg.ts
@@ -178,57 +178,56 @@ export class BrowserMsg {
     BrowserMsg.sendAwait(dest, name, bm).catch(Catch.reportErr);
   }
 
-  private static sendAwait = (destString: string | undefined, name: string, bm?: Dict<unknown>, awaitRes = false): Promise<Bm.Response> => {
-    return new Promise((resolve, reject) => {
-      bm = bm || {};
-      const isBackgroundPage = Env.isBackgroundPage();
-      if (isBackgroundPage && BrowserMsg.HANDLERS_REGISTERED_BACKGROUND && typeof destString === 'undefined') { // calling from bg script to bg script: skip messaging
-        const handler: Bm.AsyncRespondingHandler = BrowserMsg.HANDLERS_REGISTERED_BACKGROUND[name];
-        handler(bm, 'background').then(resolve).catch(reject);
-      } else { // here browser messaging is used - msg has to be serializable - Buf instances need to be converted to object urls, and back upon receipt
-        const objUrls = BrowserMsg.replaceBufWithObjUrlInplace(bm);
-        const msg: Bm.Raw = { name, data: { bm, objUrls }, to: destString || null, uid: Str.sloppyRandom(10), stack: Catch.stackTrace() }; // tslint:disable-line:no-null-keyword
-        const processRawMsgResponse = (r: Bm.RawResponse) => {
-          if (!awaitRes) {
-            resolve();
-          } else if (!r || typeof r !== 'object') { // r can be null if we sent a message to a non-existent window id
-            const lastError = chrome.runtime.lastError ? chrome.runtime.lastError.message || '(empty lastError)' : '(no lastError)';
-            let e: Error;
-            if (typeof destString === 'undefined' && typeof r === 'undefined') {
-              if (lastError === 'The object could not be cloned.') {
-                e = new Error(`BrowserMsg.sendAwait(${name}) failed with lastError: ${lastError}`);
-              } else if (lastError === 'Could not establish connection. Receiving end does not exist.' || lastError === 'The message port closed before a response was received.') {
-                // "The message port closed before a response was received." could also happen for otherwise working extension, if bg script
-                //    did not return `true` (indicating async response). That would be our own coding error in BrowserMsg.
-                e = new BgNotReadyError(`BgNotReadyError: BrowserMsg.sendAwait(${name}) failed with lastError: ${lastError}`);
-              } else {
-                e = new Error(`BrowserMsg.sendAwait(${name}) failed with unknown lastError: ${lastError}`);
-              }
+  private static sendAwait = async (destString: string | undefined, name: string, bm?: Dict<unknown>, awaitRes = false): Promise<Bm.Response> => {
+    bm = bm || {};
+    const isBackgroundPage = Env.isBackgroundPage();
+    if (isBackgroundPage && BrowserMsg.HANDLERS_REGISTERED_BACKGROUND && typeof destString === 'undefined') { // calling from bg script to bg script: skip messaging
+      const handler: Bm.AsyncRespondingHandler = BrowserMsg.HANDLERS_REGISTERED_BACKGROUND[name];
+      return await handler(bm, 'background');
+    }
+    return await new Promise((resolve, reject) => { // here browser messaging is used - msg has to be serializable - Buf instances need to be converted to object urls, and back upon receipt
+      const objUrls = BrowserMsg.replaceBufWithObjUrlInplace(bm);
+      const msg: Bm.Raw = { name, data: { bm: bm!, objUrls }, to: destString || null, uid: Str.sloppyRandom(10), stack: Catch.stackTrace() }; // tslint:disable-line:no-null-keyword
+      const processRawMsgResponse = (r: Bm.RawResponse) => {
+        if (!awaitRes) {
+          resolve();
+        } else if (!r || typeof r !== 'object') { // r can be null if we sent a message to a non-existent window id
+          const lastError = chrome.runtime.lastError ? chrome.runtime.lastError.message || '(empty lastError)' : '(no lastError)';
+          let e: Error;
+          if (typeof destString === 'undefined' && typeof r === 'undefined') {
+            if (lastError === 'The object could not be cloned.') {
+              e = new Error(`BrowserMsg.sendAwait(${name}) failed with lastError: ${lastError}`);
+            } else if (lastError === 'Could not establish connection. Receiving end does not exist.' || lastError === 'The message port closed before a response was received.') {
+              // "The message port closed before a response was received." could also happen for otherwise working extension, if bg script
+              //    did not return `true` (indicating async response). That would be our own coding error in BrowserMsg.
+              e = new BgNotReadyError(`BgNotReadyError: BrowserMsg.sendAwait(${name}) failed with lastError: ${lastError}`);
             } else {
-              e = new Error(`BrowserMsg.sendAwait(${name}) returned(${String(r)}) with lastError: ${lastError}`);
+              e = new Error(`BrowserMsg.sendAwait(${name}) failed with unknown lastError: ${lastError}`);
             }
-            e.stack = `${msg.stack}\n\n${e.stack}`;
-            reject(e);
-          } else if (typeof r === 'object' && r.exception) {
-            reject(BrowserMsg.jsonToErr(r.exception, msg));
-          } else if (!r.result || typeof r.result !== 'object') {
-            resolve(r.result);
           } else {
-            BrowserMsg.replaceObjUrlWithBuf(r.result, r.objUrls).then(resolve).catch(reject);
+            e = new Error(`BrowserMsg.sendAwait(${name}) returned(${String(r)}) with lastError: ${lastError}`);
           }
-        };
-        try {
-          if (isBackgroundPage) {
-            chrome.tabs.sendMessage(BrowserMsg.browserMsgDestParse(msg.to).tab!, msg, {}, processRawMsgResponse);
-          } else {
-            chrome.runtime.sendMessage(msg, processRawMsgResponse);
-          }
-        } catch (e) {
-          if (e instanceof Error && e.message === 'Extension context invalidated.') {
-            BrowserMsg.showFatalUserNotification('Restart browser to re-enable FlowCrypt');
-          } else {
-            throw e;
-          }
+          e.stack = `${msg.stack}\n\n${e.stack}`;
+          reject(e);
+        } else if (typeof r === 'object' && r.exception) {
+          reject(BrowserMsg.jsonToErr(r.exception, msg));
+        } else if (!r.result || typeof r.result !== 'object') {
+          resolve(r.result as Bm.Response);
+        } else {
+          BrowserMsg.replaceObjUrlWithBuf(r.result, r.objUrls).then(resolve).catch(reject);
+        }
+      };
+      try {
+        if (isBackgroundPage) {
+          chrome.tabs.sendMessage(BrowserMsg.browserMsgDestParse(msg.to).tab!, msg, {}, processRawMsgResponse);
+        } else {
+          chrome.runtime.sendMessage(msg, processRawMsgResponse);
+        }
+      } catch (e) {
+        if (e instanceof Error && e.message === 'Extension context invalidated.') {
+          BrowserMsg.showFatalUserNotification('Restart browser to re-enable FlowCrypt');
+        } else {
+          throw e;
         }
       }
     });

--- a/extension/js/common/browser/ui.ts
+++ b/extension/js/common/browser/ui.ts
@@ -27,8 +27,8 @@ export class Ui {
     return `<a href="${Xss.escape(window.location.href)}" data-test="action-retry-by-reloading">${Xss.escape(caption)}</a>`;
   }
 
-  public static delay = (ms: number) => {
-    return new Promise(resolve => Catch.setHandledTimeout(resolve, ms));
+  public static delay = async (ms: number) => {
+    return await new Promise(resolve => Catch.setHandledTimeout(resolve, ms));
   }
 
   public static spinner = (color: string, placeholderCls: "small_spinner" | "large_spinner" = 'small_spinner') => {
@@ -37,8 +37,8 @@ export class Ui {
     return `<i class="${placeholderCls}" data-test="spinner"><img src="${url}" /></i>`;
   }
 
-  public static renderOverlayPromptAwaitUserChoice = (btns: Dict<{ title?: string, color?: string }>, prompt: string, details?: string): Promise<string> => {
-    return new Promise(resolve => {
+  public static renderOverlayPromptAwaitUserChoice = async (btns: Dict<{ title?: string, color?: string }>, prompt: string, details?: string): Promise<string> => {
+    return await new Promise(resolve => {
       const getEscapedColor = (id: string) => Xss.escape(btns[id].color || 'green');
       const getEscapedTitle = (id: string) => Xss.escape(btns[id].title || id.replace(/_/g, ' '));
       const formatBtn = (id: string) => {

--- a/extension/js/common/core/mime.ts
+++ b/extension/js/common/core/mime.ts
@@ -176,44 +176,48 @@ export class Mime {
     return undefined;
   }
 
-  public static decode = (mimeMsg: Uint8Array): Promise<MimeContent> => {
-    return new Promise(resolve => {
-      let mimeContent: MimeContent = { atts: [], headers: {}, subject: undefined, text: undefined, html: undefined, signature: undefined, from: undefined, to: [], cc: [], bcc: [] };
+  public static decode = async (mimeMsg: Uint8Array): Promise<MimeContent> => {
+    let mimeContent: MimeContent = { atts: [], headers: {}, subject: undefined, text: undefined, html: undefined, signature: undefined, from: undefined, to: [], cc: [], bcc: [] };
+    const parser = new MimeParser();
+    const leafNodes: { [key: string]: MimeParserNode } = {};
+    parser.onbody = (node: MimeParserNode) => {
+      const path = String(node.path.join('.'));
+      if (typeof leafNodes[path] === 'undefined') {
+        leafNodes[path] = node;
+      }
+    };
+    return await new Promise((resolve, reject) => {
       try {
-        const parser = new MimeParser();
-        const leafNodes: { [key: string]: MimeParserNode } = {};
-        parser.onbody = (node: MimeParserNode) => {
-          const path = String(node.path.join('.'));
-          if (typeof leafNodes[path] === 'undefined') {
-            leafNodes[path] = node;
-          }
-        };
         parser.onend = () => {
-          for (const name of Object.keys(parser.node.headers)) {
-            mimeContent.headers[name] = parser.node.headers[name][0].value;
-          }
-          mimeContent.rawSignedContent = Mime.retrieveRawSignedContent([parser.node]);
-          for (const node of Object.values(leafNodes)) {
-            if (Mime.getNodeType(node) === 'application/pgp-signature') {
-              mimeContent.signature = node.rawContent;
-            } else if (Mime.getNodeType(node) === 'text/html' && !Mime.getNodeFilename(node)) {
-              // html content may be broken up into smaller pieces by attachments in between
-              // AppleMail does this with inline attachments
-              mimeContent.html = (mimeContent.html || '') + Mime.getNodeContentAsUtfStr(node);
-            } else if (Mime.getNodeType(node) === 'text/plain' && !Mime.getNodeFilename(node)) {
-              mimeContent.text = Mime.getNodeContentAsUtfStr(node);
-            } else if (Mime.getNodeType(node) === 'text/rfc822-headers') {
-              if (node._parentNode && node._parentNode.headers.subject) {
-                mimeContent.subject = node._parentNode.headers.subject[0].value;
-              }
-            } else {
-              mimeContent.atts.push(Mime.getNodeAsAtt(node));
+          try {
+            for (const name of Object.keys(parser.node.headers)) {
+              mimeContent.headers[name] = parser.node.headers[name][0].value;
             }
+            mimeContent.rawSignedContent = Mime.retrieveRawSignedContent([parser.node]);
+            for (const node of Object.values(leafNodes)) {
+              if (Mime.getNodeType(node) === 'application/pgp-signature') {
+                mimeContent.signature = node.rawContent;
+              } else if (Mime.getNodeType(node) === 'text/html' && !Mime.getNodeFilename(node)) {
+                // html content may be broken up into smaller pieces by attachments in between
+                // AppleMail does this with inline attachments
+                mimeContent.html = (mimeContent.html || '') + Mime.getNodeContentAsUtfStr(node);
+              } else if (Mime.getNodeType(node) === 'text/plain' && !Mime.getNodeFilename(node)) {
+                mimeContent.text = Mime.getNodeContentAsUtfStr(node);
+              } else if (Mime.getNodeType(node) === 'text/rfc822-headers') {
+                if (node._parentNode && node._parentNode.headers.subject) {
+                  mimeContent.subject = node._parentNode.headers.subject[0].value;
+                }
+              } else {
+                mimeContent.atts.push(Mime.getNodeAsAtt(node));
+              }
+            }
+            const headers = Mime.headerGetAddress(mimeContent, ['from', 'to', 'cc', 'bcc']);
+            mimeContent.subject = String(mimeContent.subject || mimeContent.headers.subject || '(no subject)');
+            mimeContent = Object.assign(mimeContent, headers);
+            resolve(mimeContent);
+          } catch (e) {
+            reject(e);
           }
-          const headers = Mime.headerGetAddress(mimeContent, ['from', 'to', 'cc', 'bcc']);
-          mimeContent.subject = String(mimeContent.subject || mimeContent.headers.subject || '(no subject)');
-          mimeContent = Object.assign(mimeContent, headers);
-          resolve(mimeContent);
         };
         parser.write(mimeMsg);
         parser.end();

--- a/extension/js/common/platform/catch.ts
+++ b/extension/js/common/platform/catch.ts
@@ -181,7 +181,7 @@ export class Catch {
       && typeof (v as Promise<any>).catch === 'function'; // tslint:disable-line:no-unbound-method - only testing if exists
   }
 
-  public static try = (code: Function) => { // tslint:disable-line:ban-types
+  public static try = (code: () => void | Promise<void>) => { // tslint:disable-line:ban-types
     return () => { // returns a function
       try {
         const r = code();
@@ -277,11 +277,11 @@ export class Catch {
     }
   }
 
-  public static setHandledInterval = (cb: () => void, ms: number): number => {
+  public static setHandledInterval = (cb: () => void | Promise<void>, ms: number): number => {
     return window.setInterval(Catch.try(cb), ms); // error-handled: else setInterval will silently swallow errors
   }
 
-  public static setHandledTimeout = (cb: () => void, ms: number): number => {
+  public static setHandledTimeout = (cb: () => void | Promise<void>, ms: number): number => {
     return window.setTimeout(Catch.try(cb), ms); // error-handled: else setTimeout will silently swallow errors
   }
 

--- a/extension/js/common/platform/catch.ts
+++ b/extension/js/common/platform/catch.ts
@@ -147,6 +147,9 @@ export class Catch {
 
   public static reportErr = (e: any) => {
     const { line, col } = Catch.getErrorLineAndCol(e);
+    if (e instanceof Error) { // reporting stack may differ from the stack of the actual error, both may be interesting
+      e.stack += `\n\n### Catch.reportErr calling stack ###\n# ${Catch.stackTrace().split('\n').join('\n# ')}\n######################`;
+    }
     Catch.onErrorInternalHandler(e instanceof Error ? e.message : String(e), window.location.href, line, col, e, true);
   }
 

--- a/extension/js/common/platform/store.ts
+++ b/extension/js/common/platform/store.ts
@@ -528,8 +528,8 @@ export class Store {
     }
   }
 
-  static dbOpen = (): Promise<IDBDatabase> => {
-    return new Promise((resolve, reject) => {
+  static dbOpen = async (): Promise<IDBDatabase> => {
+    return await new Promise((resolve, reject) => {
       let openDbReq: IDBOpenDBRequest;
       openDbReq = indexedDB.open('cryptup', 3);
       openDbReq.onupgradeneeded = (event) => {
@@ -651,97 +651,89 @@ export class Store {
     }
   }
 
-  static dbContactSave = (db: IDBDatabase | undefined, contact: Contact | Contact[]): Promise<void> => {
-    return new Promise((resolve, reject) => {
-      if (!db) { // relay op through background process
-        // todo - currently will silently swallow errors
-        BrowserMsg.send.bg.await.db({ f: 'dbContactSave', args: [contact] }).then(resolve).catch(Catch.reportErr);
+  static dbContactSave = async (db: IDBDatabase | undefined, contact: Contact | Contact[]): Promise<void> => {
+    if (!db) { // relay op through background process
+      return await BrowserMsg.send.bg.await.db({ f: 'dbContactSave', args: [contact] }) as void;
+    }
+    return await new Promise((resolve, reject) => {
+      if (Array.isArray(contact)) {
+        Promise.all(contact.map(oneContact => Store.dbContactSave(db, oneContact))).then(() => resolve(), reject);
       } else {
-        if (Array.isArray(contact)) {
-          Promise.all(contact.map(oneContact => Store.dbContactSave(db, oneContact))).then(() => resolve(), reject);
-        } else {
-          const tx = db.transaction('contacts', 'readwrite');
-          const contactsTable = tx.objectStore('contacts');
-          contactsTable.put(contact);
-          tx.oncomplete = () => resolve();
-          tx.onabort = () => reject(Store.errCategorize(tx.error));
-        }
+        const tx = db.transaction('contacts', 'readwrite');
+        const contactsTable = tx.objectStore('contacts');
+        contactsTable.put(contact);
+        tx.oncomplete = () => resolve();
+        tx.onabort = () => reject(Store.errCategorize(tx.error));
       }
     });
   }
 
-  static dbContactUpdate = (db: IDBDatabase | undefined, email: string | string[], update: ContactUpdate): Promise<void> => {
-    return new Promise((resolve, reject) => {
-      if (!db) { // relay op through background process
-        // todo - currently will silently swallow errors
-        BrowserMsg.send.bg.await.db({ f: 'dbContactUpdate', args: [email, update] }).then(resolve).catch(Catch.reportErr);
-      } else {
-        if (Array.isArray(email)) {
-          Promise.all(email.map(oneEmail => Store.dbContactUpdate(db, oneEmail, update))).then(() => resolve(), reject);
-          resolve();
-        } else {
-          (async () => {
-            let [contact] = await Store.dbContactGet(db, [email]);
-            if (!contact) { // updating a non-existing contact, insert it first
-              await Store.dbContactSave(db, await Store.dbContactObj({ email }));
-              [contact] = await Store.dbContactGet(db, [email]);
-              if (!contact) {
-                reject(new Error('contact not found right after inserting it'));
-                return;
-              }
-            }
-            if (update.pubkey && update.pubkey.includes(Pgp.armor.headers('privateKey').begin)) { // wrongly saving prv instead of pub
-              Catch.report('Wrongly saving prv as contact - converting to pubkey');
-              const key = await Pgp.key.read(update.pubkey);
-              update.pubkey = key.toPublic().armor();
-            }
-            for (const k of Object.keys(update)) {
-              // @ts-ignore - may be saving any of the provided values - could do this one by one while ensuring proper types
-              contact[k] = update[k];
-            }
-            const tx = db.transaction('contacts', 'readwrite');
-            const contactsTable = tx.objectStore('contacts');
-            contactsTable.put(contact);
-            tx.oncomplete = Catch.try(resolve);
-            tx.onabort = () => reject(Store.errCategorize(tx.error));
-          })().catch(reject);
-        }
+  static dbContactUpdate = async (db: IDBDatabase | undefined, email: string | string[], update: ContactUpdate): Promise<void> => {
+    if (!db) { // relay op through background process
+      await BrowserMsg.send.bg.await.db({ f: 'dbContactUpdate', args: [email, update] });
+      return;
+    }
+    if (Array.isArray(email)) {
+      await Promise.all(email.map(oneEmail => Store.dbContactUpdate(db, oneEmail, update)));
+      return;
+    }
+    let [contact] = await Store.dbContactGet(db, [email]);
+    if (!contact) { // updating a non-existing contact, insert it first
+      await Store.dbContactSave(db, await Store.dbContactObj({ email }));
+      [contact] = await Store.dbContactGet(db, [email]);
+      if (!contact) {
+        throw new Error('contact not found right after inserting it');
       }
+    }
+    if (update.pubkey && update.pubkey.includes(Pgp.armor.headers('privateKey').begin)) { // wrongly saving prv instead of pub
+      Catch.report('Wrongly saving prv as contact - converting to pubkey');
+      const key = await Pgp.key.read(update.pubkey);
+      update.pubkey = key.toPublic().armor();
+    }
+    for (const k of Object.keys(update)) {
+      // @ts-ignore - may be saving any of the provided values - could do this one by one while ensuring proper types
+      contact[k] = update[k];
+    }
+    return await new Promise((resolve, reject) => {
+      const tx = db.transaction('contacts', 'readwrite');
+      const contactsTable = tx.objectStore('contacts');
+      contactsTable.put(contact);
+      tx.oncomplete = Catch.try(resolve);
+      tx.onabort = () => reject(Store.errCategorize(tx.error));
     });
   }
 
   static dbContactGet = async (db: undefined | IDBDatabase, emailOrLongid: string[]): Promise<(Contact | undefined)[]> => {
     if (!db) { // relay op through background process
       return await BrowserMsg.send.bg.await.db({ f: 'dbContactGet', args: [emailOrLongid] }) as (Contact | undefined)[];
-    } else {
-      if (emailOrLongid.length === 1) {
-        // contacts imported before August 2019 may have only primary longid recorded, in index_longid (string)
-        // contacts imported after August 2019 have both index_longid (string) and index_longids (string[] containing all subkeys)
-        // below we search contact by first trying to only search by primary longid
-        // (or by email - such searches are not affected by longid indexing)
-        const contact = await Store.dbContactInternalGetOne(db, emailOrLongid[0], false);
-        if (contact || !/^[A-F0-9]{16}$/.test(emailOrLongid[0])) {
-          // if we found something, return it
-          // or if we were searching by email, return found contact or nothing
-          return [contact];
-        } else {
-          // not found any key by primary longid, and searching by longid -> search by any subkey longid
-          // it may not find pubkeys imported before August 2019, re-importing such pubkeys will make them findable
-          return [await Store.dbContactInternalGetOne(db, emailOrLongid[0], true)];
-        }
+    }
+    if (emailOrLongid.length === 1) {
+      // contacts imported before August 2019 may have only primary longid recorded, in index_longid (string)
+      // contacts imported after August 2019 have both index_longid (string) and index_longids (string[] containing all subkeys)
+      // below we search contact by first trying to only search by primary longid
+      // (or by email - such searches are not affected by longid indexing)
+      const contact = await Store.dbContactInternalGetOne(db, emailOrLongid[0], false);
+      if (contact || !/^[A-F0-9]{16}$/.test(emailOrLongid[0])) {
+        // if we found something, return it
+        // or if we were searching by email, return found contact or nothing
+        return [contact];
       } else {
-        const results: (Contact | undefined)[] = [];
-        for (const singleEmailOrLongid of emailOrLongid) {
-          const [contact] = await Store.dbContactGet(db, [singleEmailOrLongid]);
-          results.push(contact);
-        }
-        return results;
+        // not found any key by primary longid, and searching by longid -> search by any subkey longid
+        // it may not find pubkeys imported before August 2019, re-importing such pubkeys will make them findable
+        return [await Store.dbContactInternalGetOne(db, emailOrLongid[0], true)];
       }
+    } else {
+      const results: (Contact | undefined)[] = [];
+      for (const singleEmailOrLongid of emailOrLongid) {
+        const [contact] = await Store.dbContactGet(db, [singleEmailOrLongid]);
+        results.push(contact);
+      }
+      return results;
     }
   }
 
-  private static dbContactInternalGetOne = (db: IDBDatabase, emailOrLongid: string, searchSubkeyLongids: boolean): Promise<Contact | undefined> => {
-    return new Promise((resolve, reject) => {
+  private static dbContactInternalGetOne = async (db: IDBDatabase, emailOrLongid: string, searchSubkeyLongids: boolean): Promise<Contact | undefined> => {
+    return await new Promise((resolve, reject) => {
       let tx: IDBRequest;
       if (!/^[A-F0-9]{16}$/.test(emailOrLongid)) { // email
         tx = db.transaction('contacts', 'readonly').objectStore('contacts').get(emailOrLongid);
@@ -755,55 +747,55 @@ export class Store {
     });
   }
 
-  static dbContactSearch = (db: IDBDatabase | undefined, query: DbContactFilter): Promise<Contact[]> => {
-    return new Promise((resolve, reject) => {
-      if (!db) { // relay op through background process
-        // todo - currently will silently swallow errors
-        BrowserMsg.send.bg.await.db({ f: 'dbContactSearch', args: [query] }).then(resolve).catch(Catch.reportErr);
-      } else {
-        for (const key of Object.keys(query)) {
-          if (!Store.dbQueryKeys.includes(key)) {
-            throw new Error('dbContactSearch: unknown key: ' + key);
-          }
-        }
-        const contacts = db.transaction('contacts', 'readonly').objectStore('contacts');
-        let search: IDBRequest | undefined;
-        if (typeof query.has_pgp === 'undefined') { // any query.has_pgp value
-          query.substring = Store.normalizeString(query.substring || '');
-          if (query.substring) {
-            (async () => {
-              const resultsWithPgp = await Store.dbContactSearch(db, { substring: query.substring, limit: query.limit, has_pgp: true });
-              if (query.limit && resultsWithPgp.length === query.limit) {
-                resolve(resultsWithPgp);
-              } else {
-                const limit = query.limit ? query.limit - resultsWithPgp.length : undefined;
-                const resultsWithoutPgp = await Store.dbContactSearch(db, { substring: query.substring, limit, has_pgp: false });
-                resolve(resultsWithPgp.concat(resultsWithoutPgp));
-              }
-            })().catch(reject);
-          } else {
-            search = contacts.openCursor();
-          }
-        } else { // specific query.has_pgp value
-          if (query.substring) {
-            search = contacts.index('search').openCursor(IDBKeyRange.only(Store.dbIndex(query.has_pgp, query.substring)));
-          } else {
-            search = contacts.index('index_has_pgp').openCursor(IDBKeyRange.only(Number(query.has_pgp)));
-          }
-        }
-        if (typeof search !== 'undefined') {
-          const found: Contact[] = [];
-          search.onsuccess = Catch.try(() => {
-            const cursor = search!.result; // checked it above
-            if (!cursor || found.length === query.limit) {
-              resolve(found);
+  static dbContactSearch = async (db: IDBDatabase | undefined, query: DbContactFilter): Promise<Contact[]> => {
+    if (!db) { // relay op through background process
+      return await BrowserMsg.send.bg.await.db({ f: 'dbContactSearch', args: [query] }) as Contact[];
+    }
+    for (const key of Object.keys(query)) {
+      if (!Store.dbQueryKeys.includes(key)) {
+        throw new Error('dbContactSearch: unknown key: ' + key);
+      }
+    }
+    return await new Promise((resolve, reject) => {
+      const contacts = db.transaction('contacts', 'readonly').objectStore('contacts');
+      let search: IDBRequest | undefined;
+      if (typeof query.has_pgp === 'undefined') { // any query.has_pgp value
+        query.substring = Store.normalizeString(query.substring || '');
+        if (query.substring) {
+          (async () => {
+            const resultsWithPgp = await Store.dbContactSearch(db, { substring: query.substring, limit: query.limit, has_pgp: true });
+            if (query.limit && resultsWithPgp.length === query.limit) {
+              resolve(resultsWithPgp);
             } else {
-              found.push(cursor.value); // tslint:disable-line:no-unsafe-any
-              cursor.continue(); // tslint:disable-line:no-unsafe-any
+              const limit = query.limit ? query.limit - resultsWithPgp.length : undefined;
+              const resultsWithoutPgp = await Store.dbContactSearch(db, { substring: query.substring, limit, has_pgp: false });
+              resolve(resultsWithPgp.concat(resultsWithoutPgp));
             }
-          });
-          search.onerror = () => reject(Store.errCategorize(search!.error!)); // todo - added ! after ts3 upgrade - investigate
+          })().catch(reject);
+        } else {
+          search = contacts.openCursor();
         }
+      } else { // specific query.has_pgp value
+        if (query.substring) {
+          search = contacts.index('search').openCursor(IDBKeyRange.only(Store.dbIndex(query.has_pgp, query.substring)));
+        } else {
+          search = contacts.index('index_has_pgp').openCursor(IDBKeyRange.only(Number(query.has_pgp)));
+        }
+      }
+      if (typeof search !== 'undefined') {
+        const found: Contact[] = [];
+        search.onsuccess = Catch.try(() => {
+          const cursor = search!.result; // checked it above
+          if (!cursor || found.length === query.limit) {
+            resolve(found);
+          } else {
+            found.push(cursor.value); // tslint:disable-line:no-unsafe-any
+            cursor.continue(); // tslint:disable-line:no-unsafe-any
+          }
+        });
+        search.onerror = () => reject(Store.errCategorize(search!.error!)); // todo - added ! after ts3 upgrade - investigate
+      } else {
+        reject(new Error('search is undefined in dbContactSearch'));
       }
     });
   }

--- a/extension/js/common/platform/store.ts
+++ b/extension/js/common/platform/store.ts
@@ -796,7 +796,9 @@ export class Store {
         });
         search.onerror = () => reject(Store.errCategorize(search!.error!)); // todo - added ! after ts3 upgrade - investigate
       } else {
-        reject(new Error('search is undefined in dbContactSearch'));
+        // todo - this seems to make no sense. No callback? Why undefined?
+        // adding a reject below will break tests
+        // reject(new Error('search is undefined in dbContactSearch'));
       }
     });
   }

--- a/extension/js/common/ui/att_ui.ts
+++ b/extension/js/common/ui/att_ui.ts
@@ -144,8 +144,8 @@ export class AttUI {
     return sum;
   }
 
-  private readAttDataAsUint8 = (uploadFileId: string): Promise<Uint8Array> => {
-    return new Promise(resolve => {
+  private readAttDataAsUint8 = async (uploadFileId: string): Promise<Uint8Array> => {
+    return await new Promise(resolve => {
       const reader = new FileReader();
       reader.onload = () => {
         resolve(new Uint8Array(reader.result as ArrayBuffer)); // that's what we're getting

--- a/tooling/tslint-rules/awaitReturnedPromiseRule.ts
+++ b/tooling/tslint-rules/awaitReturnedPromiseRule.ts
@@ -1,0 +1,48 @@
+import * as ts from "typescript";
+import * as tslint from "tslint";
+import { isIdentifier } from 'tsutils';
+
+const AWAIT_RETURNED_PROMISE = `must explicitly await returned promise (see https://github.com/FlowCrypt/flowcrypt-browser/pull/2349)`;
+
+export class Rule extends tslint.Rules.TypedRule {
+
+  public static metadata: tslint.IRuleMetadata = {
+    ruleName: "await-returned-promise",
+    description: "Requres returned promises in async functions to be explicitly awaited",
+    options: undefined,
+    optionsDescription: 'Not configurable.',
+    type: "typescript",
+    typescriptOnly: true,
+    requiresTypeInfo: true,
+  };
+
+  public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): tslint.RuleFailure[] {
+    return this.applyWithWalker(new Walker(sourceFile, this.getOptions(), program));
+  }
+}
+
+class Walker extends tslint.ProgramAwareRuleWalker {
+
+  public visitReturnStatement(node: ts.ReturnStatement) {
+    if (node.expression === undefined || (isIdentifier(node.expression) && node.expression.text === "undefined")) {
+      return false;
+    }
+    const checker = this.getTypeChecker();
+    const inferredType = checker.getTypeAtLocation(node.expression);
+    if (this.returnsPromise(checker, inferredType)) {
+      this.addFailureAtNode(node, AWAIT_RETURNED_PROMISE);
+    }
+  }
+
+  private returnsPromise(checker: ts.TypeChecker, typeAt: ts.Type) {
+    if (!typeAt) {
+      return false;
+    }
+    const typeStr = checker.typeToString(typeAt);
+    if (/^Promise</.test(typeStr)) {
+      return true;
+    }
+    return false;
+  }
+
+}

--- a/tooling/tslint-rules/onelinerObjectLiteralRule.ts
+++ b/tooling/tslint-rules/onelinerObjectLiteralRule.ts
@@ -10,7 +10,7 @@ There are possible exceptions:
 In such cases you can mute supress this rule with:
 // tslint:disable-line:oneliner-object-literal
 .`;
-const MAX_LINE_LEN_WITH_OBJ_LITERAL = 160;
+const MAX_LINE_LEN_WITH_OBJ_LITERAL = 140;
 
 export class Rule extends tslint.Rules.AbstractRule {
 


### PR DESCRIPTION
close #1599 

This is extremely interesting. For our particular codebase, and our (edited compiler), if we want the longest possible stack trace, we need to await promises explicitly instead of returning them.

bad:
```js
  threadGet = (threadId: string, format?: GmailResponseFormat, progressCb?: ProgressCb): Promise<GmailRes.GmailThread> => {
    return Google.gmailCall(this.acctEmail, 'GET', `threads/${threadId}`, { format }, { download: progressCb }) as GmailRes.GmailThread;
  }
```
good:
```js
  threadGet = async (threadId: string, format?: GmailResponseFormat, progressCb?: ProgressCb): Promise<GmailRes.GmailThread> => {
    return await Google.gmailCall(this.acctEmail, 'GET', `threads/${threadId}`, { format }, { download: progressCb }) as GmailRes.GmailThread;
  }
```
This is because we hacked the transpiler to insert a bunch of try/catch for stack traces, and they only get triggered when we actually await the promises before returning:

```js
this.threadGet = async (threadId, format, progressCb) => {
	try {
		return await Google.gmailCall(this.acctEmail, 'GET', `threads/${threadId}`, { format }, { download: progressCb });
	}
	catch (t) {
		if(t instanceof Error){t.stack+="\n    at <async> threadGet (/extension/js/common/api/email_provider/gmail/gmail.ts:39:14)";throw t}const e=new Error("Thrown["+typeof t+"]"+t);e.thrown=t;throw e;
	}
};
```
Without that added await, the catch clause would never get triggered, and we lose our beautiful async stack.