### PR TITLE
Remove editor.formatOnSave and editor.formatOnPaste

### DIFF
--- a/flowcrypt-browser.code-workspace
+++ b/flowcrypt-browser.code-workspace
@@ -6,8 +6,6 @@
     "typescript.preferences.importModuleSpecifier": "relative",
     "typescript.preferences.quoteStyle": "single",
     "tslint.configFile": "conf/tslint.yaml",
-    "editor.formatOnSave": true,
-    "editor.formatOnPaste": true,
     "eslint.autoFixOnSave": true,
     "eslint.validate": [
       "javascript",


### PR DESCRIPTION
Since recently I'm using the `flowcrypt-browser.code-workspace` configuration (previously I was doing `code ~/www/flowcrypt-browser` which isn't taking `.code-workspace` file into account) 

I don't know how `editor.formatOnSave` and `editor.formatOnPaste` weren't bothering anyone before me :)

Here's what's happening:

With the clean (no changes) repo, I open `compose.htm`, hit <kbd>Ctrl</kbd>+<kbd>S</kbd> and the file is changed automatically:

![1](https://user-images.githubusercontent.com/6059356/71031661-79885480-211c-11ea-89fb-179cacd97eb8.gif)

This is happening because of `html.format.wrapLineLength` which is `120` by default. This should be happening for everybody who is using `flowcrypt-browser.code-workspace`.

So these wrapping changes are getting into other changes which isn't desired.