### PR TITLE
Issue 2416 sendbtn is blocked when canceling pp modal

### DIFF
--- a/extension/chrome/elements/attachment.ts
+++ b/extension/chrome/elements/attachment.ts
@@ -41,7 +41,7 @@ View.run(class AttachmentDownloadView extends View {
 
   constructor() {
     super();
-    const uncheckedUrlParams = Url.parse(['acctEmail', 'msgId', 'attId', 'name', 'type', 'size', 'url', 'parentTabId', 'content', 'decrypted', 'frameId', 'isEncrypted', 'tabId']);
+    const uncheckedUrlParams = Url.parse(['acctEmail', 'msgId', 'attId', 'name', 'type', 'size', 'url', 'parentTabId', 'content', 'decrypted', 'frameId', 'isEncrypted']);
     this.acctEmail = Assert.urlParamRequire.string(uncheckedUrlParams, 'acctEmail');
     this.parentTabId = Assert.urlParamRequire.string(uncheckedUrlParams, 'parentTabId');
     this.frameId = Assert.urlParamRequire.string(uncheckedUrlParams, 'frameId');

--- a/extension/chrome/elements/attachment.ts
+++ b/extension/chrome/elements/attachment.ts
@@ -3,7 +3,7 @@
 'use strict';
 
 import { Catch } from '../../js/common/platform/catch.js';
-import { Store, PromiseCancellation } from '../../js/common/platform/store.js';
+import { Store } from '../../js/common/platform/store.js';
 import { Browser } from '../../js/common/browser/browser.js';
 import { Api } from '../../js/common/api/api.js';
 import { DecryptErrTypes, PgpMsg } from '../../js/common/core/pgp-msg.js';
@@ -11,7 +11,7 @@ import { BrowserMsg, Bm } from '../../js/common/browser/browser-msg.js';
 import { Att } from '../../js/common/core/att.js';
 import { Assert } from '../../js/common/assert.js';
 import { Xss } from '../../js/common/platform/xss.js';
-import { Url } from '../../js/common/core/common.js';
+import { Url, PromiseCancellation } from '../../js/common/core/common.js';
 import { Gmail } from '../../js/common/api/email_provider/gmail/gmail.js';
 import { Ui } from '../../js/common/browser/ui.js';
 import { ApiErr } from '../../js/common/api/error/api-error.js';

--- a/extension/chrome/elements/composer/composer-send-btn.ts
+++ b/extension/chrome/elements/composer/composer-send-btn.ts
@@ -47,7 +47,8 @@ export class ComposerSendBtn extends ComposerComponent {
   resetSendBtn = (delay?: number) => {
     const doReset = () => {
       Xss.sanitizeRender(this.composer.S.cached('send_btn_text'), `<i></i>${this.btnText()}`);
-      this.composer.S.cached('toggle_send_options').show();
+      this.composer.S.cached('send_btn').addClass('green').removeClass('gray').prop('disabled', false);
+      this.composer.S.cached('toggle_send_options').addClass('green').removeClass('gray').show();
     };
     if (typeof this.btnUpdateTimeout !== 'undefined') {
       clearTimeout(this.btnUpdateTimeout);

--- a/extension/chrome/settings/modules/backup.ts
+++ b/extension/chrome/settings/modules/backup.ts
@@ -3,11 +3,11 @@
 'use strict';
 
 import { Catch, UnreportableError } from '../../../js/common/platform/catch.js';
-import { Store, KeyBackupMethod, EmailProvider } from '../../../js/common/platform/store.js';
+import { Store, KeyBackupMethod, EmailProvider, PromiseCancellationToken, PromiseCancelledError } from '../../../js/common/platform/store.js';
 import { Value, Url } from '../../../js/common/core/common.js';
 import { Att } from '../../../js/common/core/att.js';
 import { Browser } from '../../../js/common/browser/browser.js';
-import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
+import { BrowserMsg, Bm } from '../../../js/common/browser/browser-msg.js';
 import { Rules } from '../../../js/common/rules.js';
 import { Lang } from '../../../js/common/lang.js';
 import { Settings } from '../../../js/common/settings.js';
@@ -25,13 +25,15 @@ import { ApiErr } from '../../../js/common/api/error/api-error.js';
 import { PgpKey, KeyInfo } from '../../../js/common/core/pgp-key.js';
 
 View.run(class BackupView extends View {
+  private readonly gmail: Gmail;
 
   private acctEmail: string;
   private parentTabId: string | undefined;
+  private tabId!: string;
   private action: string | undefined;
   private keyImportUi = new KeyImportUi({});
   private emailProvider: EmailProvider = 'gmail';
-  private readonly gmail: Gmail;
+  private cancellationToken: PromiseCancellationToken = { cancel: false };
 
   private blocks = ['loading', 'step_0_status', 'step_1_password', 'step_2_confirm', 'step_3_automatic_backup_retry', 'step_3_manual'];
 
@@ -47,6 +49,7 @@ View.run(class BackupView extends View {
   }
 
   render = async () => {
+    this.tabId = await BrowserMsg.requiredTabId();
     const storage = await Store.getAcct(this.acctEmail, ['setup_simple', 'email_provider']);
     this.emailProvider = storage.email_provider || 'gmail';
     const rules = await Rules.newInstance(this.acctEmail);
@@ -84,6 +87,13 @@ View.run(class BackupView extends View {
     $('.auth_reconnect').click(this.setHandler(el => this.actionAuthReconnectHandler()));
     $('.reload').click(() => window.location.reload());
     $("#password2").keydown(this.setEnterHandlerThatClicks('.action_backup'));
+    BrowserMsg.addListener('passphrase_entry', async ({ entered }: Bm.PassphraseEntry) => {
+      if (!entered) {
+        this.cancellationToken.cancel = true;
+        this.cancellationToken = { cancel: false };
+      }
+    });
+    BrowserMsg.listen(this.tabId);
   }
 
   // --- PRIVATE
@@ -333,7 +343,14 @@ View.run(class BackupView extends View {
     }
     if (!pp) {
       BrowserMsg.send.passphraseDialog(this.parentTabId, { type: 'backup', longids: [primaryKi.longid] });
-      await Store.waitUntilPassphraseChanged(this.acctEmail, [primaryKi.longid]);
+      try {
+        await Store.waitUntilPassphraseChanged(this.acctEmail, [primaryKi.longid], 1000, this.cancellationToken);
+      } catch (e) {
+        if (e instanceof PromiseCancelledError) {
+          return;
+        }
+        throw e;
+      }
       await this.backupOnEmailProviderAndUpdateUi(primaryKi);
       return;
     }

--- a/extension/chrome/settings/modules/backup.ts
+++ b/extension/chrome/settings/modules/backup.ts
@@ -3,8 +3,8 @@
 'use strict';
 
 import { Catch, UnreportableError } from '../../../js/common/platform/catch.js';
-import { Store, KeyBackupMethod, EmailProvider, PromiseCancellation } from '../../../js/common/platform/store.js';
-import { Value, Url } from '../../../js/common/core/common.js';
+import { Store, KeyBackupMethod, EmailProvider } from '../../../js/common/platform/store.js';
+import { Value, Url, PromiseCancellation } from '../../../js/common/core/common.js';
 import { Att } from '../../../js/common/core/att.js';
 import { Browser } from '../../../js/common/browser/browser.js';
 import { BrowserMsg, Bm } from '../../../js/common/browser/browser-msg.js';

--- a/extension/js/common/core/common.ts
+++ b/extension/js/common/core/common.ts
@@ -7,6 +7,7 @@ import { base64encode, base64decode } from '../platform/util.js';
 export type Dict<T> = { [key: string]: T; };
 export type UrlParam = string | number | null | undefined | boolean | string[];
 export type UrlParams = Dict<UrlParam>;
+export type PromiseCancellation = { cancel: boolean };
 
 export class Str {
 

--- a/extension/js/common/platform/store.ts
+++ b/extension/js/common/platform/store.ts
@@ -2,7 +2,7 @@
 
 'use strict';
 
-import { Value, Str, Dict } from '../core/common.js';
+import { Value, Str, Dict, PromiseCancellation } from '../core/common.js';
 import { mnemonic } from '../core/mnemonic.js';
 import { KeyInfo, Contact } from '../core/pgp-key.js';
 import { SubscriptionInfo, PaymentMethod, FcUuidAuth, SubscriptionLevel } from '../api/backend.js';
@@ -136,8 +136,6 @@ export type AccountStore = {
   tmp_submit_main?: boolean;
   tmp_submit_all?: boolean;
 };
-
-export type PromiseCancellation = { cancel: boolean };
 
 export class AccountStoreExtension {
   static getEmailAliasesIncludingPrimary = (acct: string, sendAs: Dict<SendAsAlias> | undefined) => {


### PR DESCRIPTION
Issue #2416 
Time Spent: 1h 50m
I fixed those bugs and also added a new thing called `PromiseCencellationToken`, I should have added it because I found some kind of memory leak. In `attachment.ts` and `backup.ts` when we called `Store.waitUntilPassphraseChanged` and clicked `Later` button the cycle that checks if PP changed was working which is bad because how many times I opened modal dialog and clicked `Later` - how many times the function was running continuously.
This `PromiseCencellationToken` fixes that problem.