### PR TITLE
Do not autoformat links for plain text messages

### DIFF
--- a/extension/chrome/elements/composer/composer-input.ts
+++ b/extension/chrome/elements/composer/composer-input.ts
@@ -20,10 +20,15 @@ export class ComposerInput extends ComposerComponent {
     this.initShortcuts();
     this.resizeReplyBox();
     this.scrollIntoView();
+    this.squire.setConfig({ richText: this.isRichText() });
   }
 
+  addRichTextFormatting = () => {
+    this.squire.setConfig({ richText: true });
+  }
   removeRichTextFormatting = () => {
     this.squire.setHTML(Xss.htmlSanitizeAndStripAllTags(this.squire.getHTML(), '<br>'));
+    this.squire.setConfig({ richText: false });
   }
 
   public inputTextHtmlSetSafely = (html: string) => {

--- a/extension/chrome/elements/composer/composer-input.ts
+++ b/extension/chrome/elements/composer/composer-input.ts
@@ -20,15 +20,15 @@ export class ComposerInput extends ComposerComponent {
     this.initShortcuts();
     this.resizeReplyBox();
     this.scrollIntoView();
-    this.squire.setConfig({ richText: this.isRichText() });
+    this.squire.setConfig({ addLinks: this.isRichText() });
   }
 
   addRichTextFormatting = () => {
-    this.squire.setConfig({ richText: true });
+    this.squire.setConfig({ addLinks: true });
   }
   removeRichTextFormatting = () => {
     this.squire.setHTML(Xss.htmlSanitizeAndStripAllTags(this.squire.getHTML(), '<br>'));
-    this.squire.setConfig({ richText: false });
+    this.squire.setConfig({ addLinks: false });
   }
 
   public inputTextHtmlSetSafely = (html: string) => {

--- a/extension/chrome/elements/composer/composer-send-btn-popover.ts
+++ b/extension/chrome/elements/composer/composer-send-btn-popover.ts
@@ -69,9 +69,7 @@ export class ComposerSendBtnPopover extends ComposerComponent {
       this.composer.S.cached('compose_table').addClass('not-encrypted');
       this.composer.S.now('attached_files').addClass('not-encrypted');
     }
-    if (!this.choices.richText) {
-      this.composer.input.removeRichTextFormatting();
-    }
+    this.choices.richText ? this.composer.input.addRichTextFormatting() : this.composer.input.removeRichTextFormatting();
     this.composer.sendBtn.resetSendBtn();
     this.composer.pwdOrPubkeyContainer.showHideContainerAndColorSendBtn();
     if (typeof machineForceStateTo === 'undefined' && popoverOpt === 'richText') { // human-input choice of rich text

--- a/extension/lib/squire-raw.js
+++ b/extension/lib/squire-raw.js
@@ -1,5 +1,9 @@
 /* Copyright © 2011-2015 by Neil Jenkins. MIT Licensed. */
 
+// ! CUSTOM CHANGES, please apply the same changes when upgrading the library !
+//
+// 1. handleEnter(): Wrap addLinks( range.startContainer, root, self ) into if (self._config.richText) { }
+
 ( function ( doc, undefined ) {
 
 "use strict";
@@ -1434,7 +1438,9 @@ var handleEnter = function ( self, shiftKey, range ) {
     // Remove any zws so we don't think there's content in an empty
     // block.
     self._recordUndoState( range );
-    addLinks( range.startContainer, root, self );
+    if (self._config.richText) {
+        addLinks( range.startContainer, root, self );
+    }
     self._removeZWS();
     self._getRangeAndRemoveBookmark( range );
 

--- a/extension/lib/squire-raw.js
+++ b/extension/lib/squire-raw.js
@@ -1,9 +1,5 @@
 /* Copyright © 2011-2015 by Neil Jenkins. MIT Licensed. */
 
-// ! CUSTOM CHANGES, please apply the same changes when upgrading the library !
-//
-// 1. handleEnter(): Wrap addLinks( range.startContainer, root, self ) into if (self._config.richText) { }
-
 ( function ( doc, undefined ) {
 
 "use strict";
@@ -1438,7 +1434,7 @@ var handleEnter = function ( self, shiftKey, range ) {
     // Remove any zws so we don't think there's content in an empty
     // block.
     self._recordUndoState( range );
-    if (self._config.richText) {
+    if ( self._config.addLinks ) {
         addLinks( range.startContainer, root, self );
     }
     self._removeZWS();
@@ -1791,7 +1787,9 @@ var keyHandlers = {
         var node, parent;
         var root = self._root;
         self._recordUndoState( range );
-        addLinks( range.startContainer, root, self );
+        if ( self._config.addLinks ) {
+            addLinks( range.startContainer, root, self );
+        }
         self._getRangeAndRemoveBookmark( range );
 
         // If the cursor is at the end of a link (<a>foo|</a>) then move it
@@ -2756,7 +2754,8 @@ proto.setConfig = function ( config ) {
         sanitizeToDOMFragment:
             typeof DOMPurify !== 'undefined' && DOMPurify.isSupported ?
             sanitizeToDOMFragment : null,
-        willCutCopy: null
+        willCutCopy: null,
+        addLinks: true
     }, config, true );
 
     // Users may specify block tag in lower case

--- a/extension/types/squire.d.ts
+++ b/extension/types/squire.d.ts
@@ -70,6 +70,7 @@ export declare class SquireEditor {
   toggleCode(): SquireEditor;
   removeAllFormatting(): void;
   changeFormat(formattingToAdd: any, formattingToRemove: any, range: Range): void;
+  setConfig(config: any): SquireEditor;
 }
 
 export declare class WillPasteEvent extends ClipboardEvent {


### PR DESCRIPTION
Fixes #2409

Unfortunately, it doesn't seem possible to fix the issue without changing `squire-raw.js`. In order not to override changes during the upgrade, I added the comment. @tomholub please let me know if you have some other suggestions on how to prevent accidental overriding changes in `lib` files.

Should we maybe create the internal fork of `squire` (as private repo) to mirror the changes we're doing on it?