### PR TITLE
Add recommended extensions .vscode/extensions.json

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,15 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"dbaeumer.vscode-eslint",
+		"hex-ci.stylelint-plus",
+		"ms-vscode.vscode-typescript-tslint-plugin"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+
+	]
+}


### PR DESCRIPTION
I made a small Wiki page on how to get started with VSCode: https://github.com/FlowCrypt/flowcrypt-browser/wiki/Getting-started-in-VSCode

This PR will ensure that when a new developer starts working on the project, he/she will be prompted to install recommended extensions:

![image](https://user-images.githubusercontent.com/6059356/70758913-2180d500-1d4d-11ea-86eb-3e934fbd721a.png)
