### PR TITLE
Issue #1842, Added ability to download revocation certificate

### DIFF
--- a/extension/chrome/settings/modules/my_key.htm
+++ b/extension/chrome/settings/modules/my_key.htm
@@ -36,8 +36,17 @@
     <div class="line-separator"></div>
     <div class="line">
       <b class="key_type">Private Key</b> for <span class="email"></span>&nbsp;&nbsp;<a href="#"
-        class="action_view_update">update</a>
+        class="action_view_update">update</a>&nbsp;&nbsp;<a href="#"
+        class="action_download_revocation_cert">revocation certificate</a>
     </div>
+    <div class="line enter_pp" style="display: none;">
+      <input id="input_passphrase" type="text" placeholder="Enter your pass phrase" />
+    </div>
+    <div class="line enter_pp" style="display: none;">
+      <button class="button green action_continue_download">download</button>
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+      <button class="button gray action_cancel_download_cert">cancel</button>
+      </div>
     <div class="line"><span class="red_label">Never send this to anyone!</span></div>
     <div class="line">
       <a href="#" class="action_copy_prv bad">Copy private key to clipboard</a>

--- a/extension/chrome/settings/modules/my_key.ts
+++ b/extension/chrome/settings/modules/my_key.ts
@@ -91,6 +91,12 @@ View.run(class MyKeyView extends View {
     }
     $('.enter_pp').hide();
     $('#input_passphrase').val('');
+    let revokeConfirmMsg = `Revocation cert is used when you want to revoke your Public Key (meaning you are asking others to stop using it).\n\n`;
+    revokeConfirmMsg += `You can save it do your hard drive, and use it later in case you ever need it.\n\n`;
+    revokeConfirmMsg += `Would you like to generate and save a revocation cert now?`;
+    if (! await Ui.modal.confirm(revokeConfirmMsg)) {
+      return;
+    }
     const revokedArmored = await PgpKey.revoke(prv);
     if (!revokedArmored) {
       await Ui.modal.error(`Could not produce revocation cert (empty)`);

--- a/extension/js/common/core/pgp-key.ts
+++ b/extension/js/common/core/pgp-key.ts
@@ -354,4 +354,15 @@ export class PgpKey {
     throw new Error('No valid signature found in key');
   }
 
+  static revoke = async (key: OpenPGP.key.Key) => {
+    if (! await key.isRevoked()) {
+      key = await key.revoke({});
+    }
+    const certificate = await key.getRevocationCertificate();
+    if (!certificate || typeof certificate === 'string') {
+      return certificate;
+    } else {
+      return await openpgp.stream.readToEnd(certificate);
+    }
+  }
 }

--- a/extension/js/common/core/pgp-key.ts
+++ b/extension/js/common/core/pgp-key.ts
@@ -354,13 +354,13 @@ export class PgpKey {
     throw new Error('No valid signature found in key');
   }
 
-  static revoke = async (key: OpenPGP.key.Key) => {
+  static revoke = async (key: OpenPGP.key.Key): Promise<string | undefined> => {
     if (! await key.isRevoked()) {
       key = await key.revoke({});
     }
     const certificate = await key.getRevocationCertificate();
     if (!certificate || typeof certificate === 'string') {
-      return certificate;
+      return certificate || undefined;
     } else {
       return await openpgp.stream.readToEnd(certificate);
     }

--- a/extension/js/common/core/types/openpgp.d.ts
+++ b/extension/js/common/core/types/openpgp.d.ts
@@ -704,6 +704,29 @@ declare namespace OpenPGP {
       signature = 6,
     }
 
+    enum reasonForRevocation {
+      /**
+       * No reason specified (key revocations or cert revocations)
+       */
+      no_reason = 0,
+      /**
+       * Key is superseded (key revocations)
+       */
+      key_superseded = 1,
+      /**
+       * Key material has been comPromise<any>d (key revocations)
+       */
+      key_comPromised = 2,
+      /**
+       * Key is retired and no longer used (key revocations)
+       */
+      key_retired = 3,
+      /**
+       * User ID information is no longer valid (cert revocations)
+       */
+      userid_invalid = 32,
+    }
+
     export type compressionNames = 'uncompressed' | 'zip' | 'zlib' | 'bzip2';
     enum compression {
       uncompressed = 0,
@@ -818,6 +841,8 @@ declare namespace OpenPGP {
       update(key: Key): void;
       verifyPrimaryKey(): Promise<enums.keyStatus>;
       isRevoked(): Promise<boolean>;
+      revoke(easonForRevocation: revoke_reasonForRevocation, date?: Date): Promise<Key>;
+      getRevocationCertificate(): Promise<Stream<string> | string | undefined>;
       getEncryptionKey(keyid?: Keyid | null, date?: Date, userId?: UserId | null): Promise<packet.PublicSubkey | packet.SecretSubkey | packet.SecretKey | packet.PublicKey | null>;
       getSigningKey(): Promise<packet.PublicSubkey | packet.SecretSubkey | packet.SecretKey | packet.PublicKey | null>;
       getKeys(keyId?: Keyid): (Key | SubKey)[];
@@ -848,6 +873,11 @@ declare namespace OpenPGP {
       getCreationTime(): Date;
       getAlgorithmInfo(): AlgorithmInfo;
       getKeyId(): Keyid;
+    }
+
+    export interface revoke_reasonForRevocation {
+      flag?: enums.reasonForRevocation;
+      string?: string;
     }
 
     export interface User {

--- a/extension/js/common/core/types/openpgp.d.ts
+++ b/extension/js/common/core/types/openpgp.d.ts
@@ -705,26 +705,11 @@ declare namespace OpenPGP {
     }
 
     enum reasonForRevocation {
-      /**
-       * No reason specified (key revocations or cert revocations)
-       */
-      no_reason = 0,
-      /**
-       * Key is superseded (key revocations)
-       */
-      key_superseded = 1,
-      /**
-       * Key material has been comPromise<any>d (key revocations)
-       */
-      key_comPromised = 2,
-      /**
-       * Key is retired and no longer used (key revocations)
-       */
-      key_retired = 3,
-      /**
-       * User ID information is no longer valid (cert revocations)
-       */
-      userid_invalid = 32,
+      no_reason = 0, // No reason specified (key revocations or cert revocations)
+      key_superseded = 1, // Key is superseded (key revocations)
+      key_compromised = 2, // Key material has been compromised (key revocations)
+      key_retired = 3, // Key is retired and no longer used (key revocations)
+      userid_invalid = 32, // User ID information is no longer valid (cert revocations)
     }
 
     export type compressionNames = 'uncompressed' | 'zip' | 'zlib' | 'bzip2';
@@ -841,7 +826,7 @@ declare namespace OpenPGP {
       update(key: Key): void;
       verifyPrimaryKey(): Promise<enums.keyStatus>;
       isRevoked(): Promise<boolean>;
-      revoke(easonForRevocation: revoke_reasonForRevocation, date?: Date): Promise<Key>;
+      revoke(reason: { flag?: enums.reasonForRevocation; string?: string; }, date?: Date): Promise<Key>;
       getRevocationCertificate(): Promise<Stream<string> | string | undefined>;
       getEncryptionKey(keyid?: Keyid | null, date?: Date, userId?: UserId | null): Promise<packet.PublicSubkey | packet.SecretSubkey | packet.SecretKey | packet.PublicKey | null>;
       getSigningKey(): Promise<packet.PublicSubkey | packet.SecretSubkey | packet.SecretKey | packet.PublicKey | null>;
@@ -873,11 +858,6 @@ declare namespace OpenPGP {
       getCreationTime(): Date;
       getAlgorithmInfo(): AlgorithmInfo;
       getKeyId(): Keyid;
-    }
-
-    export interface revoke_reasonForRevocation {
-      flag?: enums.reasonForRevocation;
-      string?: string;
     }
 
     export interface User {


### PR DESCRIPTION
Issue #1842 
Time Spent: 4h

I thought it would be easier :)
I faced some issues that slowed me a little.
1. I had to update typings. First I decided to copy/pasted definitions from here `https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/openpgp/ts3.2/index.d.ts`  but that didn't work so I added that definitions that we only need.
2. I don't know why but `openpgp.key.Key.revoke` returns not `string` but `Stream`. I checked the original method to understand what's going on there. I checked it and didn't find out why so I had to somehow deal with that, and I corrected typings a little, so `openpgp.key.Key.revoke` may return either `string`, `Stream<string>` or `undefined`.
3. And the last thing I had to do is to handle a situation when a user doesn't have stored passphrase. Actually, I didn't have any trouble implementing this step.