### PR TITLE
Update eslint config for VSCode workspace

### DIFF
--- a/flowcrypt-browser.code-workspace
+++ b/flowcrypt-browser.code-workspace
@@ -8,13 +8,9 @@
     "tslint.configFile": "conf/tslint.yaml",
     "editor.formatOnSave": true,
     "editor.formatOnPaste": true,
-    "eslint.autoFixOnSave": true,
     "eslint.validate": [
       "javascript",
-      {
-        "language": "typescript",
-        "autoFix": true
-      },
+      "typescript",
     ],
     "html.format.enable": false,
     "stylelint.autoFixOnSave": true,


### PR DESCRIPTION
They shipped changes two days ago: https://github.com/microsoft/vscode-eslint/blob/master/README.md

![image](https://user-images.githubusercontent.com/6059356/71178226-65586a80-2276-11ea-8535-6f72150619a9.png)

![image](https://user-images.githubusercontent.com/6059356/71178301-9173eb80-2276-11ea-80f0-afba07d125d0.png)

@michael-volynets already commited a new config in https://github.com/FlowCrypt/flowcrypt-browser/commit/55293b4dec056b2a3adb9523e6d4917e9e0e73b3 so in this PR I'm removing the deprecated ones.