### PR TITLE
Enable ESLint autoFix for TS

### DIFF
--- a/flowcrypt-browser.code-workspace
+++ b/flowcrypt-browser.code-workspace
@@ -12,7 +12,10 @@
     "eslint.autoFixOnSave": true,
     "eslint.validate": [
       "javascript",
-      "typescript"
+      {
+        "language": "typescript",
+        "autoFix": true
+      },
     ],
     "stylelint.autoFixOnSave": true,
     "files.exclude": {


### PR DESCRIPTION
Follow-up for #2351

`autoFix` functionality for `.ts` files works only with this syntax as per https://github.com/microsoft/vscode-eslint/issues/609#issuecomment-460554105