### PR TITLE
Issue #2358, Sortered and ordered imports alphabetically

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,12 @@ module.exports = {
     'require-atomic-updates': 0,
     'no-empty-pattern': 0,
     'no-fallthrough': 0,
-    'no-undef': 0
+    'no-undef': 0,
+    'sort-imports': ['error', {
+      "ignoreCase": false,
+      "ignoreDeclarationSort": false,
+      "ignoreMemberSort": false,
+      "memberSyntaxSortOrder": ["none", "all", "multiple", "single"]
+    }]
   }
 }

--- a/extension/chrome/dev/export.ts
+++ b/extension/chrome/dev/export.ts
@@ -2,17 +2,18 @@
 
 'use strict';
 
-import { Catch } from '../../js/common/platform/catch.js';
-import { Browser } from '../../js/common/browser/browser.js';
+import { GmailParser, GmailRes } from '../../js/common/api/email_provider/gmail/gmail-parser.js';
+
+import { ApiErr } from '../../js/common/api/error/api-error.js';
 import { Assert } from '../../js/common/assert.js';
 import { Att } from '../../js/common/core/att.js';
+import { Browser } from '../../js/common/browser/browser.js';
 import { Buf } from '../../js/common/core/buf.js';
-import { openpgp } from '../../js/common/core/pgp.js';
-import { Url } from '../../js/common/core/common.js';
+import { Catch } from '../../js/common/platform/catch.js';
 import { Gmail } from '../../js/common/api/email_provider/gmail/gmail.js';
-import { GmailRes, GmailParser } from '../../js/common/api/email_provider/gmail/gmail-parser.js';
 import { Ui } from '../../js/common/browser/ui.js';
-import { ApiErr } from '../../js/common/api/error/api-error.js';
+import { Url } from '../../js/common/core/common.js';
+import { openpgp } from '../../js/common/core/pgp.js';
 
 Catch.try(async () => {
 

--- a/extension/chrome/elements/add_pubkey.ts
+++ b/extension/chrome/elements/add_pubkey.ts
@@ -2,18 +2,19 @@
 
 'use strict';
 
+import { KeyImportUi, UserAlert, } from '../../js/common/ui/key_import_ui.js';
+
+import { Assert } from '../../js/common/assert.js';
+import { AttUI } from '../../js/common/ui/att_ui.js';
+import { BrowserMsg } from '../../js/common/browser/browser-msg.js';
 import { Catch } from '../../js/common/platform/catch.js';
+import { FetchKeyUI } from '../../js/common/ui/fetch_key_ui.js';
+import { PgpKey } from '../../js/common/core/pgp-key.js';
 import { Store } from '../../js/common/platform/store.js';
 import { Ui } from '../../js/common/browser/ui.js';
-import { BrowserMsg } from '../../js/common/browser/browser-msg.js';
-import { Assert } from '../../js/common/assert.js';
-import { KeyImportUi, UserAlert, } from '../../js/common/ui/key_import_ui.js';
-import { AttUI } from '../../js/common/ui/att_ui.js';
-import { Xss } from '../../js/common/platform/xss.js';
-import { FetchKeyUI } from '../../js/common/ui/fetch_key_ui.js';
 import { Url } from '../../js/common/core/common.js';
 import { View } from '../../js/common/view.js';
-import { PgpKey } from '../../js/common/core/pgp-key.js';
+import { Xss } from '../../js/common/platform/xss.js';
 
 View.run(class AddPubkeyView extends View {
   private readonly acctEmail: string;

--- a/extension/chrome/elements/attachment.ts
+++ b/extension/chrome/elements/attachment.ts
@@ -2,20 +2,21 @@
 
 'use strict';
 
-import { Catch } from '../../js/common/platform/catch.js';
-import { Store } from '../../js/common/platform/store.js';
-import { Browser } from '../../js/common/browser/browser.js';
-import { Api } from '../../js/common/api/api.js';
+import { Bm, BrowserMsg } from '../../js/common/browser/browser-msg.js';
 import { DecryptErrTypes, PgpMsg } from '../../js/common/core/pgp-msg.js';
-import { BrowserMsg, Bm } from '../../js/common/browser/browser-msg.js';
-import { Att } from '../../js/common/core/att.js';
-import { Assert } from '../../js/common/assert.js';
-import { Xss } from '../../js/common/platform/xss.js';
-import { Url, PromiseCancellation } from '../../js/common/core/common.js';
-import { Gmail } from '../../js/common/api/email_provider/gmail/gmail.js';
-import { Ui } from '../../js/common/browser/ui.js';
+import { PromiseCancellation, Url } from '../../js/common/core/common.js';
+
+import { Api } from '../../js/common/api/api.js';
 import { ApiErr } from '../../js/common/api/error/api-error.js';
+import { Assert } from '../../js/common/assert.js';
+import { Att } from '../../js/common/core/att.js';
+import { Browser } from '../../js/common/browser/browser.js';
+import { Catch } from '../../js/common/platform/catch.js';
+import { Gmail } from '../../js/common/api/email_provider/gmail/gmail.js';
+import { Store } from '../../js/common/platform/store.js';
+import { Ui } from '../../js/common/browser/ui.js';
 import { View } from '../../js/common/view.js';
+import { Xss } from '../../js/common/platform/xss.js';
 
 View.run(class AttachmentDownloadView extends View {
   private readonly acctEmail: string;

--- a/extension/chrome/elements/backup.ts
+++ b/extension/chrome/elements/backup.ts
@@ -2,16 +2,16 @@
 
 'use strict';
 
-import { Ui } from '../../js/common/browser/ui.js';
-import { mnemonic } from '../../js/common/core/mnemonic.js';
-import { KeyInfo } from '../../js/common/core/pgp-key.js';
-import { BrowserMsg } from '../../js/common/browser/browser-msg.js';
-import { Store } from '../../js/common/platform/store.js';
 import { Assert } from '../../js/common/assert.js';
-import { initPassphraseToggle } from '../../js/common/ui/passphrase_ui.js';
+import { BrowserMsg } from '../../js/common/browser/browser-msg.js';
+import { KeyInfo } from '../../js/common/core/pgp-key.js';
+import { PgpKey } from '../../js/common/core/pgp-key.js';
+import { Store } from '../../js/common/platform/store.js';
+import { Ui } from '../../js/common/browser/ui.js';
 import { Url } from '../../js/common/core/common.js';
 import { View } from '../../js/common/view.js';
-import { PgpKey } from '../../js/common/core/pgp-key.js';
+import { initPassphraseToggle } from '../../js/common/ui/passphrase_ui.js';
+import { mnemonic } from '../../js/common/core/mnemonic.js';
 
 View.run(class BackupView extends View {
   private readonly acctEmail: string;

--- a/extension/chrome/elements/compose.ts
+++ b/extension/chrome/elements/compose.ts
@@ -2,21 +2,22 @@
 
 'use strict';
 
-import { Store, AccountStoreExtension, Scopes, AccountStore } from '../../js/common/platform/store.js';
-import { Ui } from '../../js/common/browser/ui.js';
-import { Composer } from './composer/composer.js';
-import { BrowserMsg } from '../../js/common/browser/browser-msg.js';
-import { openpgp } from '../../js/common/core/pgp.js';
-import { ReplyParams, EmailProviderInterface } from '../../js/common/api/email_provider/email_provider_api.js';
+import { AccountStore, AccountStoreExtension, Scopes, Store } from '../../js/common/platform/store.js';
+import { EmailProviderInterface, ReplyParams } from '../../js/common/api/email_provider/email_provider_api.js';
+
+import { ApiErr } from '../../js/common/api/error/api-error.js';
 import { Assert } from '../../js/common/assert.js';
-import { XssSafeFactory } from '../../js/common/xss_safe_factory.js';
-import { Xss } from '../../js/common/platform/xss.js';
 import { Backend } from '../../js/common/api/backend.js';
-import { Url } from '../../js/common/core/common.js';
-import { View } from '../../js/common/view.js';
+import { BrowserMsg } from '../../js/common/browser/browser-msg.js';
+import { Composer } from './composer/composer.js';
 import { Gmail } from '../../js/common/api/email_provider/gmail/gmail.js';
 import { GmailParser } from '../../js/common/api/email_provider/gmail/gmail-parser.js';
-import { ApiErr } from '../../js/common/api/error/api-error.js';
+import { Ui } from '../../js/common/browser/ui.js';
+import { Url } from '../../js/common/core/common.js';
+import { View } from '../../js/common/view.js';
+import { Xss } from '../../js/common/platform/xss.js';
+import { XssSafeFactory } from '../../js/common/xss_safe_factory.js';
+import { openpgp } from '../../js/common/core/pgp.js';
 
 export type DeterminedMsgHeaders = {
   lastMsgId: string,

--- a/extension/chrome/elements/composer/composer-abstract-component.ts
+++ b/extension/chrome/elements/composer/composer-abstract-component.ts
@@ -2,8 +2,8 @@
 
 'use strict';
 
-import { Composer } from './composer';
 import { ComposeView } from '../../../chrome/elements/compose';
+import { Composer } from './composer';
 
 export abstract class ComposerComponent {
   protected composer: Composer;

--- a/extension/chrome/elements/composer/composer-atts.ts
+++ b/extension/chrome/elements/composer/composer-atts.ts
@@ -2,14 +2,15 @@
 
 'use strict';
 
-import { ComposerComponent } from './composer-abstract-component.js';
-import { Ui } from '../../../js/common/browser/ui.js';
+import { AttLimits, AttUI } from '../../../js/common/ui/att_ui.js';
+
 import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
-import { AttUI, AttLimits } from '../../../js/common/ui/att_ui.js';
 import { Composer } from './composer.js';
+import { ComposerComponent } from './composer-abstract-component.js';
+import { PgpHash } from '../../../js/common/core/pgp-hash.js';
 import { Rules } from '../../../js/common/rules.js';
 import { Store } from '../../../js/common/platform/store.js';
-import { PgpHash } from '../../../js/common/core/pgp-hash.js';
+import { Ui } from '../../../js/common/browser/ui.js';
 
 export class ComposerAtts extends ComposerComponent {
 

--- a/extension/chrome/elements/composer/composer-draft.ts
+++ b/extension/chrome/elements/composer/composer-draft.ts
@@ -2,22 +2,22 @@
 
 'use strict';
 
-import { Xss } from '../../../js/common/platform/xss.js';
-import { Mime } from '../../../js/common/core/mime.js';
-import { Buf } from '../../../js/common/core/buf.js';
-import { PgpMsg } from '../../../js/common/core/pgp-msg.js';
+import { AjaxErr } from '../../../js/common/api/error/api-error-types.js';
+import { ApiErr } from '../../../js/common/api/error/api-error.js';
 import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
+import { Buf } from '../../../js/common/core/buf.js';
 import { Catch } from '../../../js/common/platform/catch.js';
-import { Store } from '../../../js/common/platform/store.js';
 import { Composer } from './composer.js';
 import { ComposerComponent } from './composer-abstract-component.js';
-import { Url } from '../../../js/common/core/common.js';
-import { Recipients } from '../../../js/common/api/email_provider/email_provider_api.js';
-import { Ui } from '../../../js/common/browser/ui.js';
 import { Env } from '../../../js/common/browser/env.js';
-import { ApiErr } from '../../../js/common/api/error/api-error.js';
-import { AjaxErr } from '../../../js/common/api/error/api-error-types.js';
+import { Mime } from '../../../js/common/core/mime.js';
 import { PgpArmor } from '../../../js/common/core/pgp-armor.js';
+import { PgpMsg } from '../../../js/common/core/pgp-msg.js';
+import { Recipients } from '../../../js/common/api/email_provider/email_provider_api.js';
+import { Store } from '../../../js/common/platform/store.js';
+import { Ui } from '../../../js/common/browser/ui.js';
+import { Url } from '../../../js/common/core/common.js';
+import { Xss } from '../../../js/common/platform/xss.js';
 
 export class ComposerDraft extends ComposerComponent {
 

--- a/extension/chrome/elements/composer/composer-errs.ts
+++ b/extension/chrome/elements/composer/composer-errs.ts
@@ -2,16 +2,17 @@
 
 'use strict';
 
-import { ComposerComponent } from './composer-abstract-component.js';
-import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
-import { Catch, UnreportableError } from '../../../js/common/platform/catch.js';
-import { Str } from '../../../js/common/core/common.js';
-import { SendBtnTexts } from './composer-types.js';
-import { KeyInfo } from '../../../js/common/core/pgp-key.js';
-import { Settings } from '../../../js/common/settings.js';
 import { BrowserEventErrHandler, Ui } from '../../../js/common/browser/ui.js';
-import { BrowserExtension } from '../../../js/common/browser/browser-extension.js';
+import { Catch, UnreportableError } from '../../../js/common/platform/catch.js';
+
 import { ApiErr } from '../../../js/common/api/error/api-error.js';
+import { BrowserExtension } from '../../../js/common/browser/browser-extension.js';
+import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
+import { ComposerComponent } from './composer-abstract-component.js';
+import { KeyInfo } from '../../../js/common/core/pgp-key.js';
+import { SendBtnTexts } from './composer-types.js';
+import { Settings } from '../../../js/common/settings.js';
+import { Str } from '../../../js/common/core/common.js';
 import { Xss } from '../../../js/common/platform/xss.js';
 
 export class ComposerUserError extends Error { }

--- a/extension/chrome/elements/composer/composer-input.ts
+++ b/extension/chrome/elements/composer/composer-input.ts
@@ -2,12 +2,13 @@
 
 'use strict';
 
-import { ComposerComponent } from './composer-abstract-component.js';
-import { Xss } from '../../../js/common/platform/xss.js';
 import { NewMsgData, RecipientElement } from './composer-types.js';
-import { Recipients } from '../../../js/common/api/email_provider/email_provider_api.js';
 import { SquireEditor, WillPasteEvent } from '../../../types/squire.js';
+
 import { Catch } from '../../../js/common/platform/catch.js';
+import { ComposerComponent } from './composer-abstract-component.js';
+import { Recipients } from '../../../js/common/api/email_provider/email_provider_api.js';
+import { Xss } from '../../../js/common/platform/xss.js';
 
 export class ComposerInput extends ComposerComponent {
 

--- a/extension/chrome/elements/composer/composer-my-pubkey.ts
+++ b/extension/chrome/elements/composer/composer-my-pubkey.ts
@@ -2,14 +2,14 @@
 
 'use strict';
 
-import { ComposerComponent } from './composer-abstract-component.js';
-import { Ui } from '../../../js/common/browser/ui.js';
-import { Catch } from '../../../js/common/platform/catch.js';
-import { Lang } from '../../../js/common/lang.js';
-import { Store } from '../../../js/common/platform/store.js';
-import { KeyInfo } from '../../../js/common/core/pgp-key.js';
 import { ApiErr } from '../../../js/common/api/error/api-error.js';
+import { Catch } from '../../../js/common/platform/catch.js';
+import { ComposerComponent } from './composer-abstract-component.js';
+import { KeyInfo } from '../../../js/common/core/pgp-key.js';
+import { Lang } from '../../../js/common/lang.js';
 import { PgpKey } from '../../../js/common/core/pgp-key.js';
+import { Store } from '../../../js/common/platform/store.js';
+import { Ui } from '../../../js/common/browser/ui.js';
 
 export class ComposerMyPubkey extends ComposerComponent {
 

--- a/extension/chrome/elements/composer/composer-pwd-or-pubkey-container.ts
+++ b/extension/chrome/elements/composer/composer-pwd-or-pubkey-container.ts
@@ -2,8 +2,9 @@
 
 'use strict';
 
-import { ComposerComponent } from './composer-abstract-component.js';
 import { RecipientStatuses, SendBtnTexts } from './composer-types.js';
+
+import { ComposerComponent } from './composer-abstract-component.js';
 import { KeyImportUi } from '../../../js/common/ui/key_import_ui.js';
 import { Store } from '../../../js/common/platform/store.js';
 

--- a/extension/chrome/elements/composer/composer-quote.ts
+++ b/extension/chrome/elements/composer/composer-quote.ts
@@ -2,21 +2,22 @@
 
 'use strict';
 
-import { MessageToReplyOrForward } from './composer-types.js';
-import { Xss } from '../../../js/common/platform/xss.js';
-import { Str } from '../../../js/common/core/common.js';
-import { Ui } from '../../../js/common/browser/ui.js';
-import { ProgressCb } from '../../../js/common/api/api.js';
+import { Bm, BrowserMsg } from '../../../js/common/browser/browser-msg.js';
+import { FormatError, PgpMsg } from '../../../js/common/core/pgp-msg.js';
+
+import { ApiErr } from '../../../js/common/api/error/api-error.js';
+import { Buf } from '../../../js/common/core/buf.js';
 import { Catch } from '../../../js/common/platform/catch.js';
 import { ComposerComponent } from './composer-abstract-component.js';
+import { MessageToReplyOrForward } from './composer-types.js';
 import { Mime } from '../../../js/common/core/mime.js';
-import { Buf } from '../../../js/common/core/buf.js';
-import { FormatError, PgpMsg } from '../../../js/common/core/pgp-msg.js';
-import { BrowserMsg, Bm } from '../../../js/common/browser/browser-msg.js';
-import { Store } from '../../../js/common/platform/store.js';
-import { ApiErr } from '../../../js/common/api/error/api-error.js';
 import { MsgBlock } from '../../../js/common/core/msg-block.js';
 import { MsgBlockParser } from '../../../js/common/core/msg-block-parser.js';
+import { ProgressCb } from '../../../js/common/api/api.js';
+import { Store } from '../../../js/common/platform/store.js';
+import { Str } from '../../../js/common/core/common.js';
+import { Ui } from '../../../js/common/browser/ui.js';
+import { Xss } from '../../../js/common/platform/xss.js';
 
 export class ComposerQuote extends ComposerComponent {
   public messageToReplyOrForward: MessageToReplyOrForward | undefined;

--- a/extension/chrome/elements/composer/composer-recipients.ts
+++ b/extension/chrome/elements/composer/composer-recipients.ts
@@ -2,24 +2,25 @@
 
 'use strict';
 
-import { Composer } from './composer.js';
-import { Str, Value } from '../../../js/common/core/common.js';
+import { ChunkedCb, RecipientType } from '../../../js/common/api/api.js';
+import { Contact, PgpKey } from '../../../js/common/core/pgp-key.js';
+import { PUBKEY_LOOKUP_RESULT_FAIL, PUBKEY_LOOKUP_RESULT_WRONG } from './composer-errs.js';
 import { ProviderContactsQuery, Recipients } from '../../../js/common/api/email_provider/email_provider_api.js';
-import { Xss } from '../../../js/common/platform/xss.js';
-import { Ui } from '../../../js/common/browser/ui.js';
+import { RecipientElement, RecipientStatus, RecipientStatuses } from './composer-types.js';
+import { Str, Value } from '../../../js/common/core/common.js';
+
+import { ApiErr } from '../../../js/common/api/error/api-error.js';
+import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
+import { Catch } from '../../../js/common/platform/catch.js';
+import { Composer } from './composer.js';
+import { ComposerComponent } from './composer-abstract-component.js';
 import { Google } from '../../../js/common/api/google.js';
 import { GoogleAuth } from '../../../js/common/api/google-auth.js';
 import { Lang } from '../../../js/common/lang.js';
-import { RecipientElement, RecipientStatus, RecipientStatuses } from './composer-types.js';
-import { ComposerComponent } from './composer-abstract-component.js';
-import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
-import { Catch } from '../../../js/common/platform/catch.js';
-import { moveElementInArray } from '../../../js/common/platform/util.js';
-import { RecipientType, ChunkedCb } from '../../../js/common/api/api.js';
 import { Store } from '../../../js/common/platform/store.js';
-import { PUBKEY_LOOKUP_RESULT_FAIL, PUBKEY_LOOKUP_RESULT_WRONG } from './composer-errs.js';
-import { ApiErr } from '../../../js/common/api/error/api-error.js';
-import { PgpKey, Contact } from '../../../js/common/core/pgp-key.js';
+import { Ui } from '../../../js/common/browser/ui.js';
+import { Xss } from '../../../js/common/platform/xss.js';
+import { moveElementInArray } from '../../../js/common/platform/util.js';
 
 export class ComposerRecipients extends ComposerComponent {
   private readonly failedLookupEmails: string[] = [];

--- a/extension/chrome/elements/composer/composer-render.ts
+++ b/extension/chrome/elements/composer/composer-render.ts
@@ -2,19 +2,20 @@
 
 'use strict';
 
-import { ComposerComponent } from './composer-abstract-component.js';
-import { Ui } from '../../../js/common/browser/ui.js';
-import { RecipientType } from '../../../js/common/api/api.js';
-import { Xss } from '../../../js/common/platform/xss.js';
-import { Catch } from '../../../js/common/platform/catch.js';
-import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
-import { Lang } from '../../../js/common/lang.js';
-import { KeyImportUi } from '../../../js/common/ui/key_import_ui.js';
-import { Str } from '../../../js/common/core/common.js';
-import { Store } from '../../../js/common/platform/store.js';
-import { SendableMsg, Recipients } from '../../../js/common/api/email_provider/email_provider_api.js';
+import { Recipients, SendableMsg } from '../../../js/common/api/email_provider/email_provider_api.js';
+
 import { Att } from '../../../js/common/core/att.js';
+import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
+import { Catch } from '../../../js/common/platform/catch.js';
+import { ComposerComponent } from './composer-abstract-component.js';
+import { KeyImportUi } from '../../../js/common/ui/key_import_ui.js';
+import { Lang } from '../../../js/common/lang.js';
 import { PgpKey } from '../../../js/common/core/pgp-key.js';
+import { RecipientType } from '../../../js/common/api/api.js';
+import { Store } from '../../../js/common/platform/store.js';
+import { Str } from '../../../js/common/core/common.js';
+import { Ui } from '../../../js/common/browser/ui.js';
+import { Xss } from '../../../js/common/platform/xss.js';
 
 export class ComposerRender extends ComposerComponent {
 

--- a/extension/chrome/elements/composer/composer-send-btn-popover.ts
+++ b/extension/chrome/elements/composer/composer-send-btn-popover.ts
@@ -2,12 +2,13 @@
 
 'use strict';
 
-import { ComposerComponent } from './composer-abstract-component.js';
-import { PopoverOpt, PopoverChoices } from './composer-types.js';
-import { Xss } from '../../../js/common/platform/xss.js';
-import { Lang } from '../../../js/common/lang.js';
+import { PopoverChoices, PopoverOpt } from './composer-types.js';
+
 import { Catch } from '../../../js/common/platform/catch.js';
+import { ComposerComponent } from './composer-abstract-component.js';
+import { Lang } from '../../../js/common/lang.js';
 import { Store } from '../../../js/common/platform/store.js';
+import { Xss } from '../../../js/common/platform/xss.js';
 
 export class ComposerSendBtnPopover extends ComposerComponent {
 

--- a/extension/chrome/elements/composer/composer-send-btn.ts
+++ b/extension/chrome/elements/composer/composer-send-btn.ts
@@ -2,22 +2,22 @@
 
 'use strict';
 
-import { ComposerComponent } from './composer-abstract-component.js';
-import { SendBtnTexts } from './composer-types.js';
-import { Composer } from './composer.js';
-import { Xss } from '../../../js/common/platform/xss.js';
-import { Ui } from '../../../js/common/browser/ui.js';
-import { Catch } from '../../../js/common/platform/catch.js';
-import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
-import { KeyInfo } from '../../../js/common/core/pgp-key.js';
-import { Store } from '../../../js/common/platform/store.js';
-import { SendableMsg } from '../../../js/common/api/email_provider/email_provider_api.js';
-import { Att } from '../../../js/common/core/att.js';
-import { GeneralMailFormatter } from './formatters/composer-mail-formatter.js';
-import { ComposerSendBtnPopover } from './composer-send-btn-popover.js';
-import { GmailRes } from '../../../js/common/api/email_provider/gmail/gmail-parser.js';
 import { ApiErr } from '../../../js/common/api/error/api-error.js';
+import { Att } from '../../../js/common/core/att.js';
+import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
+import { Catch } from '../../../js/common/platform/catch.js';
+import { Composer } from './composer.js';
+import { ComposerComponent } from './composer-abstract-component.js';
+import { ComposerSendBtnPopover } from './composer-send-btn-popover.js';
+import { GeneralMailFormatter } from './formatters/composer-mail-formatter.js';
+import { GmailRes } from '../../../js/common/api/email_provider/gmail/gmail-parser.js';
+import { KeyInfo } from '../../../js/common/core/pgp-key.js';
 import { PgpKey } from '../../../js/common/core/pgp-key.js';
+import { SendBtnTexts } from './composer-types.js';
+import { SendableMsg } from '../../../js/common/api/email_provider/email_provider_api.js';
+import { Store } from '../../../js/common/platform/store.js';
+import { Ui } from '../../../js/common/browser/ui.js';
+import { Xss } from '../../../js/common/platform/xss.js';
 
 export class ComposerSendBtn extends ComposerComponent {
 

--- a/extension/chrome/elements/composer/composer-sender.ts
+++ b/extension/chrome/elements/composer/composer-sender.ts
@@ -2,13 +2,13 @@
 
 'use strict';
 
+import { ApiErr } from '../../../js/common/api/error/api-error.js';
+import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
 import { ComposerComponent } from './composer-abstract-component.js';
-import { Settings } from '../../../js/common/settings.js';
-import { Xss } from '../../../js/common/platform/xss.js';
 import { Dict } from '../../../js/common/core/common.js';
 import { SendAsAlias } from '../../../js/common/platform/store.js';
-import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
-import { ApiErr } from '../../../js/common/api/error/api-error.js';
+import { Settings } from '../../../js/common/settings.js';
+import { Xss } from '../../../js/common/platform/xss.js';
 
 export class ComposerSender extends ComposerComponent {
 

--- a/extension/chrome/elements/composer/composer-size.ts
+++ b/extension/chrome/elements/composer/composer-size.ts
@@ -2,9 +2,9 @@
 
 'use strict';
 
-import { ComposerComponent } from './composer-abstract-component.js';
 import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
 import { Catch } from '../../../js/common/platform/catch.js';
+import { ComposerComponent } from './composer-abstract-component.js';
 
 export class ComposerSize extends ComposerComponent {
 

--- a/extension/chrome/elements/composer/composer-storage.ts
+++ b/extension/chrome/elements/composer/composer-storage.ts
@@ -2,17 +2,18 @@
 
 'use strict';
 
-import { ComposerComponent } from './composer-abstract-component.js';
-import { Store, SendAsAlias } from '../../../js/common/platform/store.js';
+import { Bm, BrowserMsg } from '../../../js/common/browser/browser-msg.js';
+import { Contact, KeyInfo } from '../../../js/common/core/pgp-key.js';
+import { Keyserver, PubkeySearchResult } from '../../../js/common/api/keyserver.js';
+import { SendAsAlias, Store } from '../../../js/common/platform/store.js';
+
+import { ApiErr } from '../../../js/common/api/error/api-error.js';
 import { Assert } from '../../../js/common/assert.js';
-import { KeyInfo, Contact } from '../../../js/common/core/pgp-key.js';
-import { Dict } from '../../../js/common/core/common.js';
 import { Catch } from '../../../js/common/platform/catch.js';
 import { CollectPubkeysResult } from './composer-types.js';
-import { PubkeySearchResult, Keyserver } from '../../../js/common/api/keyserver.js';
+import { ComposerComponent } from './composer-abstract-component.js';
+import { Dict } from '../../../js/common/core/common.js';
 import { PUBKEY_LOOKUP_RESULT_FAIL } from './composer-errs.js';
-import { BrowserMsg, Bm } from '../../../js/common/browser/browser-msg.js';
-import { ApiErr } from '../../../js/common/api/error/api-error.js';
 import { PgpKey } from '../../../js/common/core/pgp-key.js';
 import { openpgp } from '../../../js/common/core/pgp.js';
 

--- a/extension/chrome/elements/composer/composer.ts
+++ b/extension/chrome/elements/composer/composer.ts
@@ -2,24 +2,24 @@
 
 'use strict';
 
-import { Ui } from '../../../js/common/browser/ui.js';
-import { ComposerDraft } from './composer-draft.js';
-import { ComposerQuote } from './composer-quote.js';
-import { ComposerRecipients } from './composer-recipients.js';
-import { ComposerSendBtn } from './composer-send-btn.js';
-import { ComposerPwdOrPubkeyContainer } from './composer-pwd-or-pubkey-container.js';
-import { ComposerSize } from './composer-size.js';
-import { ComposerSender } from './composer-sender.js';
+import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
+import { Catch } from '../../../js/common/platform/catch.js';
+import { ComposeView } from '../../../js/common/../../chrome/elements/compose.js';
 import { ComposerAtts } from './composer-atts.js';
+import { ComposerDraft } from './composer-draft.js';
 import { ComposerErrs } from './composer-errs.js';
 import { ComposerInput } from './composer-input.js';
-import { ComposerRender } from './composer-render.js';
-import { Catch } from '../../../js/common/platform/catch.js';
 import { ComposerMyPubkey } from './composer-my-pubkey.js';
+import { ComposerPwdOrPubkeyContainer } from './composer-pwd-or-pubkey-container.js';
+import { ComposerQuote } from './composer-quote.js';
+import { ComposerRecipients } from './composer-recipients.js';
+import { ComposerRender } from './composer-render.js';
+import { ComposerSendBtn } from './composer-send-btn.js';
+import { ComposerSender } from './composer-sender.js';
+import { ComposerSize } from './composer-size.js';
 import { ComposerStorage } from './composer-storage.js';
-import { ComposeView } from '../../../js/common/../../chrome/elements/compose.js';
-import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
 import { EmailProviderInterface } from '../../../js/common/api/email_provider/email_provider_api.js';
+import { Ui } from '../../../js/common/browser/ui.js';
 
 export class Composer {
 

--- a/extension/chrome/elements/composer/formatters/base-mail-formatter.ts
+++ b/extension/chrome/elements/composer/formatters/base-mail-formatter.ts
@@ -2,9 +2,9 @@
 
 'use strict';
 
+import { Composer } from '../composer.js';
 import { NewMsgData } from '../composer-types.js';
 import { SendableMsg } from '../../../../js/common/api/email_provider/email_provider_api.js';
-import { Composer } from '../composer.js';
 
 export interface MailFormatterInterface {
   sendableMsg(newMsgData: NewMsgData, signingPrv?: OpenPGP.key.Key): Promise<SendableMsg>;

--- a/extension/chrome/elements/composer/formatters/composer-mail-formatter.ts
+++ b/extension/chrome/elements/composer/formatters/composer-mail-formatter.ts
@@ -2,13 +2,13 @@
 
 'use strict';
 
-import { NewMsgData } from "../composer-types.js";
-import { KeyInfo } from "../../../../js/common/core/pgp-key.js";
 import { Composer } from "../composer.js";
-import { PlainMsgMailFormatter } from './plain-mail-msg-formatter.js';
-import { SignedMsgMailFormatter } from './signed-msg-mail-formatter.js';
 import { EncryptedMsgMailFormatter } from './encrypted-mail-msg-formatter.js';
+import { KeyInfo } from "../../../../js/common/core/pgp-key.js";
+import { NewMsgData } from "../composer-types.js";
+import { PlainMsgMailFormatter } from './plain-mail-msg-formatter.js';
 import { SendableMsg } from '../../../../js/common/api/email_provider/email_provider_api.js';
+import { SignedMsgMailFormatter } from './signed-msg-mail-formatter.js';
 
 export class GeneralMailFormatter {
 

--- a/extension/chrome/elements/composer/formatters/encrypted-mail-msg-formatter.ts
+++ b/extension/chrome/elements/composer/formatters/encrypted-mail-msg-formatter.ts
@@ -2,26 +2,27 @@
 
 'use strict';
 
-import { NewMsgData, PubkeyResult, SendBtnTexts } from '../composer-types.js';
-import { SendableMsg } from '../../../../js/common/api/email_provider/email_provider_api.js';
-import { Composer } from '../composer.js';
-import { PgpMsg } from '../../../../js/common/core/pgp-msg.js';
-import { Catch } from '../../../../js/common/platform/catch.js';
-import { SendableMsgBody, Mime } from '../../../../js/common/core/mime.js';
-import { Buf } from '../../../../js/common/core/buf.js';
-import { Backend, BackendRes, AwsS3UploadItem, FcUuidAuth } from '../../../../js/common/api/backend.js';
-import { Store, Subscription } from '../../../../js/common/platform/store.js';
-import { Value, Str } from '../../../../js/common/core/common.js';
-import { Ui } from '../../../../js/common/browser/ui.js';
-import { Att } from '../../../../js/common/core/att.js';
-import { Xss } from '../../../../js/common/platform/xss.js';
-import { Lang } from '../../../../js/common/lang.js';
-import { ComposerResetBtnTrigger, ComposerUserError } from '../composer-errs.js';
+import { AwsS3UploadItem, Backend, BackendRes, FcUuidAuth } from '../../../../js/common/api/backend.js';
 import { BaseMailFormatter, MailFormatterInterface } from './base-mail-formatter.js';
-import { Settings } from '../../../../js/common/settings.js';
-import { PgpArmor } from '../../../../js/common/core/pgp-armor.js';
+import { ComposerResetBtnTrigger, ComposerUserError } from '../composer-errs.js';
+import { Mime, SendableMsgBody } from '../../../../js/common/core/mime.js';
+import { NewMsgData, PubkeyResult, SendBtnTexts } from '../composer-types.js';
+import { Store, Subscription } from '../../../../js/common/platform/store.js';
+import { Str, Value } from '../../../../js/common/core/common.js';
+
 import { ApiErr } from '../../../../js/common/api/error/api-error.js';
+import { Att } from '../../../../js/common/core/att.js';
+import { Buf } from '../../../../js/common/core/buf.js';
+import { Catch } from '../../../../js/common/platform/catch.js';
+import { Composer } from '../composer.js';
+import { Lang } from '../../../../js/common/lang.js';
+import { PgpArmor } from '../../../../js/common/core/pgp-armor.js';
 import { PgpKey } from '../../../../js/common/core/pgp-key.js';
+import { PgpMsg } from '../../../../js/common/core/pgp-msg.js';
+import { SendableMsg } from '../../../../js/common/api/email_provider/email_provider_api.js';
+import { Settings } from '../../../../js/common/settings.js';
+import { Ui } from '../../../../js/common/browser/ui.js';
+import { Xss } from '../../../../js/common/platform/xss.js';
 import { openpgp } from '../../../../js/common/core/pgp.js';
 
 export class EncryptedMsgMailFormatter extends BaseMailFormatter implements MailFormatterInterface {

--- a/extension/chrome/elements/composer/formatters/plain-mail-msg-formatter.ts
+++ b/extension/chrome/elements/composer/formatters/plain-mail-msg-formatter.ts
@@ -2,10 +2,11 @@
 
 'use strict';
 
-import { SendableMsg } from '../../../../js/common/api/email_provider/email_provider_api.js';
-import { SendBtnTexts, NewMsgData } from '../composer-types.js';
-import { SendableMsgBody } from '../../../../js/common/core/mime.js';
 import { BaseMailFormatter, MailFormatterInterface } from './base-mail-formatter.js';
+import { NewMsgData, SendBtnTexts } from '../composer-types.js';
+
+import { SendableMsg } from '../../../../js/common/api/email_provider/email_provider_api.js';
+import { SendableMsgBody } from '../../../../js/common/core/mime.js';
 
 export class PlainMsgMailFormatter extends BaseMailFormatter implements MailFormatterInterface {
 

--- a/extension/chrome/elements/composer/formatters/signed-msg-mail-formatter.ts
+++ b/extension/chrome/elements/composer/formatters/signed-msg-mail-formatter.ts
@@ -2,12 +2,13 @@
 
 'use strict';
 
-import { NewMsgData } from '../composer-types.js';
-import { SendableMsg } from '../../../../js/common/api/email_provider/email_provider_api.js';
-import { PgpMsg } from '../../../../js/common/core/pgp-msg.js';
+import { BaseMailFormatter, MailFormatterInterface } from './base-mail-formatter.js';
+
 import { BrowserWindow } from '../../../../js/common/browser/browser-window.js';
 import { Catch } from '../../../../js/common/platform/catch.js';
-import { BaseMailFormatter, MailFormatterInterface } from './base-mail-formatter.js';
+import { NewMsgData } from '../composer-types.js';
+import { PgpMsg } from '../../../../js/common/core/pgp-msg.js';
+import { SendableMsg } from '../../../../js/common/api/email_provider/email_provider_api.js';
 import { SendableMsgBody } from '../../../../js/common/core/mime.js';
 import { Store } from '../../../../js/common/platform/store.js';
 

--- a/extension/chrome/elements/passphrase.ts
+++ b/extension/chrome/elements/passphrase.ts
@@ -2,17 +2,18 @@
 
 'use strict';
 
-import { Catch } from '../../js/common/platform/catch.js';
-import { Store, StorageType } from '../../js/common/platform/store.js';
-import { Ui } from '../../js/common/browser/ui.js';
-import { mnemonic } from '../../js/common/core/mnemonic.js';
-import { BrowserMsg } from '../../js/common/browser/browser-msg.js';
+import { KeyInfo, PgpKey } from '../../js/common/core/pgp-key.js';
+import { StorageType, Store } from '../../js/common/platform/store.js';
+
 import { Assert } from '../../js/common/assert.js';
-import { initPassphraseToggle } from '../../js/common/ui/passphrase_ui.js';
-import { Xss } from '../../js/common/platform/xss.js';
+import { BrowserMsg } from '../../js/common/browser/browser-msg.js';
+import { Catch } from '../../js/common/platform/catch.js';
+import { Ui } from '../../js/common/browser/ui.js';
 import { Url } from '../../js/common/core/common.js';
 import { View } from '../../js/common/view.js';
-import { PgpKey, KeyInfo } from '../../js/common/core/pgp-key.js';
+import { Xss } from '../../js/common/platform/xss.js';
+import { initPassphraseToggle } from '../../js/common/ui/passphrase_ui.js';
+import { mnemonic } from '../../js/common/core/mnemonic.js';
 import { openpgp } from '../../js/common/core/pgp.js';
 
 View.run(class PassphraseView extends View {

--- a/extension/chrome/elements/pgp_block.ts
+++ b/extension/chrome/elements/pgp_block.ts
@@ -2,21 +2,22 @@
 
 'use strict';
 
-import { Store } from '../../js/common/platform/store.js';
 import { Str, Url } from '../../js/common/core/common.js';
-import { Ui } from '../../js/common/browser/ui.js';
-import { Lang } from '../../js/common/lang.js';
-import { Buf } from '../../js/common/core/buf.js';
+
 import { Assert } from '../../js/common/assert.js';
-import { View } from '../../js/common/view.js';
+import { Buf } from '../../js/common/core/buf.js';
+import { Gmail } from '../../js/common/api/email_provider/gmail/gmail.js';
+import { Lang } from '../../js/common/lang.js';
 import { PgpBlockViewAttachmentsModule } from './pgp_block_modules/pgp_block_attachmens_module.js';
-import { PgpBlockViewSignatureModule } from './pgp_block_modules/pgp_block_signature_module.js';
+import { PgpBlockViewDecryptModule } from './pgp_block_modules/pgp_block_decrypt_module.js';
+import { PgpBlockViewErrorModule } from './pgp_block_modules/pgp_block_error_module.js';
 import { PgpBlockViewPwdEncryptedMsgModule } from './pgp_block_modules/pgp_block_pwd_encrypted_msg_module.js';
 import { PgpBlockViewQuoteModule } from './pgp_block_modules/pgp_block_quote_module.js';
-import { PgpBlockViewErrorModule } from './pgp_block_modules/pgp_block_error_module.js';
 import { PgpBlockViewRenderModule } from './pgp_block_modules/pgp_block_render_module.js';
-import { PgpBlockViewDecryptModule } from './pgp_block_modules/pgp_block_decrypt_module.js';
-import { Gmail } from '../../js/common/api/email_provider/gmail/gmail.js';
+import { PgpBlockViewSignatureModule } from './pgp_block_modules/pgp_block_signature_module.js';
+import { Store } from '../../js/common/platform/store.js';
+import { Ui } from '../../js/common/browser/ui.js';
+import { View } from '../../js/common/view.js';
 
 export class PgpBlockView extends View {
 

--- a/extension/chrome/elements/pgp_block_modules/pgp_block_attachmens_module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp_block_attachmens_module.ts
@@ -2,15 +2,15 @@
 
 'use strict';
 
+import { Api } from '../../../js/common/api/api.js';
 import { Att } from '../../../js/common/core/att.js';
+import { Browser } from '../../../js/common/browser/browser.js';
+import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
 import { PgpBlockView } from '../pgp_block';
 import { Store } from '../../../js/common/platform/store.js';
-import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
-import { Browser } from '../../../js/common/browser/browser.js';
-import { Xss } from '../../../js/common/platform/xss.js';
 import { Str } from '../../../js/common/core/common.js';
-import { Api } from '../../../js/common/api/api.js';
 import { Ui } from '../../../js/common/browser/ui.js';
+import { Xss } from '../../../js/common/platform/xss.js';
 
 export class PgpBlockViewAttachmentsModule {
 

--- a/extension/chrome/elements/pgp_block_modules/pgp_block_decrypt_module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp_block_decrypt_module.ts
@@ -2,18 +2,18 @@
 
 'use strict';
 
-import { PgpBlockView } from '../pgp_block.js';
-import { Store } from '../../../js/common/platform/store.js';
-import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
-import { Ui } from '../../../js/common/browser/ui.js';
 import { Api } from '../../../js/common/api/api.js';
-import { Xss } from '../../../js/common/platform/xss.js';
 import { Backend } from '../../../js/common/api/backend.js';
-import { Lang } from '../../../js/common/lang.js';
+import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
 import { Buf } from '../../../js/common/core/buf.js';
-import { Mime } from '../../../js/common/core/mime.js';
 import { DecryptErrTypes } from '../../../js/common/core/pgp-msg.js';
 import { GmailResponseFormat } from '../../../js/common/api/email_provider/gmail/gmail.js';
+import { Lang } from '../../../js/common/lang.js';
+import { Mime } from '../../../js/common/core/mime.js';
+import { PgpBlockView } from '../pgp_block.js';
+import { Store } from '../../../js/common/platform/store.js';
+import { Ui } from '../../../js/common/browser/ui.js';
+import { Xss } from '../../../js/common/platform/xss.js';
 
 export class PgpBlockViewDecryptModule {
 

--- a/extension/chrome/elements/pgp_block_modules/pgp_block_error_module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp_block_error_module.ts
@@ -2,15 +2,15 @@
 
 'use strict';
 
-import { PgpBlockView } from '../pgp_block.js';
-import { Xss } from '../../../js/common/platform/xss.js';
+import { ApiErr } from '../../../js/common/api/error/api-error.js';
 import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
 import { Catch } from '../../../js/common/platform/catch.js';
 import { FormatError } from '../../../js/common/core/pgp-msg.js';
 import { Lang } from '../../../js/common/lang.js';
+import { PgpBlockView } from '../pgp_block.js';
 import { Store } from '../../../js/common/platform/store.js';
 import { Ui } from '../../../js/common/browser/ui.js';
-import { ApiErr } from '../../../js/common/api/error/api-error.js';
+import { Xss } from '../../../js/common/platform/xss.js';
 
 export class PgpBlockViewErrorModule {
 

--- a/extension/chrome/elements/pgp_block_modules/pgp_block_pwd_encrypted_msg_module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp_block_pwd_encrypted_msg_module.ts
@@ -2,18 +2,19 @@
 
 'use strict';
 
-import { PgpBlockView } from '../pgp_block';
-import { Store } from '../../../js/common/platform/store.js';
-import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
-import { Ui } from '../../../js/common/browser/ui.js';
-import { Str } from '../../../js/common/core/common.js';
-import { Catch } from '../../../js/common/platform/catch.js';
-import { Xss } from '../../../js/common/platform/xss.js';
 import { Backend, BackendRes } from '../../../js/common/api/backend.js';
-import { Settings } from '../../../js/common/settings.js';
-import { Lang } from '../../../js/common/lang.js';
+
 import { ApiErr } from '../../../js/common/api/error/api-error.js';
 import { BackendAuthErr } from '../../../js/common/api/error/api-error-types.js';
+import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
+import { Catch } from '../../../js/common/platform/catch.js';
+import { Lang } from '../../../js/common/lang.js';
+import { PgpBlockView } from '../pgp_block';
+import { Settings } from '../../../js/common/settings.js';
+import { Store } from '../../../js/common/platform/store.js';
+import { Str } from '../../../js/common/core/common.js';
+import { Ui } from '../../../js/common/browser/ui.js';
+import { Xss } from '../../../js/common/platform/xss.js';
 
 export class PgpBlockViewPwdEncryptedMsgModule {
 

--- a/extension/chrome/elements/pgp_block_modules/pgp_block_render_module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp_block_render_module.ts
@@ -2,17 +2,18 @@
 
 'use strict';
 
-import { PgpBlockView } from '../pgp_block.js';
-import { Xss } from '../../../js/common/platform/xss.js';
-import { Mime } from '../../../js/common/core/mime.js';
+import { PgpMsg, VerifyRes } from '../../../js/common/core/pgp-msg.js';
+
 import { Att } from '../../../js/common/core/att.js';
-import { Buf } from '../../../js/common/core/buf.js';
-import { VerifyRes, PgpMsg } from '../../../js/common/core/pgp-msg.js';
 import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
-import { Ui } from '../../../js/common/browser/ui.js';
-import { Store } from '../../../js/common/platform/store.js';
+import { Buf } from '../../../js/common/core/buf.js';
 import { Catch } from '../../../js/common/platform/catch.js';
+import { Mime } from '../../../js/common/core/mime.js';
 import { MsgBlock } from '../../../js/common/core/msg-block.js';
+import { PgpBlockView } from '../pgp_block.js';
+import { Store } from '../../../js/common/platform/store.js';
+import { Ui } from '../../../js/common/browser/ui.js';
+import { Xss } from '../../../js/common/platform/xss.js';
 
 export class PgpBlockViewRenderModule {
 

--- a/extension/chrome/elements/pgp_block_modules/pgp_block_signature_module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp_block_signature_module.ts
@@ -2,16 +2,16 @@
 
 'use strict';
 
-import { PgpBlockView } from '../pgp_block';
-import { Store } from '../../../js/common/platform/store.js';
+import { ApiErr } from '../../../js/common/api/error/api-error.js';
 import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
-import { Ui } from '../../../js/common/browser/ui.js';
-import { Str } from '../../../js/common/core/common.js';
-import { VerifyRes } from '../../../js/common/core/pgp-msg.js';
 import { Catch } from '../../../js/common/platform/catch.js';
 import { Keyserver } from '../../../js/common/api/keyserver.js';
-import { ApiErr } from '../../../js/common/api/error/api-error.js';
+import { PgpBlockView } from '../pgp_block';
 import { PgpKey } from '../../../js/common/core/pgp-key.js';
+import { Store } from '../../../js/common/platform/store.js';
+import { Str } from '../../../js/common/core/common.js';
+import { Ui } from '../../../js/common/browser/ui.js';
+import { VerifyRes } from '../../../js/common/core/pgp-msg.js';
 
 export class PgpBlockViewSignatureModule {
 

--- a/extension/chrome/elements/pgp_pubkey.ts
+++ b/extension/chrome/elements/pgp_pubkey.ts
@@ -2,19 +2,19 @@
 
 'use strict';
 
+import { Assert } from '../../js/common/assert.js';
+import { BrowserMsg } from '../../js/common/browser/browser-msg.js';
 import { Catch } from '../../js/common/platform/catch.js';
+import { Contact } from '../../js/common/core/pgp-key.js';
+import { PgpArmor } from '../../js/common/core/pgp-armor.js';
+import { PgpKey } from '../../js/common/core/pgp-key.js';
 import { Store } from '../../js/common/platform/store.js';
 import { Str } from '../../js/common/core/common.js';
 import { Ui } from '../../js/common/browser/ui.js';
-import { mnemonic } from '../../js/common/core/mnemonic.js';
-import { Contact } from '../../js/common/core/pgp-key.js';
-import { BrowserMsg } from '../../js/common/browser/browser-msg.js';
-import { Assert } from '../../js/common/assert.js';
-import { Xss } from '../../js/common/platform/xss.js';
 import { Url } from '../../js/common/core/common.js';
 import { View } from '../../js/common/view.js';
-import { PgpArmor } from '../../js/common/core/pgp-armor.js';
-import { PgpKey } from '../../js/common/core/pgp-key.js';
+import { Xss } from '../../js/common/platform/xss.js';
+import { mnemonic } from '../../js/common/core/mnemonic.js';
 import { openpgp } from '../../js/common/core/pgp.js';
 
 // todo - this should use KeyImportUI for consistency.

--- a/extension/chrome/elements/subscribe.ts
+++ b/extension/chrome/elements/subscribe.ts
@@ -2,19 +2,20 @@
 
 'use strict';
 
-import { Catch } from '../../js/common/platform/catch.js';
-import { Store } from '../../js/common/platform/store.js';
-import { Str, Url } from '../../js/common/core/common.js';
-import { Ui } from '../../js/common/browser/ui.js';
-import { Lang } from '../../js/common/lang.js';
-import { BrowserMsg, Bm } from '../../js/common/browser/browser-msg.js';
 import { Backend, FcUuidAuth, PaymentMethod, SubscriptionLevel } from '../../js/common/api/backend.js';
-import { Assert } from '../../js/common/assert.js';
-import { XssSafeFactory } from '../../js/common/xss_safe_factory.js';
-import { Xss } from '../../js/common/platform/xss.js';
-import { Settings } from '../../js/common/settings.js';
-import { View } from '../../js/common/view.js';
+import { Bm, BrowserMsg } from '../../js/common/browser/browser-msg.js';
+import { Str, Url } from '../../js/common/core/common.js';
+
 import { ApiErr } from '../../js/common/api/error/api-error.js';
+import { Assert } from '../../js/common/assert.js';
+import { Catch } from '../../js/common/platform/catch.js';
+import { Lang } from '../../js/common/lang.js';
+import { Settings } from '../../js/common/settings.js';
+import { Store } from '../../js/common/platform/store.js';
+import { Ui } from '../../js/common/browser/ui.js';
+import { View } from '../../js/common/view.js';
+import { Xss } from '../../js/common/platform/xss.js';
+import { XssSafeFactory } from '../../js/common/xss_safe_factory.js';
 
 // todo - this page should be removed, link from settings should point to flowcrypt.com/account once available
 

--- a/extension/chrome/popups/default.ts
+++ b/extension/chrome/popups/default.ts
@@ -2,10 +2,10 @@
 
 'use strict';
 
+import { BrowserMsg } from '../../js/common/browser/browser-msg.js';
 import { Catch } from '../../js/common/platform/catch.js';
 import { Store } from '../../js/common/platform/store.js';
 import { Ui } from '../../js/common/browser/ui.js';
-import { BrowserMsg } from '../../js/common/browser/browser-msg.js';
 import { View } from '../../js/common/view.js';
 
 View.run(class DefaultPopupView extends View {

--- a/extension/chrome/popups/select_account.ts
+++ b/extension/chrome/popups/select_account.ts
@@ -2,14 +2,14 @@
 
 'use strict';
 
-import { Store } from '../../js/common/platform/store.js';
-import { Ui } from '../../js/common/browser/ui.js';
+import { Assert } from '../../js/common/assert.js';
 import { BrowserMsg } from '../../js/common/browser/browser-msg.js';
 import { Catch } from '../../js/common/platform/catch.js';
-import { Assert } from '../../js/common/assert.js';
-import { Xss } from '../../js/common/platform/xss.js';
+import { Store } from '../../js/common/platform/store.js';
+import { Ui } from '../../js/common/browser/ui.js';
 import { Url } from '../../js/common/core/common.js';
 import { View } from '../../js/common/view.js';
+import { Xss } from '../../js/common/platform/xss.js';
 
 View.run(class SelectAcctPopupView extends View {
 

--- a/extension/chrome/settings/fatal.ts
+++ b/extension/chrome/settings/fatal.ts
@@ -3,8 +3,8 @@
 'use strict';
 
 import { Lang } from '../../js/common/lang.js';
-import { Xss } from '../../js/common/platform/xss.js';
 import { Url } from '../../js/common/core/common.js';
+import { Xss } from '../../js/common/platform/xss.js';
 
 const uncheckedUrlParams = Url.parse(['reason', 'stack']);
 const reason = String(uncheckedUrlParams.reason);

--- a/extension/chrome/settings/inbox/inbox.ts
+++ b/extension/chrome/settings/inbox/inbox.ts
@@ -2,24 +2,25 @@
 
 'use strict';
 
-import { Catch } from '../../../js/common/platform/catch.js';
-import { Store, AccountStore } from '../../../js/common/platform/store.js';
+import { AccountStore, Store } from '../../../js/common/platform/store.js';
+import { SelCache, Ui } from '../../../js/common/browser/ui.js';
 import { Url, UrlParams } from '../../../js/common/core/common.js';
-import { Ui, SelCache } from '../../../js/common/browser/ui.js';
+
+import { ApiErr } from '../../../js/common/api/error/api-error.js';
+import { Assert } from '../../../js/common/assert.js';
+import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
+import { Catch } from '../../../js/common/platform/catch.js';
+import { Gmail } from '../../../js/common/api/email_provider/gmail/gmail.js';
+import { InboxActiveThreadModule } from './inbox_modules/inbox_thread_module.js';
+import { InboxListThreadsModule } from './inbox_modules/inbox_threads_module.js';
+import { InboxMenuModule } from './inbox_modules/inbox_menu_module.js';
+import { InboxNotificationModule } from './inbox_modules/inbox_notification_module.js';
 import { Injector } from '../../../js/common/inject.js';
 import { Settings } from '../../../js/common/settings.js';
-import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
-import { Assert } from '../../../js/common/assert.js';
-import { XssSafeFactory } from '../../../js/common/xss_safe_factory.js';
-import { WebmailCommon } from "../../../js/common/webmail.js";
-import { Gmail } from '../../../js/common/api/email_provider/gmail/gmail.js';
-import { ApiErr } from '../../../js/common/api/error/api-error.js';
 import { View } from '../../../js/common/view.js';
-import { InboxMenuModule } from './inbox_modules/inbox_menu_module.js';
-import { InboxListThreadsModule } from './inbox_modules/inbox_threads_module.js';
-import { InboxNotificationModule } from './inbox_modules/inbox_notification_module.js';
-import { InboxActiveThreadModule } from './inbox_modules/inbox_thread_module.js';
+import { WebmailCommon } from "../../../js/common/webmail.js";
 import { Xss } from '../../../js/common/platform/xss.js';
+import { XssSafeFactory } from '../../../js/common/xss_safe_factory.js';
 
 export class InboxView extends View {
 

--- a/extension/chrome/settings/inbox/inbox_modules/inbox_menu_module.ts
+++ b/extension/chrome/settings/inbox/inbox_modules/inbox_menu_module.ts
@@ -2,15 +2,16 @@
 
 'use strict';
 
-import { GmailRes } from '../../../../js/common/api/email_provider/gmail/gmail-parser.js';
-import { Xss } from '../../../../js/common/platform/xss.js';
-import { Dict } from '../../../../js/common/core/common.js';
-import { BrowserMsg, Bm } from '../../../../js/common/browser/browser-msg.js';
+import { Bm, BrowserMsg } from '../../../../js/common/browser/browser-msg.js';
+
 import { Catch } from '../../../../js/common/platform/catch.js';
-import { Settings } from '../../../../js/common/settings.js';
+import { Dict } from '../../../../js/common/core/common.js';
+import { GmailRes } from '../../../../js/common/api/email_provider/gmail/gmail-parser.js';
 import { Google } from '../../../../js/common/api/google.js';
-import { ViewModule } from '../../../../js/common/view_module.js';
 import { InboxView } from '../inbox.js';
+import { Settings } from '../../../../js/common/settings.js';
+import { ViewModule } from '../../../../js/common/view_module.js';
+import { Xss } from '../../../../js/common/platform/xss.js';
 
 export class InboxMenuModule extends ViewModule<InboxView> {
 

--- a/extension/chrome/settings/inbox/inbox_modules/inbox_notification_module.ts
+++ b/extension/chrome/settings/inbox/inbox_modules/inbox_notification_module.ts
@@ -3,10 +3,11 @@
 'use strict';
 
 import { Bm, BrowserMsg } from '../../../../js/common/browser/browser-msg.js';
+
 import { Dict } from '../../../../js/common/core/common.js';
-import { Notifications } from '../../../../js/common/notifications.js';
-import { InboxView } from '../inbox.js';
 import { GoogleAuth } from '../../../../js/common/api/google-auth.js';
+import { InboxView } from '../inbox.js';
+import { Notifications } from '../../../../js/common/notifications.js';
 import { ViewModule } from '../../../../js/common/view_module.js';
 
 export class InboxNotificationModule extends ViewModule<InboxView> {

--- a/extension/chrome/settings/inbox/inbox_modules/inbox_thread_module.ts
+++ b/extension/chrome/settings/inbox/inbox_modules/inbox_thread_module.ts
@@ -2,20 +2,21 @@
 
 'use strict';
 
-import { GmailRes, GmailParser } from '../../../../js/common/api/email_provider/gmail/gmail-parser.js';
-import { Catch } from '../../../../js/common/platform/catch.js';
-import { Xss } from '../../../../js/common/platform/xss.js';
+import { Bm, BrowserMsg } from '../../../../js/common/browser/browser-msg.js';
+import { FactoryReplyParams, XssSafeFactory } from '../../../../js/common/xss_safe_factory.js';
+import { GmailParser, GmailRes } from '../../../../js/common/api/email_provider/gmail/gmail-parser.js';
+import { Url, UrlParams } from '../../../../js/common/core/common.js';
+
 import { ApiErr } from '../../../../js/common/api/error/api-error.js';
+import { BrowserMsgCommonHandlers } from '../../../../js/common/browser/browser-msg-common-handlers.js';
+import { Buf } from '../../../../js/common/core/buf.js';
+import { Catch } from '../../../../js/common/platform/catch.js';
 import { InboxView } from '../inbox.js';
 import { Lang } from '../../../../js/common/lang.js';
-import { Ui } from '../../../../js/common/browser/ui.js';
-import { Url, UrlParams } from '../../../../js/common/core/common.js';
-import { Buf } from '../../../../js/common/core/buf.js';
 import { Mime } from '../../../../js/common/core/mime.js';
-import { XssSafeFactory, FactoryReplyParams } from '../../../../js/common/xss_safe_factory.js';
-import { BrowserMsg, Bm } from '../../../../js/common/browser/browser-msg.js';
-import { BrowserMsgCommonHandlers } from '../../../../js/common/browser/browser-msg-common-handlers.js';
+import { Ui } from '../../../../js/common/browser/ui.js';
 import { ViewModule } from '../../../../js/common/view_module.js';
+import { Xss } from '../../../../js/common/platform/xss.js';
 
 export class InboxActiveThreadModule extends ViewModule<InboxView> {
 

--- a/extension/chrome/settings/inbox/inbox_modules/inbox_threads_module.ts
+++ b/extension/chrome/settings/inbox/inbox_modules/inbox_threads_module.ts
@@ -2,15 +2,15 @@
 
 'use strict';
 
-import { Xss } from '../../../../js/common/platform/xss.js';
-import { Ui } from '../../../../js/common/browser/ui.js';
-import { Catch } from '../../../../js/common/platform/catch.js';
 import { ApiErr } from '../../../../js/common/api/error/api-error.js';
+import { Catch } from '../../../../js/common/platform/catch.js';
+import { GmailParser } from '../../../../js/common/api/email_provider/gmail/gmail-parser.js';
 import { InboxView } from '../inbox.js';
 import { Lang } from '../../../../js/common/lang.js';
-import { GmailParser } from '../../../../js/common/api/email_provider/gmail/gmail-parser.js';
 import { Str } from '../../../../js/common/core/common.js';
+import { Ui } from '../../../../js/common/browser/ui.js';
 import { ViewModule } from '../../../../js/common/view_module.js';
+import { Xss } from '../../../../js/common/platform/xss.js';
 
 export class InboxListThreadsModule extends ViewModule<InboxView> {
 

--- a/extension/chrome/settings/index.ts
+++ b/extension/chrome/settings/index.ts
@@ -2,25 +2,26 @@
 
 'use strict';
 
-import { VERSION } from '../../js/common/core/const.js';
-import { Catch } from '../../js/common/platform/catch.js';
-import { Store } from '../../js/common/platform/store.js';
-import { Str, UrlParams, Url } from '../../js/common/core/common.js';
-import { Ui, JQS } from '../../js/common/browser/ui.js';
-import { Rules } from '../../js/common/rules.js';
-import { Notifications } from '../../js/common/notifications.js';
-import { Settings } from '../../js/common/settings.js';
-import { BrowserMsg, Bm } from '../../js/common/browser/browser-msg.js';
-import { Lang } from '../../js/common/lang.js';
+import { Bm, BrowserMsg } from '../../js/common/browser/browser-msg.js';
+import { JQS, Ui } from '../../js/common/browser/ui.js';
 import { KeyInfo, PgpKey } from '../../js/common/core/pgp-key.js';
-import { Backend } from '../../js/common/api/backend.js';
-import { Assert } from '../../js/common/assert.js';
-import { XssSafeFactory } from '../../js/common/xss_safe_factory.js';
-import { Xss } from '../../js/common/platform/xss.js';
-import { View } from '../../js/common/view.js';
-import { Gmail } from '../../js/common/api/email_provider/gmail/gmail.js';
-import { Env } from '../../js/common/browser/env.js';
+import { Str, Url, UrlParams } from '../../js/common/core/common.js';
+
 import { ApiErr } from '../../js/common/api/error/api-error.js';
+import { Assert } from '../../js/common/assert.js';
+import { Backend } from '../../js/common/api/backend.js';
+import { Catch } from '../../js/common/platform/catch.js';
+import { Env } from '../../js/common/browser/env.js';
+import { Gmail } from '../../js/common/api/email_provider/gmail/gmail.js';
+import { Lang } from '../../js/common/lang.js';
+import { Notifications } from '../../js/common/notifications.js';
+import { Rules } from '../../js/common/rules.js';
+import { Settings } from '../../js/common/settings.js';
+import { Store } from '../../js/common/platform/store.js';
+import { VERSION } from '../../js/common/core/const.js';
+import { View } from '../../js/common/view.js';
+import { Xss } from '../../js/common/platform/xss.js';
+import { XssSafeFactory } from '../../js/common/xss_safe_factory.js';
 
 View.run(class SettingsView extends View {
 

--- a/extension/chrome/settings/modules/account.ts
+++ b/extension/chrome/settings/modules/account.ts
@@ -3,14 +3,15 @@
 'use strict';
 
 import { Store, Subscription } from '../../../js/common/platform/store.js';
-import { Ui } from '../../../js/common/browser/ui.js';
-import { Settings } from '../../../js/common/settings.js';
-import { Backend } from '../../../js/common/api/backend.js';
+
+import { ApiErr } from '../../../js/common/api/error/api-error.js';
 import { Assert } from '../../../js/common/assert.js';
-import { Xss } from '../../../js/common/platform/xss.js';
+import { Backend } from '../../../js/common/api/backend.js';
+import { Settings } from '../../../js/common/settings.js';
+import { Ui } from '../../../js/common/browser/ui.js';
 import { Url } from '../../../js/common/core/common.js';
 import { View } from '../../../js/common/view.js';
-import { ApiErr } from '../../../js/common/api/error/api-error.js';
+import { Xss } from '../../../js/common/platform/xss.js';
 
 // todo - this this page should be removed, link from settings should point to flowcrypt.com/account once available
 

--- a/extension/chrome/settings/modules/add_key.ts
+++ b/extension/chrome/settings/modules/add_key.ts
@@ -2,19 +2,20 @@
 
 'use strict';
 
-import { Catch } from '../../../js/common/platform/catch.js';
-import { Store } from '../../../js/common/platform/store.js';
-import { Value, Url } from '../../../js/common/core/common.js';
-import { Ui } from '../../../js/common/browser/ui.js';
-import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
-import { Gmail } from './../../../js/common/api/email_provider/gmail/gmail.js';
-import { Assert } from '../../../js/common/assert.js';
-import { KeyImportUi, UserAlert, KeyCanBeFixed } from '../../../js/common/ui/key_import_ui.js';
-import { initPassphraseToggle } from '../../../js/common/ui/passphrase_ui.js';
-import { Xss } from '../../../js/common/platform/xss.js';
-import { View } from '../../../js/common/view.js';
+import { KeyCanBeFixed, KeyImportUi, UserAlert } from '../../../js/common/ui/key_import_ui.js';
+import { Url, Value } from '../../../js/common/core/common.js';
+
 import { ApiErr } from '../../../js/common/api/error/api-error.js';
+import { Assert } from '../../../js/common/assert.js';
+import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
+import { Catch } from '../../../js/common/platform/catch.js';
+import { Gmail } from './../../../js/common/api/email_provider/gmail/gmail.js';
 import { PgpKey } from '../../../js/common/core/pgp-key.js';
+import { Store } from '../../../js/common/platform/store.js';
+import { Ui } from '../../../js/common/browser/ui.js';
+import { View } from '../../../js/common/view.js';
+import { Xss } from '../../../js/common/platform/xss.js';
+import { initPassphraseToggle } from '../../../js/common/ui/passphrase_ui.js';
 
 View.run(class AddKeyView extends View {
 

--- a/extension/chrome/settings/modules/auth_denied.ts
+++ b/extension/chrome/settings/modules/auth_denied.ts
@@ -2,10 +2,10 @@
 
 'use strict';
 
-import { Store } from '../../../js/common/platform/store.js';
+import { Assert } from '../../../js/common/assert.js';
 import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
 import { GoogleAuth } from '../../../js/common/api/google-auth.js';
-import { Assert } from '../../../js/common/assert.js';
+import { Store } from '../../../js/common/platform/store.js';
 import { Url } from '../../../js/common/core/common.js';
 import { View } from '../../../js/common/view.js';
 

--- a/extension/chrome/settings/modules/backup.ts
+++ b/extension/chrome/settings/modules/backup.ts
@@ -2,27 +2,28 @@
 
 'use strict';
 
+import { Bm, BrowserMsg } from '../../../js/common/browser/browser-msg.js';
 import { Catch, UnreportableError } from '../../../js/common/platform/catch.js';
-import { Store, KeyBackupMethod, EmailProvider } from '../../../js/common/platform/store.js';
-import { Value, Url, PromiseCancellation } from '../../../js/common/core/common.js';
+import { EmailProvider, KeyBackupMethod, Store } from '../../../js/common/platform/store.js';
+import { KeyInfo, PgpKey } from '../../../js/common/core/pgp-key.js';
+import { PromiseCancellation, Url, Value } from '../../../js/common/core/common.js';
+
+import { ApiErr } from '../../../js/common/api/error/api-error.js';
+import { Assert } from '../../../js/common/assert.js';
 import { Att } from '../../../js/common/core/att.js';
 import { Browser } from '../../../js/common/browser/browser.js';
-import { BrowserMsg, Bm } from '../../../js/common/browser/browser-msg.js';
-import { Rules } from '../../../js/common/rules.js';
-import { Lang } from '../../../js/common/lang.js';
-import { Settings } from '../../../js/common/settings.js';
-import { GoogleAuth } from '../../../js/common/api/google-auth.js';
 import { Buf } from '../../../js/common/core/buf.js';
 import { GMAIL_RECOVERY_EMAIL_SUBJECTS } from '../../../js/common/core/const.js';
-import { Assert } from '../../../js/common/assert.js';
-import { initPassphraseToggle } from '../../../js/common/ui/passphrase_ui.js';
-import { Xss } from '../../../js/common/platform/xss.js';
-import { View } from '../../../js/common/view.js';
-import { KeyImportUi } from './../../../js/common/ui/key_import_ui.js';
 import { Gmail } from '../../../js/common/api/email_provider/gmail/gmail.js';
+import { GoogleAuth } from '../../../js/common/api/google-auth.js';
+import { KeyImportUi } from './../../../js/common/ui/key_import_ui.js';
+import { Lang } from '../../../js/common/lang.js';
+import { Rules } from '../../../js/common/rules.js';
+import { Settings } from '../../../js/common/settings.js';
 import { Ui } from '../../../js/common/browser/ui.js';
-import { ApiErr } from '../../../js/common/api/error/api-error.js';
-import { PgpKey, KeyInfo } from '../../../js/common/core/pgp-key.js';
+import { View } from '../../../js/common/view.js';
+import { Xss } from '../../../js/common/platform/xss.js';
+import { initPassphraseToggle } from '../../../js/common/ui/passphrase_ui.js';
 
 View.run(class BackupView extends View {
   private readonly gmail: Gmail;

--- a/extension/chrome/settings/modules/change_passphrase.ts
+++ b/extension/chrome/settings/modules/change_passphrase.ts
@@ -2,17 +2,17 @@
 
 'use strict';
 
+import { Assert } from '../../../js/common/assert.js';
 import { Catch } from '../../../js/common/platform/catch.js';
+import { KeyImportUi } from '../../../js/common/ui/key_import_ui.js';
+import { KeyInfo } from '../../../js/common/core/pgp-key.js';
+import { PgpKey } from '../../../js/common/core/pgp-key.js';
+import { Settings } from '../../../js/common/settings.js';
 import { Store } from '../../../js/common/platform/store.js';
 import { Ui } from '../../../js/common/browser/ui.js';
-import { Settings } from '../../../js/common/settings.js';
-import { KeyInfo } from '../../../js/common/core/pgp-key.js';
-import { Assert } from '../../../js/common/assert.js';
-import { initPassphraseToggle } from '../../../js/common/ui/passphrase_ui.js';
-import { KeyImportUi } from '../../../js/common/ui/key_import_ui.js';
 import { Url } from '../../../js/common/core/common.js';
 import { View } from '../../../js/common/view.js';
-import { PgpKey } from '../../../js/common/core/pgp-key.js';
+import { initPassphraseToggle } from '../../../js/common/ui/passphrase_ui.js';
 
 View.run(class ChangePassPhraseView extends View {
 

--- a/extension/chrome/settings/modules/compatibility.ts
+++ b/extension/chrome/settings/modules/compatibility.ts
@@ -1,11 +1,11 @@
 'use strict';
 
-import { Ui } from '../../../js/common/browser/ui.js';
-import { PgpMsg } from '../../../js/common/core/pgp-msg.js';
-import { Xss } from '../../../js/common/platform/xss.js';
 import { Buf } from '../../../js/common/core/buf.js';
-import { View } from '../../../js/common/view.js';
 import { PgpKey } from '../../../js/common/core/pgp-key.js';
+import { PgpMsg } from '../../../js/common/core/pgp-msg.js';
+import { Ui } from '../../../js/common/browser/ui.js';
+import { View } from '../../../js/common/view.js';
+import { Xss } from '../../../js/common/platform/xss.js';
 import { openpgp } from '../../../js/common/core/pgp.js';
 
 View.run(class CompatibilityView extends View {

--- a/extension/chrome/settings/modules/contact_page.ts
+++ b/extension/chrome/settings/modules/contact_page.ts
@@ -2,19 +2,20 @@
 
 'use strict';
 
-import { Catch } from '../../../js/common/platform/catch.js';
-import { Store, Serializable } from '../../../js/common/platform/store.js';
-import { Value, Str, Dict, Url } from '../../../js/common/core/common.js';
-import { Att } from '../../../js/common/core/att.js';
-import { Ui, SelCache } from '../../../js/common/browser/ui.js';
-import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
-import { Settings } from '../../../js/common/settings.js';
 import { Backend, BackendRes, FcUuidAuth } from '../../../js/common/api/backend.js';
-import { Assert } from '../../../js/common/assert.js';
-import { AttUI } from '../../../js/common/ui/att_ui.js';
-import { Xss } from '../../../js/common/platform/xss.js';
-import { View } from '../../../js/common/view.js';
+import { Dict, Str, Url, Value } from '../../../js/common/core/common.js';
+import { SelCache, Ui } from '../../../js/common/browser/ui.js';
+import { Serializable, Store } from '../../../js/common/platform/store.js';
+
 import { ApiErr } from '../../../js/common/api/error/api-error.js';
+import { Assert } from '../../../js/common/assert.js';
+import { Att } from '../../../js/common/core/att.js';
+import { AttUI } from '../../../js/common/ui/att_ui.js';
+import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
+import { Catch } from '../../../js/common/platform/catch.js';
+import { Settings } from '../../../js/common/settings.js';
+import { View } from '../../../js/common/view.js';
+import { Xss } from '../../../js/common/platform/xss.js';
 
 View.run(class ContactPageView extends View {
   private readonly acctEmail: string;

--- a/extension/chrome/settings/modules/contacts.ts
+++ b/extension/chrome/settings/modules/contacts.ts
@@ -2,25 +2,26 @@
 
 'use strict';
 
-import { Store } from '../../../js/common/platform/store.js';
+import { Contact, PgpKey } from '../../../js/common/core/pgp-key.js';
+import { Str, Url } from '../../../js/common/core/common.js';
+
+import { ApiErr } from '../../../js/common/api/error/api-error.js';
+import { Assert } from '../../../js/common/assert.js';
 import { Att } from '../../../js/common/core/att.js';
+import { AttUI } from '../../../js/common/ui/att_ui.js';
 import { Browser } from '../../../js/common/browser/browser.js';
-import { Ui } from '../../../js/common/browser/ui.js';
 import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
 import { Buf } from '../../../js/common/core/buf.js';
-import { AttUI } from '../../../js/common/ui/att_ui.js';
-import { KeyImportUi } from '../../../js/common/ui/key_import_ui.js';
-import { XssSafeFactory } from '../../../js/common/xss_safe_factory.js';
-import { Assert } from '../../../js/common/assert.js';
-import { Xss } from '../../../js/common/platform/xss.js';
-import { Rules } from '../../../js/common/rules.js';
-import { Keyserver } from '../../../js/common/api/keyserver.js';
-import { Str, Url } from '../../../js/common/core/common.js';
 import { FetchKeyUI } from '../../../js/common/ui/fetch_key_ui.js';
-import { View } from '../../../js/common/view.js';
-import { ApiErr } from '../../../js/common/api/error/api-error.js';
-import { PgpKey, Contact } from '../../../js/common/core/pgp-key.js';
+import { KeyImportUi } from '../../../js/common/ui/key_import_ui.js';
+import { Keyserver } from '../../../js/common/api/keyserver.js';
 import { MsgBlockParser } from '../../../js/common/core/msg-block-parser.js';
+import { Rules } from '../../../js/common/rules.js';
+import { Store } from '../../../js/common/platform/store.js';
+import { Ui } from '../../../js/common/browser/ui.js';
+import { View } from '../../../js/common/view.js';
+import { Xss } from '../../../js/common/platform/xss.js';
+import { XssSafeFactory } from '../../../js/common/xss_safe_factory.js';
 
 View.run(class ContactsView extends View {
 

--- a/extension/chrome/settings/modules/debug_api.ts
+++ b/extension/chrome/settings/modules/debug_api.ts
@@ -3,11 +3,12 @@
 'use strict';
 
 import { Dict, Url } from '../../../js/common/core/common.js';
-import { Store } from '../../../js/common/platform/store.js';
+
 import { Assert } from '../../../js/common/assert.js';
-import { Xss } from '../../../js/common/platform/xss.js';
-import { View } from '../../../js/common/view.js';
 import { Gmail } from '../../../js/common/api/email_provider/gmail/gmail.js';
+import { Store } from '../../../js/common/platform/store.js';
+import { View } from '../../../js/common/view.js';
+import { Xss } from '../../../js/common/platform/xss.js';
 
 View.run(class DebugApiView extends View {
 

--- a/extension/chrome/settings/modules/decrypt.ts
+++ b/extension/chrome/settings/modules/decrypt.ts
@@ -2,18 +2,19 @@
 
 'use strict';
 
-import { Store } from '../../../js/common/platform/store.js';
+import { DecryptErrTypes, PgpMsg } from '../../../js/common/core/pgp-msg.js';
+
+import { Assert } from '../../../js/common/assert.js';
 import { Att } from '../../../js/common/core/att.js';
+import { AttUI } from '../../../js/common/ui/att_ui.js';
 import { Browser } from '../../../js/common/browser/browser.js';
 import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
-import { DecryptErrTypes, PgpMsg } from '../../../js/common/core/pgp-msg.js';
-import { Assert } from '../../../js/common/assert.js';
-import { AttUI } from '../../../js/common/ui/att_ui.js';
-import { XssSafeFactory } from '../../../js/common/xss_safe_factory.js';
-import { Xss } from '../../../js/common/platform/xss.js';
-import { Url } from '../../../js/common/core/common.js';
+import { Store } from '../../../js/common/platform/store.js';
 import { Ui } from '../../../js/common/browser/ui.js';
+import { Url } from '../../../js/common/core/common.js';
 import { View } from '../../../js/common/view.js';
+import { Xss } from '../../../js/common/platform/xss.js';
+import { XssSafeFactory } from '../../../js/common/xss_safe_factory.js';
 
 View.run(class ManualDecryptView extends View {
 

--- a/extension/chrome/settings/modules/experimental.ts
+++ b/extension/chrome/settings/modules/experimental.ts
@@ -2,19 +2,19 @@
 
 'use strict';
 
-import { Catch } from '../../../js/common/platform/catch.js';
-import { Store } from '../../../js/common/platform/store.js';
+import { Assert } from '../../../js/common/assert.js';
 import { Att } from '../../../js/common/core/att.js';
 import { Browser } from '../../../js/common/browser/browser.js';
 import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
-import { Settings } from '../../../js/common/settings.js';
-import { Lang } from '../../../js/common/lang.js';
-import { GoogleAuth } from '../../../js/common/api/google-auth.js';
 import { Buf } from '../../../js/common/core/buf.js';
-import { Assert } from '../../../js/common/assert.js';
+import { Catch } from '../../../js/common/platform/catch.js';
+import { GoogleAuth } from '../../../js/common/api/google-auth.js';
+import { Lang } from '../../../js/common/lang.js';
+import { Settings } from '../../../js/common/settings.js';
+import { Store } from '../../../js/common/platform/store.js';
+import { Ui } from '../../../js/common/browser/ui.js';
 import { Url } from '../../../js/common/core/common.js';
 import { View } from '../../../js/common/view.js';
-import { Ui } from '../../../js/common/browser/ui.js';
 
 View.run(class ExperimentalView extends View {
 

--- a/extension/chrome/settings/modules/help.ts
+++ b/extension/chrome/settings/modules/help.ts
@@ -2,16 +2,17 @@
 
 'use strict';
 
-import { VERSION } from '../../../js/common/core/const.js';
-import { Catch } from '../../../js/common/platform/catch.js';
 import { Str, Url } from '../../../js/common/core/common.js';
-import { Ui } from '../../../js/common/browser/ui.js';
-import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
-import { Backend } from '../../../js/common/api/backend.js';
-import { Assert } from '../../../js/common/assert.js';
-import { Xss } from '../../../js/common/platform/xss.js';
-import { View } from '../../../js/common/view.js';
+
 import { ApiErr } from '../../../js/common/api/error/api-error.js';
+import { Assert } from '../../../js/common/assert.js';
+import { Backend } from '../../../js/common/api/backend.js';
+import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
+import { Catch } from '../../../js/common/platform/catch.js';
+import { Ui } from '../../../js/common/browser/ui.js';
+import { VERSION } from '../../../js/common/core/const.js';
+import { View } from '../../../js/common/view.js';
+import { Xss } from '../../../js/common/platform/xss.js';
 
 View.run(class HelpView extends View {
 

--- a/extension/chrome/settings/modules/keyserver.ts
+++ b/extension/chrome/settings/modules/keyserver.ts
@@ -2,18 +2,19 @@
 
 'use strict';
 
-import { Store } from '../../../js/common/platform/store.js';
 import { Dict, Url } from '../../../js/common/core/common.js';
-import { Ui } from '../../../js/common/browser/ui.js';
-import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
-import { Settings } from '../../../js/common/settings.js';
-import { Attester } from '../../../js/common/api/attester.js';
-import { Assert } from '../../../js/common/assert.js';
-import { Xss } from '../../../js/common/platform/xss.js';
-import { Lang } from '../../../js/common/lang.js';
-import { View } from '../../../js/common/view.js';
+
 import { ApiErr } from '../../../js/common/api/error/api-error.js';
+import { Assert } from '../../../js/common/assert.js';
+import { Attester } from '../../../js/common/api/attester.js';
+import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
+import { Lang } from '../../../js/common/lang.js';
 import { PgpKey } from '../../../js/common/core/pgp-key.js';
+import { Settings } from '../../../js/common/settings.js';
+import { Store } from '../../../js/common/platform/store.js';
+import { Ui } from '../../../js/common/browser/ui.js';
+import { View } from '../../../js/common/view.js';
+import { Xss } from '../../../js/common/platform/xss.js';
 
 type AttesterKeyserverDiagnosis = { hasPubkeyMissing: boolean, hasPubkeyMismatch: boolean, results: Dict<{ pubkey?: string, match: boolean }> };
 

--- a/extension/chrome/settings/modules/my_key.ts
+++ b/extension/chrome/settings/modules/my_key.ts
@@ -2,20 +2,20 @@
 
 'use strict';
 
-import { Store } from '../../../js/common/platform/store.js';
+import { ApiErr } from '../../../js/common/api/error/api-error.js';
+import { Assert } from '../../../js/common/assert.js';
 import { Att } from '../../../js/common/core/att.js';
-import { Browser } from '../../../js/common/browser/browser.js';
-import { KeyInfo } from '../../../js/common/core/pgp-key.js';
 import { Attester } from '../../../js/common/api/attester.js';
 import { Backend } from '../../../js/common/api/backend.js';
-import { Assert } from '../../../js/common/assert.js';
+import { Browser } from '../../../js/common/browser/browser.js';
 import { Buf } from '../../../js/common/core/buf.js';
+import { KeyInfo } from '../../../js/common/core/pgp-key.js';
+import { PgpKey } from '../../../js/common/core/pgp-key.js';
+import { Store } from '../../../js/common/platform/store.js';
+import { Ui } from '../../../js/common/browser/ui.js';
 import { Url } from '../../../js/common/core/common.js';
 import { View } from '../../../js/common/view.js';
-import { ApiErr } from '../../../js/common/api/error/api-error.js';
-import { PgpKey } from '../../../js/common/core/pgp-key.js';
 import { initPassphraseToggle } from '../../../js/common/ui/passphrase_ui.js';
-import { Ui } from '../../../js/common/browser/ui.js';
 
 declare const ClipboardJS: any;
 

--- a/extension/chrome/settings/modules/my_key_update.ts
+++ b/extension/chrome/settings/modules/my_key_update.ts
@@ -2,18 +2,18 @@
 
 'use strict';
 
-import { Store } from '../../../js/common/platform/store.js';
-import { Ui } from '../../../js/common/browser/ui.js';
-import { Settings } from '../../../js/common/settings.js';
-import { KeyInfo } from '../../../js/common/core/pgp-key.js';
-import { Lang } from '../../../js/common/lang.js';
+import { ApiErr } from '../../../js/common/api/error/api-error.js';
 import { Assert } from '../../../js/common/assert.js';
 import { Attester } from '../../../js/common/api/attester.js';
+import { KeyInfo } from '../../../js/common/core/pgp-key.js';
+import { Lang } from '../../../js/common/lang.js';
+import { PgpArmor } from '../../../js/common/core/pgp-armor.js';
+import { PgpKey } from '../../../js/common/core/pgp-key.js';
+import { Settings } from '../../../js/common/settings.js';
+import { Store } from '../../../js/common/platform/store.js';
+import { Ui } from '../../../js/common/browser/ui.js';
 import { Url } from '../../../js/common/core/common.js';
 import { View } from '../../../js/common/view.js';
-import { PgpArmor } from '../../../js/common/core/pgp-armor.js';
-import { ApiErr } from '../../../js/common/api/error/api-error.js';
-import { PgpKey } from '../../../js/common/core/pgp-key.js';
 import { openpgp } from '../../../js/common/core/pgp.js';
 
 View.run(class MyKeyUpdateView extends View {

--- a/extension/chrome/settings/modules/my_key_user_ids.ts
+++ b/extension/chrome/settings/modules/my_key_user_ids.ts
@@ -2,12 +2,13 @@
 
 'use strict';
 
-import { Store } from '../../../js/common/platform/store.js';
+import { KeyInfo, PgpKey } from '../../../js/common/core/pgp-key.js';
+
 import { Assert } from '../../../js/common/assert.js';
-import { Xss } from '../../../js/common/platform/xss.js';
+import { Store } from '../../../js/common/platform/store.js';
 import { Url } from '../../../js/common/core/common.js';
 import { View } from '../../../js/common/view.js';
-import { KeyInfo, PgpKey } from '../../../js/common/core/pgp-key.js';
+import { Xss } from '../../../js/common/platform/xss.js';
 
 View.run(class MyKeyUserIdsView extends View {
   private readonly acctEmail: string;

--- a/extension/chrome/settings/modules/security.ts
+++ b/extension/chrome/settings/modules/security.ts
@@ -2,18 +2,19 @@
 
 'use strict';
 
+import { Backend, FcUuidAuth } from '../../../js/common/api/backend.js';
+
+import { ApiErr } from '../../../js/common/api/error/api-error.js';
+import { Assert } from '../../../js/common/assert.js';
 import { Catch } from '../../../js/common/platform/catch.js';
+import { KeyInfo } from '../../../js/common/core/pgp-key.js';
+import { Settings } from '../../../js/common/settings.js';
 import { Store } from '../../../js/common/platform/store.js';
 import { Ui } from '../../../js/common/browser/ui.js';
-import { Settings } from '../../../js/common/settings.js';
-import { Backend, FcUuidAuth } from '../../../js/common/api/backend.js';
-import { Assert } from '../../../js/common/assert.js';
-import { initPassphraseToggle } from '../../../js/common/ui/passphrase_ui.js';
-import { Xss } from '../../../js/common/platform/xss.js';
 import { Url } from '../../../js/common/core/common.js';
 import { View } from '../../../js/common/view.js';
-import { KeyInfo } from '../../../js/common/core/pgp-key.js';
-import { ApiErr } from '../../../js/common/api/error/api-error.js';
+import { Xss } from '../../../js/common/platform/xss.js';
+import { initPassphraseToggle } from '../../../js/common/ui/passphrase_ui.js';
 
 View.run(class SecurityView extends View {
 

--- a/extension/chrome/settings/modules/test_passphrase.ts
+++ b/extension/chrome/settings/modules/test_passphrase.ts
@@ -2,17 +2,17 @@
 
 'use strict';
 
+import { Assert } from '../../../js/common/assert.js';
+import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
+import { Lang } from '../../../js/common/lang.js';
+import { PgpKey } from '../../../js/common/core/pgp-key.js';
+import { Settings } from '../../../js/common/settings.js';
 import { Store } from '../../../js/common/platform/store.js';
 import { Ui } from '../../../js/common/browser/ui.js';
-import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
-import { Settings } from '../../../js/common/settings.js';
-import { Lang } from '../../../js/common/lang.js';
-import { Assert } from '../../../js/common/assert.js';
-import { initPassphraseToggle } from '../../../js/common/ui/passphrase_ui.js';
-import { Xss } from '../../../js/common/platform/xss.js';
 import { Url } from '../../../js/common/core/common.js';
 import { View } from '../../../js/common/view.js';
-import { PgpKey } from '../../../js/common/core/pgp-key.js';
+import { Xss } from '../../../js/common/platform/xss.js';
+import { initPassphraseToggle } from '../../../js/common/ui/passphrase_ui.js';
 
 View.run(class TestPassphrase extends View {
   private readonly acctEmail: string;

--- a/extension/chrome/settings/setup.ts
+++ b/extension/chrome/settings/setup.ts
@@ -2,29 +2,30 @@
 
 'use strict';
 
-import { Store, SendAsAlias, AccountStore, Scopes } from '../../js/common/platform/store.js';
-import { Value, Dict, Url } from '../../js/common/core/common.js';
-import { Ui } from '../../js/common/browser/ui.js';
-import { BrowserMsg, Bm } from '../../js/common/browser/browser-msg.js';
-import { Rules } from '../../js/common/rules.js';
-import { Lang } from '../../js/common/lang.js';
-import { Settings } from '../../js/common/settings.js';
-import { Contact } from '../../js/common/core/pgp-key.js';
-import { Catch } from '../../js/common/platform/catch.js';
-import { Google } from '../../js/common/api/google.js';
-import { Attester } from '../../js/common/api/attester.js';
+import { AccountStore, Scopes, SendAsAlias, Store } from '../../js/common/platform/store.js';
+import { Bm, BrowserMsg } from '../../js/common/browser/browser-msg.js';
+import { Dict, Url, Value } from '../../js/common/core/common.js';
+
+import { ApiErr } from '../../js/common/api/error/api-error.js';
 import { Assert } from '../../js/common/assert.js';
+import { Attester } from '../../js/common/api/attester.js';
+import { Catch } from '../../js/common/platform/catch.js';
+import { Contact } from '../../js/common/core/pgp-key.js';
+import { Gmail } from '../../js/common/api/email_provider/gmail/gmail.js';
+import { Google } from '../../js/common/api/google.js';
 import { KeyImportUi } from '../../js/common/ui/key_import_ui.js';
-import { initPassphraseToggle } from '../../js/common/ui/passphrase_ui.js';
-import { Xss } from '../../js/common/platform/xss.js';
-import { View } from '../../js/common/view.js';
-import { SetupRecoverKeyModule } from './setup/setup-recover-key.js';
+import { Lang } from '../../js/common/lang.js';
+import { PgpKey } from '../../js/common/core/pgp-key.js';
+import { Rules } from '../../js/common/rules.js';
+import { Settings } from '../../js/common/settings.js';
 import { SetupCreateKeyModule } from './setup/setup-create-key.js';
 import { SetupImportKeyModule } from './setup/setup-import-key.js';
+import { SetupRecoverKeyModule } from './setup/setup-recover-key.js';
 import { SetupRenderModule } from './setup/setup-render.js';
-import { Gmail } from '../../js/common/api/email_provider/gmail/gmail.js';
-import { ApiErr } from '../../js/common/api/error/api-error.js';
-import { PgpKey } from '../../js/common/core/pgp-key.js';
+import { Ui } from '../../js/common/browser/ui.js';
+import { View } from '../../js/common/view.js';
+import { Xss } from '../../js/common/platform/xss.js';
+import { initPassphraseToggle } from '../../js/common/ui/passphrase_ui.js';
 
 export interface SetupOptions {
   passphrase: string;

--- a/extension/chrome/settings/setup/setup-create-key.ts
+++ b/extension/chrome/settings/setup/setup-create-key.ts
@@ -2,16 +2,17 @@
 
 'use strict';
 
-import { SetupView, SetupOptions } from '../setup.js';
-import { Ui } from '../../../js/common/browser/ui.js';
+import { SetupOptions, SetupView } from '../setup.js';
+
 import { Catch } from '../../../js/common/platform/catch.js';
-import { Settings } from '../../../js/common/settings.js';
-import { Xss } from '../../../js/common/platform/xss.js';
-import { shouldPassPhraseBeHidden } from '../../../js/common/ui/passphrase_ui.js';
-import { Url } from '../../../js/common/core/common.js';
-import { Store } from '../../../js/common/platform/store.js';
 import { Lang } from '../../../js/common/lang.js';
 import { PgpKey } from '../../../js/common/core/pgp-key.js';
+import { Settings } from '../../../js/common/settings.js';
+import { Store } from '../../../js/common/platform/store.js';
+import { Ui } from '../../../js/common/browser/ui.js';
+import { Url } from '../../../js/common/core/common.js';
+import { Xss } from '../../../js/common/platform/xss.js';
+import { shouldPassPhraseBeHidden } from '../../../js/common/ui/passphrase_ui.js';
 
 export class SetupCreateKeyModule {
 

--- a/extension/chrome/settings/setup/setup-import-key.ts
+++ b/extension/chrome/settings/setup/setup-import-key.ts
@@ -2,12 +2,13 @@
 
 'use strict';
 
-import { SetupView, SetupOptions } from '../setup.js';
-import { Ui } from '../../../js/common/browser/ui.js';
+import { KeyCanBeFixed, UserAlert } from '../../../js/common/ui/key_import_ui.js';
+import { SetupOptions, SetupView } from '../setup.js';
+
 import { Catch } from '../../../js/common/platform/catch.js';
 import { Settings } from '../../../js/common/settings.js';
+import { Ui } from '../../../js/common/browser/ui.js';
 import { Xss } from '../../../js/common/platform/xss.js';
-import { UserAlert, KeyCanBeFixed } from '../../../js/common/ui/key_import_ui.js';
 
 export class SetupImportKeyModule {
 

--- a/extension/chrome/settings/setup/setup-recover-key.ts
+++ b/extension/chrome/settings/setup/setup-recover-key.ts
@@ -2,14 +2,15 @@
 
 'use strict';
 
-import { SetupView, SetupOptions } from '../setup.js';
-import { Ui } from '../../../js/common/browser/ui.js';
+import { SetupOptions, SetupView } from '../setup.js';
+
+import { ApiErr } from '../../../js/common/api/error/api-error.js';
 import { Lang } from '../../../js/common/lang.js';
+import { PgpKey } from '../../../js/common/core/pgp-key.js';
 import { Store } from '../../../js/common/platform/store.js';
+import { Ui } from '../../../js/common/browser/ui.js';
 import { Url } from '../../../js/common/core/common.js';
 import { Xss } from '../../../js/common/platform/xss.js';
-import { ApiErr } from '../../../js/common/api/error/api-error.js';
-import { PgpKey } from '../../../js/common/core/pgp-key.js';
 
 export class SetupRecoverKeyModule {
 

--- a/extension/chrome/settings/setup/setup-render.ts
+++ b/extension/chrome/settings/setup/setup-render.ts
@@ -2,15 +2,15 @@
 
 'use strict';
 
-import { SetupView } from '../setup.js';
-import { Ui } from '../../../js/common/browser/ui.js';
-import { Settings } from '../../../js/common/settings.js';
-import { Xss } from '../../../js/common/platform/xss.js';
-import { Url } from '../../../js/common/core/common.js';
-import { Store } from '../../../js/common/platform/store.js';
-import { Lang } from '../../../js/common/lang.js';
 import { Keyserver } from '../../../js/common/api/keyserver.js';
+import { Lang } from '../../../js/common/lang.js';
 import { PgpKey } from '../../../js/common/core/pgp-key.js';
+import { Settings } from '../../../js/common/settings.js';
+import { SetupView } from '../setup.js';
+import { Store } from '../../../js/common/platform/store.js';
+import { Ui } from '../../../js/common/browser/ui.js';
+import { Url } from '../../../js/common/core/common.js';
+import { Xss } from '../../../js/common/platform/xss.js';
 
 export class SetupRenderModule {
 

--- a/extension/js/background_page/background_page.ts
+++ b/extension/js/background_page/background_page.ts
@@ -2,18 +2,19 @@
 
 'use strict';
 
-import { VERSION } from '../common/core/const.js';
+import { Bm, BrowserMsg } from '../common/browser/browser-msg.js';
+import { GlobalStore, Store } from '../common/platform/store.js';
+
+import { BgHandlers } from './bg_handlers.js';
+import { BgUtils } from './bgutils.js';
+import { Buf } from '../common/core/buf.js';
 import { Catch } from '../common/platform/catch.js';
-import { Store, GlobalStore } from '../common/platform/store.js';
-import { BrowserMsg, Bm } from '../common/browser/browser-msg.js';
+import { GoogleAuth } from '../common/api/google-auth.js';
+import { PgpHash } from '../common/core/pgp-hash.js';
+import { PgpMsg } from '../common/core/pgp-msg.js';
+import { VERSION } from '../common/core/const.js';
 import { injectFcIntoWebmail } from './inject.js';
 import { migrateGlobal } from './migrations.js';
-import { GoogleAuth } from '../common/api/google-auth.js';
-import { BgUtils } from './bgutils.js';
-import { BgHandlers } from './bg_handlers.js';
-import { PgpMsg } from '../common/core/pgp-msg.js';
-import { Buf } from '../common/core/buf.js';
-import { PgpHash } from '../common/core/pgp-hash.js';
 import { openpgp } from '../common/core/pgp.js';
 
 console.info('background_process.js starting');

--- a/extension/js/background_page/bg_handlers.ts
+++ b/extension/js/background_page/bg_handlers.ts
@@ -2,13 +2,13 @@
 
 'use strict';
 
-import { Store } from '../common/platform/store.js';
-import { Bm } from '../common/browser/browser-msg.js';
-import { BgUtils } from './bgutils.js';
 import { Api } from '../common/api/api.js';
-import { Url } from '../common/core/common.js';
+import { BgUtils } from './bgutils.js';
+import { Bm } from '../common/browser/browser-msg.js';
 import { Gmail } from '../common/api/email_provider/gmail/gmail.js';
 import { PgpKey } from '../common/core/pgp-key.js';
+import { Store } from '../common/platform/store.js';
+import { Url } from '../common/core/common.js';
 
 export class BgHandlers {
 

--- a/extension/js/common/api/api.ts
+++ b/extension/js/common/api/api.ts
@@ -4,15 +4,16 @@
 
 // tslint:disable:no-direct-ajax
 
+import { AjaxErr, ApiErrResponse, StandardErrRes } from './error/api-error-types.js';
+
+import { Att } from '../core/att.js';
+import { BrowserMsg } from '../browser/browser-msg.js';
+import { Buf } from '../core/buf.js';
+import { Catch } from '../platform/catch.js';
+import { Contact } from '../core/pgp-key.js';
 import { Dict } from '../core/common.js';
 import { Env } from '../browser/env.js';
-import { Att } from '../core/att.js';
-import { Catch } from '../platform/catch.js';
-import { Buf } from '../core/buf.js';
-import { BrowserMsg } from '../browser/browser-msg.js';
-import { Contact } from '../core/pgp-key.js';
 import { secureRandomBytes } from '../platform/util.js';
-import { StandardErrRes, ApiErrResponse, AjaxErr } from './error/api-error-types.js';
 
 export type ReqFmt = 'JSON' | 'FORM' | 'TEXT';
 export type RecipientType = 'to' | 'cc' | 'bcc';

--- a/extension/js/common/api/attester.ts
+++ b/extension/js/common/api/attester.ts
@@ -4,7 +4,7 @@
 
 import { Api, ReqMethod } from './api.js';
 import { Dict, Str } from '../core/common.js';
-import { PubkeySearchResult, PgpClient } from './keyserver.js';
+import { PgpClient, PubkeySearchResult } from './keyserver.js';
 import { ApiErr } from './error/api-error.js';
 
 type PubCallRes = { responseText: string, getResponseHeader: (n: string) => string | null };

--- a/extension/js/common/api/backend.ts
+++ b/extension/js/common/api/backend.ts
@@ -5,16 +5,17 @@
 
 'use strict';
 
-import { Api, ReqFmt, ProgressCb } from './api.js';
+import { Api, ProgressCb, ReqFmt } from './api.js';
 import { Dict, Value } from '../core/common.js';
-import { Store } from '../platform/store.js';
-import { Catch } from '../platform/catch.js';
+
 import { Att } from '../core/att.js';
-import { Ui } from '../browser/ui.js';
-import { Buf } from '../core/buf.js';
-import { BackendAuthErr } from './error/api-error-types.js';
-import { DomainRules } from '../rules.js';
 import { BACKEND_API_HOST } from '../core/const.js';
+import { BackendAuthErr } from './error/api-error-types.js';
+import { Buf } from '../core/buf.js';
+import { Catch } from '../platform/catch.js';
+import { DomainRules } from '../rules.js';
+import { Store } from '../platform/store.js';
+import { Ui } from '../browser/ui.js';
 
 type ProfileUpdate = { alias?: string, name?: string, photo?: string, intro?: string, web?: string, phone?: string, default_message_expire?: number };
 type FcAuthToken = { account: string, token: string };

--- a/extension/js/common/api/chrome.ts
+++ b/extension/js/common/api/chrome.ts
@@ -2,12 +2,12 @@
 
 'use strict';
 
-import { Store } from '../platform/store.js';
 import { Catch } from '../platform/catch.js';
-import { Url } from '../core/common.js';
-import { Env } from '../browser/env.js';
 import { ContentScriptWindow } from '../browser/browser-window.js';
+import { Env } from '../browser/env.js';
+import { Store } from '../platform/store.js';
 import { Ui } from '../browser/ui.js';
+import { Url } from '../core/common.js';
 
 export const handleFatalErr = (reason: 'storage_undefined', error: Error) => {
   try {

--- a/extension/js/common/api/email_provider/email_provider_api.ts
+++ b/extension/js/common/api/email_provider/email_provider_api.ts
@@ -4,14 +4,15 @@
 
 'use strict';
 
+import { Api, ChunkedCb, ProgressCb } from '../api.js';
 import { Dict, Str } from '../../core/common.js';
-import { Store } from '../../platform/store.js';
+import { MimeEncodeType, SendableMsgBody } from '../../core/mime.js';
+
 import { Att } from '../../core/att.js';
-import { SendableMsgBody, MimeEncodeType } from '../../core/mime.js';
-import { Api, ProgressCb, ChunkedCb } from '../api.js';
-import { GmailResponseFormat } from './gmail/gmail.js';
-import { GmailRes } from './gmail/gmail-parser.js';
 import { Contact } from '../../core/pgp-key.js';
+import { GmailRes } from './gmail/gmail-parser.js';
+import { GmailResponseFormat } from './gmail/gmail.js';
+import { Store } from '../../platform/store.js';
 
 export type Recipients = { to?: string[], cc?: string[], bcc?: string[] };
 export type ProviderContactsQuery = { substring: string };

--- a/extension/js/common/api/email_provider/gmail/gmail-parser.ts
+++ b/extension/js/common/api/email_provider/gmail/gmail-parser.ts
@@ -2,12 +2,13 @@
 
 'use strict';
 
-import { Value, Str } from '../../../core/common.js';
+import { Mime, SendableMsgBody } from '../../../core/mime.js';
+import { Str, Value } from '../../../core/common.js';
+
 import { Att } from '../../../core/att.js';
-import { SendableMsgBody, Mime } from '../../../core/mime.js';
-import { ReplyParams } from '../email_provider_api.js';
-import { RecipientType } from '../../api.js';
 import { Buf } from '../../../core/buf.js';
+import { RecipientType } from '../../api.js';
+import { ReplyParams } from '../email_provider_api.js';
 
 export namespace GmailRes { // responses
 

--- a/extension/js/common/api/email_provider/gmail/gmail.ts
+++ b/extension/js/common/api/email_provider/gmail/gmail.ts
@@ -2,27 +2,28 @@
 
 'use strict';
 
-import { GOOGLE_API_HOST, gmailBackupSearchQuery } from '../../../core/const.js';
-import { EmailProviderApi, EmailProviderInterface, SendableMsg } from '../email_provider_api.js';
-import { Google } from '../../google.js';
-import { ProgressCb, RecipientType, ChunkedCb, ProviderContactsResults } from '../../api.js';
-import { Buf } from '../../../core/buf.js';
-import { Mime } from '../../../core/mime.js';
-import { Value, Str, Dict } from '../../../core/common.js';
-import { Env } from '../../../browser/env.js';
-import { BrowserMsg } from '../../../browser/browser-msg.js';
-import { Catch } from '../../../platform/catch.js';
-import { Att } from '../../../core/att.js';
-import { FormatError } from '../../../core/pgp-msg.js';
-import { Contact } from '../../../core/pgp-key.js';
-import { Xss } from '../../../platform/xss.js';
-import { Store } from '../../../platform/store.js';
-import { GmailRes, GmailParser } from './gmail-parser.js';
-import { GoogleAuth } from '../../google-auth.js';
 import { AddrParserResult, BrowserWindow } from '../../../browser/browser-window.js';
-import { PgpArmor } from '../../../core/pgp-armor.js';
+import { ChunkedCb, ProgressCb, ProviderContactsResults, RecipientType } from '../../api.js';
+import { Dict, Str, Value } from '../../../core/common.js';
+import { EmailProviderApi, EmailProviderInterface, SendableMsg } from '../email_provider_api.js';
+import { GOOGLE_API_HOST, gmailBackupSearchQuery } from '../../../core/const.js';
+import { GmailParser, GmailRes } from './gmail-parser.js';
+
 import { AjaxErr } from '../../error/api-error-types.js';
+import { Att } from '../../../core/att.js';
+import { BrowserMsg } from '../../../browser/browser-msg.js';
+import { Buf } from '../../../core/buf.js';
+import { Catch } from '../../../platform/catch.js';
+import { Contact } from '../../../core/pgp-key.js';
+import { Env } from '../../../browser/env.js';
+import { FormatError } from '../../../core/pgp-msg.js';
+import { Google } from '../../google.js';
+import { GoogleAuth } from '../../google-auth.js';
+import { Mime } from '../../../core/mime.js';
+import { PgpArmor } from '../../../core/pgp-armor.js';
 import { PgpKey } from '../../../core/pgp-key.js';
+import { Store } from '../../../platform/store.js';
+import { Xss } from '../../../platform/xss.js';
 
 export type GmailResponseFormat = 'raw' | 'full' | 'metadata';
 

--- a/extension/js/common/api/error/api-error.ts
+++ b/extension/js/common/api/error/api-error.ts
@@ -1,7 +1,8 @@
-import { Xss } from '../../platform/xss.js';
-import { AjaxErr, ApiErrResponse, StandardError, StandardErrRes, AuthErr, GoogleAuthErr } from './api-error-types.js';
-import { Catch } from '../../platform/catch.js';
+import { AjaxErr, ApiErrResponse, AuthErr, GoogleAuthErr, StandardErrRes, StandardError } from './api-error-types.js';
+
 import { BgNotReadyErr } from '../../browser/browser-msg.js';
+import { Catch } from '../../platform/catch.js';
+import { Xss } from '../../platform/xss.js';
 
 export class ApiErr {
   static eli5 = (e: any): string => {

--- a/extension/js/common/api/google-auth.ts
+++ b/extension/js/common/api/google-auth.ts
@@ -7,20 +7,21 @@
 
 const BUILD = 'consumer'; // todo
 
-import { Catch } from '../platform/catch.js';
-import { Store, AccountStore } from '../platform/store.js';
-import { Api } from './api.js';
-import { Ui } from '../browser/ui.js';
-import { Value, Url } from '../core/common.js';
-import { GoogleAuthWindowResult$result } from '../browser/browser-msg.js';
-import { tabsQuery, windowsCreate } from './chrome.js';
-import { Buf } from '../core/buf.js';
+import { AccountStore, Store } from '../platform/store.js';
 import { GOOGLE_API_HOST, GOOGLE_OAUTH_SCREEN_HOST } from '../core/const.js';
-import { GmailRes } from './email_provider/gmail/gmail-parser.js';
-import { GoogleAuthErr } from './error/api-error-types.js';
+import { Url, Value } from '../core/common.js';
+import { tabsQuery, windowsCreate } from './chrome.js';
+
+import { Api } from './api.js';
 import { ApiErr } from './error/api-error.js';
 import { Backend } from './backend.js';
+import { Buf } from '../core/buf.js';
+import { Catch } from '../platform/catch.js';
+import { GmailRes } from './email_provider/gmail/gmail-parser.js';
+import { GoogleAuthErr } from './error/api-error-types.js';
+import { GoogleAuthWindowResult$result } from '../browser/browser-msg.js';
 import { Rules } from '../rules.js';
+import { Ui } from '../browser/ui.js';
 
 type GoogleAuthTokenInfo = { issued_to: string, audience: string, scope: string, expires_in: number, access_type: 'offline' };
 type GoogleAuthTokensResponse = { access_token: string, expires_in: number, refresh_token?: string, id_token: string, token_type: 'Bearer' };

--- a/extension/js/common/api/google.ts
+++ b/extension/js/common/api/google.ts
@@ -4,12 +4,13 @@
 
 // tslint:disable:no-direct-ajax
 
-import { Serializable } from '../platform/store.js';
-import { Api, ReqMethod, ProgressCbs } from './api.js';
+import { Api, ProgressCbs, ReqMethod } from './api.js';
 import { Dict, Str } from '../core/common.js';
+
 import { GOOGLE_API_HOST } from '../core/const.js';
 import { GmailRes } from './email_provider/gmail/gmail-parser.js';
 import { GoogleAuth } from './google-auth.js';
+import { Serializable } from '../platform/store.js';
 
 export class Google {
 

--- a/extension/js/common/api/keyserver.ts
+++ b/extension/js/common/api/keyserver.ts
@@ -2,8 +2,8 @@
 
 'use strict';
 
-import { Rules } from '../rules.js';
 import { Attester } from './attester.js';
+import { Rules } from '../rules.js';
 import { Sks } from './sks.js';
 
 export type PgpClient = 'flowcrypt' | 'pgp-other' | null;

--- a/extension/js/common/api/sks.ts
+++ b/extension/js/common/api/sks.ts
@@ -3,9 +3,9 @@
 'use strict';
 
 import { Api } from './api.js';
-import { PubkeySearchResult } from './keyserver.js';
-import { PgpArmor } from '../core/pgp-armor.js';
 import { ApiErr } from './error/api-error.js';
+import { PgpArmor } from '../core/pgp-armor.js';
+import { PubkeySearchResult } from './keyserver.js';
 
 export class Sks extends Api {
 

--- a/extension/js/common/assert.ts
+++ b/extension/js/common/assert.ts
@@ -2,15 +2,16 @@
 
 'use strict';
 
-import { Ui } from './browser/ui.js';
-import { Dict, UrlParams, UrlParam } from './core/common.js';
 import { Catch, UnreportableError } from './platform/catch.js';
-import { KeyInfo } from './core/pgp-key.js';
+import { Dict, UrlParam, UrlParams } from './core/common.js';
+
 import { BrowserMsg } from './browser/browser-msg.js';
-import { Store } from './platform/store.js';
-import { Settings } from './settings.js';
-import { Xss } from './platform/xss.js';
+import { KeyInfo } from './core/pgp-key.js';
 import { PgpKey } from './core/pgp-key.js';
+import { Settings } from './settings.js';
+import { Store } from './platform/store.js';
+import { Ui } from './browser/ui.js';
+import { Xss } from './platform/xss.js';
 
 /**
  * Methods in this class will render a fatal message in the browser when assertion fails.

--- a/extension/js/common/browser/browser-extension.ts
+++ b/extension/js/common/browser/browser-extension.ts
@@ -2,8 +2,8 @@
 
 'use strict';
 
-import { Dict } from '../core/common.js';
 import { Catch } from '../platform/catch.js';
+import { Dict } from '../core/common.js';
 import { FlatTypes } from '../platform/store.js';
 
 export class BrowserExtension { // todo - move extension-specific common.js code here

--- a/extension/js/common/browser/browser-msg.ts
+++ b/extension/js/common/browser/browser-msg.ts
@@ -2,19 +2,20 @@
 
 'use strict';
 
-import { Str, Dict, UrlParams } from '../core/common.js';
-import { DiagnoseMsgPubkeysResult, DecryptResult, VerifyRes, PgpMsgTypeResult, PgpMsgMethod } from '../core/pgp-msg.js';
-import { GlobalIndex, GlobalStore, AccountIndex, AccountStore } from '../platform/store.js';
-import { Browser } from './browser.js';
-import { Catch } from '../platform/catch.js';
-import { Buf } from '../core/buf.js';
-import { PassphraseDialogType } from '../xss_safe_factory.js';
-import { AuthRes } from '../api/google-auth.js';
-import { BrowserMsgCommonHandlers } from './browser-msg-common-handlers.js';
-import { Env } from './env.js';
-import { Ui } from './ui.js';
+import { AccountIndex, AccountStore, GlobalIndex, GlobalStore } from '../platform/store.js';
+import { DecryptResult, DiagnoseMsgPubkeysResult, PgpMsgMethod, PgpMsgTypeResult, VerifyRes } from '../core/pgp-msg.js';
+import { Dict, Str, UrlParams } from '../core/common.js';
+
 import { AjaxErr } from '../api/error/api-error-types.js';
+import { AuthRes } from '../api/google-auth.js';
+import { Browser } from './browser.js';
+import { BrowserMsgCommonHandlers } from './browser-msg-common-handlers.js';
+import { Buf } from '../core/buf.js';
+import { Catch } from '../platform/catch.js';
+import { Env } from './env.js';
 import { KeyDetails } from '../core/pgp-key.js';
+import { PassphraseDialogType } from '../xss_safe_factory.js';
+import { Ui } from './ui.js';
 
 export type GoogleAuthWindowResult$result = 'Success' | 'Denied' | 'Error' | 'Closed';
 

--- a/extension/js/common/browser/browser.ts
+++ b/extension/js/common/browser/browser.ts
@@ -4,11 +4,11 @@
 
 'use strict';
 
-import { Catch } from '../platform/catch.js';
 import { Api } from '../api/api.js';
 import { Att } from '../core/att.js';
-import { Xss } from '../platform/xss.js';
+import { Catch } from '../platform/catch.js';
 import { Ui } from './ui.js';
+import { Xss } from '../platform/xss.js';
 
 export class Browser {
 

--- a/extension/js/common/browser/ui.ts
+++ b/extension/js/common/browser/ui.ts
@@ -2,11 +2,11 @@
 
 'use strict';
 
-import Swal from 'sweetalert2';
-import { Dict } from '../core/common.js';
-import { Catch } from '../platform/catch.js';
-import { Xss } from '../platform/xss.js';
 import { ApiErr } from '../api/error/api-error.js';
+import { Catch } from '../platform/catch.js';
+import { Dict } from '../core/common.js';
+import Swal from 'sweetalert2';
+import { Xss } from '../platform/xss.js';
 
 type NamedSels = Dict<JQuery<HTMLElement>>;
 type ProvidedEventHandler = (e: HTMLElement, event: JQuery.Event<HTMLElement, null>) => void | Promise<void>;

--- a/extension/js/common/core/buf.ts
+++ b/extension/js/common/core/buf.ts
@@ -2,7 +2,7 @@
 
 'use strict';
 
-import { base64encode, base64decode } from '../platform/util.js';
+import { base64decode, base64encode } from '../platform/util.js';
 
 export class Buf extends Uint8Array {
 

--- a/extension/js/common/core/common.ts
+++ b/extension/js/common/core/common.ts
@@ -2,7 +2,7 @@
 
 'use strict';
 
-import { base64encode, base64decode } from '../platform/util.js';
+import { base64decode, base64encode } from '../platform/util.js';
 
 export type Dict<T> = { [key: string]: T; };
 export type UrlParam = string | number | null | undefined | boolean | string[];

--- a/extension/js/common/core/mime.ts
+++ b/extension/js/common/core/mime.ts
@@ -2,15 +2,16 @@
 
 'use strict';
 
-import { Str, Dict } from './common.js';
-import { Catch } from '../platform/catch.js';
-import { requireMimeParser, requireMimeBuilder, requireIso88592 } from '../platform/require.js';
-import { Buf } from './buf.js';
-import { MimeParserNode } from './types/emailjs';
-import { PgpArmor } from './pgp-armor.js';
-import { MsgBlock } from './msg-block.js';
+import { Dict, Str } from './common.js';
+import { requireIso88592, requireMimeBuilder, requireMimeParser } from '../platform/require.js';
+
 import { Att } from './att.js';
+import { Buf } from './buf.js';
+import { Catch } from '../platform/catch.js';
+import { MimeParserNode } from './types/emailjs';
+import { MsgBlock } from './msg-block.js';
 import { MsgBlockParser } from './msg-block-parser.js';
+import { PgpArmor } from './pgp-armor.js';
 
 const MimeParser = requireMimeParser();  // tslint:disable-line:variable-name
 const MimeBuilder = requireMimeBuilder();  // tslint:disable-line:variable-name

--- a/extension/js/common/core/msg-block-parser.ts
+++ b/extension/js/common/core/msg-block-parser.ts
@@ -2,15 +2,16 @@
 
 'use strict';
 
-import { Catch } from '../platform/catch.js';
-import { Str } from './common.js';
-import { PgpArmor } from './pgp-armor.js';
-import { Mime } from './mime.js';
-import { Xss } from '../platform/xss.js';
 import { MsgBlock, ReplaceableMsgBlockType } from './msg-block.js';
+
 import { Buf } from './buf.js';
-import { PgpMsg } from './pgp-msg.js';
+import { Catch } from '../platform/catch.js';
+import { Mime } from './mime.js';
+import { PgpArmor } from './pgp-armor.js';
 import { PgpKey } from './pgp-key.js';
+import { PgpMsg } from './pgp-msg.js';
+import { Str } from './common.js';
+import { Xss } from '../platform/xss.js';
 
 export class MsgBlockParser {
 

--- a/extension/js/common/core/msg-block.ts
+++ b/extension/js/common/core/msg-block.ts
@@ -2,10 +2,11 @@
 
 'use strict';
 
+import { DecryptError, VerifyRes } from './pgp-msg.js';
+
+import { AttMeta } from './att.js';
 import { Buf } from './buf.js';
 import { KeyDetails } from './pgp-key.js';
-import { AttMeta } from './att.js';
-import { DecryptError, VerifyRes } from './pgp-msg.js';
 
 export type KeyBlockType = 'publicKey' | 'privateKey';
 export type ReplaceableMsgBlockType = KeyBlockType | 'signedMsg' | 'encryptedMsg' | 'encryptedMsgLink';

--- a/extension/js/common/core/pgp-armor.ts
+++ b/extension/js/common/core/pgp-armor.ts
@@ -2,10 +2,10 @@
 
 'use strict';
 
-import { Str } from './common.js';
-import { openpgp } from './pgp.js';
 import { Buf } from './buf.js';
 import { ReplaceableMsgBlockType } from './msg-block.js';
+import { Str } from './common.js';
+import { openpgp } from './pgp.js';
 
 export type PreparedForDecrypt = { isArmored: boolean, isCleartext: true, message: OpenPGP.cleartext.CleartextMessage }
   | { isArmored: boolean, isCleartext: false, message: OpenPGP.message.Message };

--- a/extension/js/common/core/pgp-hash.ts
+++ b/extension/js/common/core/pgp-hash.ts
@@ -2,8 +2,8 @@
 
 'use strict';
 
-import { openpgp } from './pgp.js';
 import { Buf } from './buf.js';
+import { openpgp } from './pgp.js';
 
 export class PgpHash {
 

--- a/extension/js/common/core/pgp-key.ts
+++ b/extension/js/common/core/pgp-key.ts
@@ -2,13 +2,13 @@
 
 'use strict';
 
-import { openpgp } from './pgp.js';
-import { Store } from '../platform/store.js';
-import { PgpArmor } from './pgp-armor.js';
 import { Buf } from './buf.js';
 import { Catch } from '../platform/catch.js';
-import { mnemonic } from './mnemonic.js';
 import { MsgBlockParser } from './msg-block-parser.js';
+import { PgpArmor } from './pgp-armor.js';
+import { Store } from '../platform/store.js';
+import { mnemonic } from './mnemonic.js';
+import { openpgp } from './pgp.js';
 
 export type Contact = {
   email: string;

--- a/extension/js/common/core/pgp-msg.ts
+++ b/extension/js/common/core/pgp-msg.ts
@@ -2,17 +2,18 @@
 
 'use strict';
 
-import { Catch } from '../platform/catch.js';
-import { Store } from '../platform/store.js';
+import { Contact, KeyInfo, PgpKey, PrvKeyInfo } from './pgp-key.js';
+import { MsgBlock, MsgBlockType } from './msg-block.js';
 import { Str, Value } from './common.js';
-import { FcAttLinkData } from './att.js';
+
 import { Buf } from './buf.js';
-import { PgpHash } from './pgp-hash.js';
-import { PgpArmor } from './pgp-armor.js';
-import { PgpKey, PrvKeyInfo, KeyInfo, Contact } from './pgp-key.js';
-import { openpgp } from './pgp.js';
-import { MsgBlockType, MsgBlock } from './msg-block.js';
+import { Catch } from '../platform/catch.js';
+import { FcAttLinkData } from './att.js';
 import { MsgBlockParser } from './msg-block-parser.js';
+import { PgpArmor } from './pgp-armor.js';
+import { PgpHash } from './pgp-hash.js';
+import { Store } from '../platform/store.js';
+import { openpgp } from './pgp.js';
 
 export namespace PgpMsgMethod {
   export namespace Arg {

--- a/extension/js/common/core/pgp-password.ts
+++ b/extension/js/common/core/pgp-password.ts
@@ -2,8 +2,9 @@
 
 'use strict';
 
-import { openpgp } from './pgp.js';
 import { base64encode, secureRandomBytes } from '../platform/util.js';
+
+import { openpgp } from './pgp.js';
 
 interface PwdStrengthResult {
   word: {

--- a/extension/js/common/core/pgp.ts
+++ b/extension/js/common/core/pgp.ts
@@ -2,9 +2,10 @@
 
 'use strict';
 
-import { requireOpenpgp } from '../platform/require.js';
-import { VERSION } from './const.js';
 import { PgpKey, PrvPacket } from './pgp-key.js';
+
+import { VERSION } from './const.js';
+import { requireOpenpgp } from '../platform/require.js';
 
 export const openpgp = requireOpenpgp();
 

--- a/extension/js/common/inject.ts
+++ b/extension/js/common/inject.ts
@@ -2,13 +2,14 @@
 
 'use strict';
 
-import { XssSafeFactory, WebmailVariantString } from './xss_safe_factory.js';
-import { Catch } from './platform/catch.js';
-import { Store } from './platform/store.js';
-import { Dict } from './core/common.js';
-import { WebMailName } from './browser/env.js';
 import { SelCache, Ui } from './browser/ui.js';
+import { WebmailVariantString, XssSafeFactory } from './xss_safe_factory.js';
+
+import { Catch } from './platform/catch.js';
 import { ContentScriptWindow } from './browser/browser-window.js';
+import { Dict } from './core/common.js';
+import { Store } from './platform/store.js';
+import { WebMailName } from './browser/env.js';
 
 type Host = {
   gmail: string,

--- a/extension/js/common/notifications.ts
+++ b/extension/js/common/notifications.ts
@@ -2,12 +2,12 @@
 
 'use strict';
 
-import { Catch } from './platform/catch.js';
-import { Store } from './platform/store.js';
-import { Dict } from './core/common.js';
 import { BrowserMsg } from './browser/browser-msg.js';
-import { Ui } from './browser/ui.js';
+import { Catch } from './platform/catch.js';
+import { Dict } from './core/common.js';
 import { Lang } from './lang.js';
+import { Store } from './platform/store.js';
+import { Ui } from './browser/ui.js';
 import { Xss } from './platform/xss.js';
 
 export type NotificationWithHandlers = { notification: string, callbacks: Dict<() => void> };

--- a/extension/js/common/platform/store.ts
+++ b/extension/js/common/platform/store.ts
@@ -2,21 +2,22 @@
 
 'use strict';
 
-import { Value, Str, Dict, PromiseCancellation } from '../core/common.js';
-import { mnemonic } from '../core/mnemonic.js';
-import { KeyInfo, Contact } from '../core/pgp-key.js';
-import { SubscriptionInfo, PaymentMethod, FcUuidAuth, SubscriptionLevel } from '../api/backend.js';
-import { BrowserMsg, BgNotReadyErr } from '../browser/browser-msg.js';
+import { BgNotReadyErr, BrowserMsg } from '../browser/browser-msg.js';
 import { Catch, UnreportableError } from './catch.js';
-import { storageLocalSet, storageLocalGet, storageLocalRemove } from '../api/chrome.js';
-import { PgpClient } from '../api/keyserver.js';
-import { GmailRes } from '../api/email_provider/gmail/gmail-parser.js';
-import { GoogleAuth } from '../api/google-auth.js';
+import { Contact, KeyInfo } from '../core/pgp-key.js';
+import { Dict, PromiseCancellation, Str, Value } from '../core/common.js';
+import { FcUuidAuth, PaymentMethod, SubscriptionInfo, SubscriptionLevel } from '../api/backend.js';
+import { storageLocalGet, storageLocalRemove, storageLocalSet } from '../api/chrome.js';
+
 import { DomainRules } from '../rules.js';
 import { Env } from '../browser/env.js';
-import { Ui } from '../browser/ui.js';
+import { GmailRes } from '../api/email_provider/gmail/gmail-parser.js';
+import { GoogleAuth } from '../api/google-auth.js';
 import { PgpArmor } from '../core/pgp-armor.js';
+import { PgpClient } from '../api/keyserver.js';
 import { PgpKey } from '../core/pgp-key.js';
+import { Ui } from '../browser/ui.js';
+import { mnemonic } from '../core/mnemonic.js';
 
 // tslint:disable:no-null-keyword
 

--- a/extension/js/common/settings.ts
+++ b/extension/js/common/settings.ts
@@ -2,25 +2,26 @@
 
 'use strict';
 
-import { Catch } from './platform/catch.js';
-import { Store, SendAsAlias } from './platform/store.js';
-import { Str, Dict, UrlParams, Url } from './core/common.js';
-import { Lang } from './lang.js';
-import { Rules } from './rules.js';
+import { Dict, Str, Url, UrlParams } from './core/common.js';
+import { JQS, Ui } from './browser/ui.js';
+import { SendAsAlias, Store } from './platform/store.js';
+
 import { Api } from './api/api.js';
-import { GoogleAuth } from './api/google-auth.js';
-import { Attester } from './api/attester.js';
-import { Xss } from './platform/xss.js';
-import { Backend } from './api/backend.js';
-import { storageLocalGetAll } from './api/chrome.js';
-import { Gmail } from './api/email_provider/gmail/gmail.js';
-import { Ui, JQS } from './browser/ui.js';
-import { Env } from './browser/env.js';
 import { ApiErr } from './api/error/api-error.js';
 import { ApiErrResponse } from './api/error/api-error-types.js';
-import { PgpPwd } from './core/pgp-password.js';
+import { Attester } from './api/attester.js';
+import { Backend } from './api/backend.js';
+import { Catch } from './platform/catch.js';
+import { Env } from './browser/env.js';
+import { Gmail } from './api/email_provider/gmail/gmail.js';
+import { GoogleAuth } from './api/google-auth.js';
+import { Lang } from './lang.js';
 import { PgpKey } from './core/pgp-key.js';
+import { PgpPwd } from './core/pgp-password.js';
+import { Rules } from './rules.js';
+import { Xss } from './platform/xss.js';
 import { openpgp } from './core/pgp.js';
+import { storageLocalGetAll } from './api/chrome.js';
 
 declare const zxcvbn: Function; // tslint:disable-line:ban-types
 

--- a/extension/js/common/ui/att_ui.ts
+++ b/extension/js/common/ui/att_ui.ts
@@ -2,10 +2,10 @@
 
 'use strict';
 
-import { PgpMsg } from '../core/pgp-msg.js';
-import { Dict } from '../core/common.js';
 import { Att } from '../core/att.js';
 import { Catch } from '../platform/catch.js';
+import { Dict } from '../core/common.js';
+import { PgpMsg } from '../core/pgp-msg.js';
 import { Ui } from '../browser/ui.js';
 
 declare const qq: any;

--- a/extension/js/common/ui/fetch_key_ui.ts
+++ b/extension/js/common/ui/fetch_key_ui.ts
@@ -2,10 +2,10 @@
 
 'use strict';
 
-import { Ui } from '../browser/ui.js';
+import { BrowserMsg } from '../browser/browser-msg.js';
 import { Catch } from '../platform/catch.js';
 import { KeyImportUi } from './key_import_ui.js';
-import { BrowserMsg } from '../browser/browser-msg.js';
+import { Ui } from '../browser/ui.js';
 
 export class FetchKeyUI {
   handleOnPaste = (elem: JQuery<HTMLElement>) => {

--- a/extension/js/common/ui/key_import_ui.ts
+++ b/extension/js/common/ui/key_import_ui.ts
@@ -2,20 +2,20 @@
 
 'use strict';
 
+import { AttUI } from './att_ui.js';
+import { Catch } from '../platform/catch.js';
+import { KeyBlockType } from '../core/msg-block.js';
+import { Lang } from '../lang.js';
+import { MsgBlockParser } from '../core/msg-block-parser.js';
+import { PgpArmor } from '../core/pgp-armor.js';
+import { PgpKey } from '../core/pgp-key.js';
+import { PgpPwd } from '../core/pgp-password.js';
+import { Settings } from '../settings.js';
 import { Store } from '../platform/store.js';
 import { Ui } from '../browser/ui.js';
-import { mnemonic } from '../core/mnemonic.js';
-import { AttUI } from './att_ui.js';
-import { Lang } from '../lang.js';
-import { Catch } from '../platform/catch.js';
-import { Settings } from '../settings.js';
 import { Url } from '../core/common.js';
-import { PgpArmor } from '../core/pgp-armor.js';
-import { PgpPwd } from '../core/pgp-password.js';
-import { PgpKey } from '../core/pgp-key.js';
+import { mnemonic } from '../core/mnemonic.js';
 import { openpgp } from '../core/pgp.js';
-import { KeyBlockType } from '../core/msg-block.js';
-import { MsgBlockParser } from '../core/msg-block-parser.js';
 
 type KeyImportUiCheckResult = {
   normalized: string; longid: string; passphrase: string; fingerprint: string; decrypted: OpenPGP.key.Key;

--- a/extension/js/common/ui/passphrase_ui.ts
+++ b/extension/js/common/ui/passphrase_ui.ts
@@ -3,9 +3,9 @@
 
 'use strict';
 
+import { Catch } from '../platform/catch.js';
 import { Store } from '../platform/store.js';
 import { Ui } from '../browser/ui.js';
-import { Catch } from '../platform/catch.js';
 import { Xss } from '../platform/xss.js';
 
 export const shouldPassPhraseBeHidden = async () => {

--- a/extension/js/common/view.ts
+++ b/extension/js/common/view.ts
@@ -3,9 +3,10 @@
 
 'use strict';
 
-import { Xss } from './platform/xss.js';
-import { Ui, BrowserEventErrHandler, PreventableEventName } from './browser/ui.js';
+import { BrowserEventErrHandler, PreventableEventName, Ui } from './browser/ui.js';
+
 import { ApiErr } from './api/error/api-error.js';
+import { Xss } from './platform/xss.js';
 
 export abstract class View {
 

--- a/extension/js/common/webmail.ts
+++ b/extension/js/common/webmail.ts
@@ -2,8 +2,8 @@
 
 'use strict';
 
-import { Store } from './platform/store.js';
 import { Injector } from './inject.js';
+import { Store } from './platform/store.js';
 
 export class WebmailCommon {
   private acctEmail: string;

--- a/extension/js/common/xss_safe_factory.ts
+++ b/extension/js/common/xss_safe_factory.ts
@@ -4,17 +4,18 @@
 
 'use strict';
 
-import { Catch } from './platform/catch.js';
-import { Str, Dict, UrlParams, Url } from './core/common.js';
+import { Dict, Str, Url, UrlParams } from './core/common.js';
+
 import { Att } from './core/att.js';
 import { Browser } from './browser/browser.js';
-import { Xss } from './platform/xss.js';
+import { Catch } from './platform/catch.js';
+import { MsgBlock } from './core/msg-block.js';
+import { MsgBlockParser } from './core/msg-block-parser.js';
+import { PgpArmor } from './core/pgp-armor.js';
 import { SendAsAlias } from './platform/store.js';
 import { Ui } from './browser/ui.js';
 import { WebMailName } from './browser/env.js';
-import { PgpArmor } from './core/pgp-armor.js';
-import { MsgBlock } from './core/msg-block.js';
-import { MsgBlockParser } from './core/msg-block-parser.js';
+import { Xss } from './platform/xss.js';
 
 type Placement = 'settings' | 'settings_compose' | 'default' | 'dialog' | 'gmail' | 'embedded' | 'compose';
 export type WebmailVariantString = undefined | 'html' | 'standard' | 'new';

--- a/extension/js/content_scripts/checkout/stripe.ts
+++ b/extension/js/content_scripts/checkout/stripe.ts
@@ -2,10 +2,10 @@
 
 'use strict';
 
-import { Catch } from '../../common/platform/catch.js';
 import { Assert } from '../../common/assert.js';
-import { Url } from '../../common/core/common.js';
 import { BrowserMsg } from '../../common/browser/browser-msg.js';
+import { Catch } from '../../common/platform/catch.js';
+import { Url } from '../../common/core/common.js';
 
 Catch.try(async () => {
 

--- a/extension/js/content_scripts/webmail/gmail_element_replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail_element_replacer.ts
@@ -2,25 +2,26 @@
 
 'use strict';
 
-import { Str, Dict } from '../../common/core/common.js';
-import { Injector } from '../../common/inject.js';
-import { Notifications } from '../../common/notifications.js';
-import { XssSafeFactory, WebmailVariantString, FactoryReplyParams } from '../../common/xss_safe_factory.js';
+import { Dict, Str } from '../../common/core/common.js';
+import { FactoryReplyParams, WebmailVariantString, XssSafeFactory } from '../../common/xss_safe_factory.js';
+import { GmailParser, GmailRes } from '../../common/api/email_provider/gmail/gmail-parser.js';
+import { IntervalFunction, WebmailElementReplacer } from './setup_webmail_content_script.js';
+import { SendAsAlias, Store } from '../../common/platform/store.js';
+
+import { AjaxErr } from '../../common/api/error/api-error-types.js';
+import { ApiErr } from '../../common/api/error/api-error.js';
 import { Att } from '../../common/core/att.js';
-import { WebmailElementReplacer, IntervalFunction } from './setup_webmail_content_script.js';
-import { Catch } from '../../common/platform/catch.js';
-import { Xss } from '../../common/platform/xss.js';
-import { Keyserver } from '../../common/api/keyserver.js';
-import { WebmailCommon } from "../../common/webmail.js";
-import { Store, SendAsAlias } from '../../common/platform/store.js';
-import { GmailRes, GmailParser } from '../../common/api/email_provider/gmail/gmail-parser.js';
-import { Gmail } from '../../common/api/email_provider/gmail/gmail.js';
-import { Ui } from '../../common/browser/ui.js';
 import { Browser } from '../../common/browser/browser.js';
 import { BrowserMsg } from '../../common/browser/browser-msg.js';
-import { ApiErr } from '../../common/api/error/api-error.js';
-import { AjaxErr } from '../../common/api/error/api-error-types.js';
+import { Catch } from '../../common/platform/catch.js';
+import { Gmail } from '../../common/api/email_provider/gmail/gmail.js';
+import { Injector } from '../../common/inject.js';
+import { Keyserver } from '../../common/api/keyserver.js';
+import { Notifications } from '../../common/notifications.js';
 import { PgpArmor } from '../../common/core/pgp-armor.js';
+import { Ui } from '../../common/browser/ui.js';
+import { WebmailCommon } from "../../common/webmail.js";
+import { Xss } from '../../common/platform/xss.js';
 
 type JQueryEl = JQuery<HTMLElement>;
 

--- a/extension/js/content_scripts/webmail/setup_webmail_content_script.ts
+++ b/extension/js/content_scripts/webmail/setup_webmail_content_script.ts
@@ -2,17 +2,18 @@
 
 'use strict';
 
-import { VERSION } from '../../common/core/const.js';
+import { Bm, BrowserMsg, TabIdRequiredError } from '../../common/browser/browser-msg.js';
+import { Env, WebMailName } from '../../common/browser/env.js';
+import { WebmailVariantString, XssSafeFactory } from '../../common/xss_safe_factory.js';
+
+import { BrowserMsgCommonHandlers } from '../../common/browser/browser-msg-common-handlers.js';
 import { Catch } from '../../common/platform/catch.js';
-import { Store } from '../../common/platform/store.js';
+import { ContentScriptWindow } from '../../common/browser/browser-window.js';
 import { Injector } from '../../common/inject.js';
 import { Notifications } from '../../common/notifications.js';
-import { BrowserMsg, TabIdRequiredError, Bm } from '../../common/browser/browser-msg.js';
-import { XssSafeFactory, WebmailVariantString } from '../../common/xss_safe_factory.js';
-import { WebMailName, Env } from '../../common/browser/env.js';
+import { Store } from '../../common/platform/store.js';
 import { Ui } from '../../common/browser/ui.js';
-import { ContentScriptWindow } from '../../common/browser/browser-window.js';
-import { BrowserMsgCommonHandlers } from '../../common/browser/browser-msg-common-handlers.js';
+import { VERSION } from '../../common/core/const.js';
 
 export type WebmailVariantObject = { newDataLayer: undefined | boolean, newUi: undefined | boolean, email: undefined | string, gmailVariant: WebmailVariantString };
 export type IntervalFunction = { interval: number, handler: () => void };

--- a/extension/js/content_scripts/webmail/webmail.ts
+++ b/extension/js/content_scripts/webmail/webmail.ts
@@ -6,16 +6,17 @@
 
 /// <reference path="../../../node_modules/@types/chrome/index.d.ts" />
 
+import { WebmailVariantObject, contentScriptSetupIfVacant } from './setup_webmail_content_script.js';
+
 import { Catch } from '../../common/platform/catch.js';
-import { Store } from '../../common/platform/store.js';
-import { Str } from '../../common/core/common.js';
-import { Injector } from '../../common/inject.js';
-import { Notifications } from '../../common/notifications.js';
-import { GmailElementReplacer } from './gmail_element_replacer.js';
-import { contentScriptSetupIfVacant, WebmailVariantObject } from './setup_webmail_content_script.js';
-import { XssSafeFactory } from '../../common/xss_safe_factory.js';
 import { ContentScriptWindow } from '../../common/browser/browser-window.js';
 import { Env } from '../../common/browser/env.js';
+import { GmailElementReplacer } from './gmail_element_replacer.js';
+import { Injector } from '../../common/inject.js';
+import { Notifications } from '../../common/notifications.js';
+import { Store } from '../../common/platform/store.js';
+import { Str } from '../../common/core/common.js';
+import { XssSafeFactory } from '../../common/xss_safe_factory.js';
 
 Catch.try(async () => {
 

--- a/test/samples/mock-data.ts
+++ b/test/samples/mock-data.ts
@@ -1,4 +1,4 @@
-import { GmailMsg, GmailDraft } from '../source/mock/google/google-data';
+import { GmailDraft, GmailMsg } from '../source/mock/google/google-data';
 
 type UserMessages = {
   [email: string]: {
@@ -46,7 +46,8 @@ const data: UserMessages = {
             "name": "MIME-Version", "value": "1.0"
           }],
           "parts": [{
-            "headers": [{ "name": "Content-Type", "value": "text/plain" },
+            "headers": [
+              { "name": "Content-Type", "value": "text/plain" },
               { "name": "Content-Transfer-Encoding", "value": "quoted-printable" }],
             "body": {
               attachmentId: "",
@@ -79,7 +80,8 @@ const data: UserMessages = {
             { "name": "MIME-Version", "value": "1.0" }],
           "parts": [
             {
-              "headers": [{ "name": "Content-Type", "value": "text/plain" },
+              "headers": [
+                { "name": "Content-Type", "value": "text/plain" },
                 { "name": "Content-Transfer-Encoding", "value": "quoted-printable" }],
             }]
         },

--- a/test/source/browser/browser_handle.ts
+++ b/test/source/browser/browser_handle.ts
@@ -1,10 +1,11 @@
-import { Page, Browser, Target, EvaluateFn } from 'puppeteer';
-import { Semaphore } from './browser_pool';
-import { ControllablePage } from './controllable';
-import { Util, Config } from '../util';
-import { TIMEOUT_ELEMENT_APPEAR } from '.';
+import { Browser, EvaluateFn, Page, Target } from 'puppeteer';
+import { Config, Util } from '../util';
+
 import { AvaContext } from '../tests';
+import { ControllablePage } from './controllable';
 import { FlowCryptApi } from '../tests/api';
+import { Semaphore } from './browser_pool';
+import { TIMEOUT_ELEMENT_APPEAR } from '.';
 
 export class BrowserHandle {
 

--- a/test/source/browser/browser_pool.ts
+++ b/test/source/browser/browser_pool.ts
@@ -1,10 +1,10 @@
+import { AvaContext, addDebugHtml, newWithTimeoutsFunc } from '../tests';
+import { Config, Util } from "../util";
 
-import { launch } from "puppeteer";
 import { BrowserHandle } from './browser_handle';
-import { Util, Config } from "../util";
-import { addDebugHtml, AvaContext, newWithTimeoutsFunc } from '../tests';
 import { Consts } from '../test';
 import { TIMEOUT_DESTROY_UNEXPECTED_ALERT } from '.';
+import { launch } from "puppeteer";
 
 class TimeoutError extends Error { }
 

--- a/test/source/browser/controllable.ts
+++ b/test/source/browser/controllable.ts
@@ -1,9 +1,9 @@
+import { AvaContext, newTimeoutPromise } from '../tests';
+import { ConsoleMessage, Dialog, ElementHandle, Frame, Page } from 'puppeteer';
+import { TIMEOUT_DESTROY_UNEXPECTED_ALERT, TIMEOUT_ELEMENT_APPEAR, TIMEOUT_ELEMENT_GONE, TIMEOUT_PAGE_LOAD, TIMEOUT_TEST_STATE_SATISFY } from '.';
 
-import { Page, ElementHandle, Frame, Dialog, ConsoleMessage } from 'puppeteer';
-import { Util } from '../util';
 import { TestUrls } from './test_urls';
-import { TIMEOUT_TEST_STATE_SATISFY, TIMEOUT_ELEMENT_APPEAR, TIMEOUT_ELEMENT_GONE, TIMEOUT_PAGE_LOAD, TIMEOUT_DESTROY_UNEXPECTED_ALERT } from '.';
-import { newTimeoutPromise, AvaContext } from '../tests';
+import { Util } from '../util';
 import { expect } from 'chai';
 
 declare const jQuery: any;

--- a/test/source/mock.ts
+++ b/test/source/mock.ts
@@ -1,9 +1,10 @@
-
-import { startAllApisMock } from './mock/all-apis-mock';
-import { Config } from './util';
 import * as request from 'fc-node-requests';
-import { writeFileSync, existsSync } from 'fs';
+
+import { existsSync, writeFileSync } from 'fs';
+
+import { Config } from './util';
 import { openpgp } from './core/pgp';
+import { startAllApisMock } from './mock/all-apis-mock';
 
 export const mock = async (logger: (line: string) => void) => {
   const start = Date.now();

--- a/test/source/mock/all-apis-mock.ts
+++ b/test/source/mock/all-apis-mock.ts
@@ -2,10 +2,12 @@
 
 'use strict';
 
-import { Api, Handlers } from './lib/api';
 import * as http from 'http';
-import { mockGoogleEndpoints } from './google/google-endpoints';
+
+import { Api, Handlers } from './lib/api';
+
 import { mockBackendEndpoints } from './backend/backend-endpoints';
+import { mockGoogleEndpoints } from './google/google-endpoints';
 
 export type HandlersDefinition = Handlers<{ query: { [k: string]: string; }; body?: unknown; }, unknown>;
 

--- a/test/source/mock/backend/backend-data.ts
+++ b/test/source/mock/backend/backend-data.ts
@@ -1,6 +1,6 @@
-import { OauthMock } from '../lib/oauth';
 import { Dict } from '../../core/common';
 import { HttpAuthErr } from '../lib/api';
+import { OauthMock } from '../lib/oauth';
 
 // tslint:disable:no-null-keyword
 

--- a/test/source/mock/backend/backend-endpoints.ts
+++ b/test/source/mock/backend/backend-endpoints.ts
@@ -1,11 +1,13 @@
-import { isPost } from '../lib/mock-util';
-import { HttpClientErr, HttpAuthErr } from '../lib/api';
-import { HandlersDefinition } from '../all-apis-mock';
-import { IncomingMessage } from 'http';
 import * as request from 'fc-node-requests';
-import { oauth } from '../lib/oauth';
+
+import { HttpAuthErr, HttpClientErr } from '../lib/api';
+
 import { BackendData } from './backend-data';
 import { Dict } from '../../core/common';
+import { HandlersDefinition } from '../all-apis-mock';
+import { IncomingMessage } from 'http';
+import { isPost } from '../lib/mock-util';
+import { oauth } from '../lib/oauth';
 
 export const mockBackendData = new BackendData(oauth);
 

--- a/test/source/mock/google/google-data.ts
+++ b/test/source/mock/google/google-data.ts
@@ -1,7 +1,7 @@
-import { Util } from '../../util/index';
 import { ParsedMail } from 'mailparser';
-import { readFileSync } from 'fs';
 import UserMessages from '../../../samples/mock-data';
+import { Util } from '../../util/index';
+import { readFileSync } from 'fs';
 
 type GmailMsg$header = { name: string, value: string };
 type GmailMsg$payload$body = { attachmentId: string, size: number, data?: string };

--- a/test/source/mock/google/google-endpoints.ts
+++ b/test/source/mock/google/google-endpoints.ts
@@ -1,11 +1,12 @@
+import { HttpClientErr, Status } from '../lib/api';
+import Parse, { ParseMsgResult } from '../../util/parse';
+import { isDelete, isGet, isPost, isPut, parseResourceId } from '../lib/mock-util';
+
+import { GoogleData } from './google-data';
+import { HandlersDefinition } from '../all-apis-mock';
+import { ParsedMail } from 'mailparser';
 import { TestBySubjectStrategyContext } from './strategies/send-message-strategy';
 import { UnsuportableStrategyError } from './strategies/strategy-base';
-import { isGet, isPost, parseResourceId, isPut, isDelete } from '../lib/mock-util';
-import { HttpClientErr, Status } from '../lib/api';
-import { GoogleData } from './google-data';
-import { ParsedMail } from 'mailparser';
-import Parse, { ParseMsgResult } from '../../util/parse';
-import { HandlersDefinition } from '../all-apis-mock';
 import { oauth } from '../lib/oauth';
 
 type DraftSaveModel = { message: { raw: string, threadId: string } };

--- a/test/source/mock/google/strategies/send-message-strategy.ts
+++ b/test/source/mock/google/strategies/send-message-strategy.ts
@@ -1,10 +1,11 @@
-import { GoogleData } from '../google-data';
-import { UnsuportableStrategyError, ITestMsgStrategy } from './strategy-base.js';
-import { ParsedMail, AddressObject } from 'mailparser';
-import { HttpClientErr } from '../../lib/api';
-import { Config } from '../../../util';
-import { PgpMsg } from '../../../core/pgp-msg';
+import { AddressObject, ParsedMail } from 'mailparser';
+import { ITestMsgStrategy, UnsuportableStrategyError } from './strategy-base.js';
+
 import { Buf } from '../../../core/buf';
+import { Config } from '../../../util';
+import { GoogleData } from '../google-data';
+import { HttpClientErr } from '../../lib/api';
+import { PgpMsg } from '../../../core/pgp-msg';
 
 class PwdEncryptedMessageTestStrategy implements ITestMsgStrategy {
   test = async (mimeMsg: ParsedMail) => {

--- a/test/source/mock/lib/oauth.ts
+++ b/test/source/mock/lib/oauth.ts
@@ -1,6 +1,7 @@
-import { HttpClientErr, Status, HttpAuthErr } from './api';
-import { Config } from '../../util';
+import { HttpAuthErr, HttpClientErr, Status } from './api';
+
 import { Buf } from '../../core/buf';
+import { Config } from '../../util';
 import { Str } from '../../core/common';
 
 // tslint:disable:variable-name

--- a/test/source/patterns.ts
+++ b/test/source/patterns.ts
@@ -1,6 +1,6 @@
-
-import { readdirSync, statSync, readFileSync } from 'fs';
 import * as path from 'path';
+
+import { readFileSync, readdirSync, statSync } from 'fs';
 
 let errsFound = 0;
 

--- a/test/source/test.ts
+++ b/test/source/test.ts
@@ -1,22 +1,24 @@
-import { defineFlakyTests } from './tests/tests/flaky';
-/* © 2016-2018 FlowCrypt Limited. Limitations apply. Contact human@flowcrypt.com */
-
 import * as ava from 'ava';
+
+import { AvaContext, GlobalBrowser, getDebugHtmlAtts, minutes, newWithTimeoutsFunc, standaloneTestTimeout } from './tests';
 import { BrowserHandle, BrowserPool } from './browser';
+import { Config, Util, getParsedCliParams } from './util';
+
 import { BrowserRecipe } from './tests/browser_recipe';
-import { defineUnitTests } from './tests/tests/unit';
-import { defineSetupTests } from './tests/tests/setup';
+import { FlowCryptApi } from './tests/api';
+import { defineConsumerAcctTests as defineAcctTests } from './tests/tests/account';
 import { defineComposeTests } from './tests/tests/compose';
 import { defineDecryptTests } from './tests/tests/decrypt';
+import { defineElementTests } from './tests/tests/elements';
+import { defineFlakyTests } from './tests/tests/flaky';
 import { defineGmailTests } from './tests/tests/gmail';
 import { defineSettingsTests } from './tests/tests/settings';
-import { defineElementTests } from './tests/tests/elements';
-import { defineConsumerAcctTests as defineAcctTests } from './tests/tests/account';
-import { Config, Util, getParsedCliParams } from './util';
-import { FlowCryptApi } from './tests/api';
-import { getDebugHtmlAtts, AvaContext, standaloneTestTimeout, minutes, GlobalBrowser, newWithTimeoutsFunc } from './tests';
+import { defineSetupTests } from './tests/tests/setup';
+import { defineUnitTests } from './tests/tests/unit';
 import { mock } from './mock';
 import { mockBackendData } from './mock/backend/backend-endpoints';
+/* © 2016-2018 FlowCrypt Limited. Limitations apply. Contact human@flowcrypt.com */
+
 
 const { testVariant, testGroup, oneIfNotPooled, buildDir, isMock } = getParsedCliParams();
 const startedAt = Date.now();

--- a/test/source/tests/api.ts
+++ b/test/source/tests/api.ts
@@ -1,7 +1,8 @@
 import * as request from 'fc-node-requests';
-import { Response } from 'request';
+
 import { Config } from '../util';
 import { Cookie } from 'puppeteer';
+import { Response } from 'request';
 
 const ci_admin_token = Config.secrets.ci_admin_token;
 

--- a/test/source/tests/browser_recipe.ts
+++ b/test/source/tests/browser_recipe.ts
@@ -1,10 +1,11 @@
-import { TestUrls } from './../browser/test_urls';
-import { BrowserHandle } from '../browser';
-import { Util, Config } from '../util';
+import { Config, Util } from '../util';
+
 import { AvaContext } from '.';
-import { SettingsPageRecipe } from './page_recipe/settings-page-recipe';
+import { BrowserHandle } from '../browser';
 import { OauthPageRecipe } from './page_recipe/oauth-page-recipe';
+import { SettingsPageRecipe } from './page_recipe/settings-page-recipe';
 import { SetupPageRecipe } from './page_recipe/setup-page-recipe';
+import { TestUrls } from './../browser/test_urls';
 
 export class BrowserRecipe {
 

--- a/test/source/tests/index.ts
+++ b/test/source/tests/index.ts
@@ -1,7 +1,7 @@
+import * as ava from 'ava';
 
 import { BrowserPool } from '../browser';
 import { Consts } from '../test';
-import * as ava from 'ava';
 
 export type AvaContext = ava.ExecutionContext<{}> & { retry?: true, attemptNumber?: number, totalAttempts?: number, attemptText?: string };
 export type GlobalBrowser = { browsers: BrowserPool };

--- a/test/source/tests/page_recipe/abstract-page-recipe.ts
+++ b/test/source/tests/page_recipe/abstract-page-recipe.ts
@@ -1,7 +1,8 @@
-import { ElementHandle } from 'puppeteer';
-import { Controllable, BrowserHandle, ControllablePage } from '../../browser';
-import { expect } from 'chai';
+import { BrowserHandle, Controllable, ControllablePage } from '../../browser';
+
 import { AvaContext } from '..';
+import { ElementHandle } from 'puppeteer';
+import { expect } from 'chai';
 
 type ModalOpts = { contentToCheck?: string, clickOn?: 'confirm' | 'cancel', getTriggeredPage?: boolean, timeout?: number };
 type ModalType = 'confirm' | 'error' | 'info' | 'warning';

--- a/test/source/tests/page_recipe/compose-page-recipe.ts
+++ b/test/source/tests/page_recipe/compose-page-recipe.ts
@@ -1,8 +1,9 @@
+import { BrowserHandle, Controllable, ControllableFrame, ControllablePage } from '../../browser';
+
 import { AvaContext } from '..';
-import { PageRecipe } from './abstract-page-recipe';
-import { BrowserHandle, ControllablePage, ControllableFrame, Controllable } from '../../browser';
 import { CommonBrowserGroup } from '../../test';
 import { EvaluateFn } from 'puppeteer';
+import { PageRecipe } from './abstract-page-recipe';
 import { Util } from '../../util';
 
 type RecipientType = "to" | "cc" | "bcc";

--- a/test/source/tests/page_recipe/gmail-page-recipe.ts
+++ b/test/source/tests/page_recipe/gmail-page-recipe.ts
@@ -1,6 +1,7 @@
-import { PageRecipe } from './abstract-page-recipe';
+import { BrowserHandle, ControllablePage } from '../../browser';
+
 import { AvaContext } from '..';
-import { ControllablePage, BrowserHandle } from '../../browser';
+import { PageRecipe } from './abstract-page-recipe';
 import { expect } from 'chai';
 
 export class GmailPageRecipe extends PageRecipe {

--- a/test/source/tests/page_recipe/inbox-page-recipe.ts
+++ b/test/source/tests/page_recipe/inbox-page-recipe.ts
@@ -1,7 +1,8 @@
-import { PageRecipe } from './abstract-page-recipe';
+import { BrowserHandle, ControllableFrame, ControllablePage } from '../../browser';
+
 import { AvaContext } from '..';
+import { PageRecipe } from './abstract-page-recipe';
 import { TestUrls } from '../../browser/test_urls';
-import { BrowserHandle, ControllablePage, ControllableFrame } from '../../browser';
 import { Util } from '../../util';
 
 type CheckDecryptMsg$opt = { acctEmail: string, threadId: string, expectedContent: string, enterPp?: string, finishCurrentSession?: boolean };

--- a/test/source/tests/page_recipe/oauth-page-recipe.ts
+++ b/test/source/tests/page_recipe/oauth-page-recipe.ts
@@ -1,9 +1,10 @@
-import { ControllablePage } from '../../browser';
-import { Util, Config } from '../../util';
+import { Config, Util } from '../../util';
+
 import { AvaContext } from '..';
+import { ControllablePage } from '../../browser';
 import { FlowCryptApi } from '../api';
-import { totp as produce2faToken } from 'speakeasy';
 import { PageRecipe } from './abstract-page-recipe';
+import { totp as produce2faToken } from 'speakeasy';
 
 export class OauthPageRecipe extends PageRecipe {
 

--- a/test/source/tests/page_recipe/settings-page-recipe.ts
+++ b/test/source/tests/page_recipe/settings-page-recipe.ts
@@ -1,6 +1,7 @@
-import { Util, Config } from '../../util';
+import { Config, Util } from '../../util';
+import { ControllableFrame, ControllablePage } from '../../browser';
+
 import { PageRecipe } from './abstract-page-recipe';
-import { ControllablePage, ControllableFrame } from '../../browser';
 import { expect } from 'chai';
 
 export class SettingsPageRecipe extends PageRecipe {

--- a/test/source/tests/page_recipe/setup-page-recipe.ts
+++ b/test/source/tests/page_recipe/setup-page-recipe.ts
@@ -1,8 +1,9 @@
-import { PageRecipe } from './abstract-page-recipe';
 import { Config, Util } from '../../util';
+
 import { ControllablePage } from '../../browser';
-import { expect } from 'chai';
+import { PageRecipe } from './abstract-page-recipe';
 import { SettingsPageRecipe } from './settings-page-recipe';
+import { expect } from 'chai';
 
 type ManualEnterOpts = {
   usedPgpBefore?: boolean,

--- a/test/source/tests/tests/account.ts
+++ b/test/source/tests/tests/account.ts
@@ -1,14 +1,15 @@
-
-import { TestWithNewBrowser, TestWithGlobalBrowser } from '../../test';
-import { BrowserRecipe } from '../browser_recipe';
 import * as ava from 'ava';
-import { Util } from '../../util';
-import { FlowCryptApi } from '../api';
-import { TestVariant } from '../../util';
-import { SetupPageRecipe } from '../page_recipe/setup-page-recipe';
-import { GmailPageRecipe } from '../page_recipe/gmail-page-recipe';
+
+import { TestWithGlobalBrowser, TestWithNewBrowser } from '../../test';
+
+import { BrowserRecipe } from '../browser_recipe';
 import { ComposePageRecipe } from '../page_recipe/compose-page-recipe';
+import { FlowCryptApi } from '../api';
+import { GmailPageRecipe } from '../page_recipe/gmail-page-recipe';
 import { PageRecipe } from '../page_recipe/abstract-page-recipe';
+import { SetupPageRecipe } from '../page_recipe/setup-page-recipe';
+import { TestVariant } from '../../util';
+import { Util } from '../../util';
 
 // tslint:disable:no-blank-lines-func
 

--- a/test/source/tests/tests/compose.ts
+++ b/test/source/tests/tests/compose.ts
@@ -1,22 +1,24 @@
-import { TestUrls } from './../../browser/test_urls';
-import { TestWithNewBrowser, TestWithGlobalBrowser } from '../../test';
-import { OauthPageRecipe } from '../page_recipe/oauth-page-recipe';
-import { ComposePageRecipe } from '../page_recipe/compose-page-recipe';
-import { PageRecipe } from '../page_recipe/abstract-page-recipe';
-import { BrowserRecipe } from '../browser_recipe';
-import { Controllable, BrowserHandle, ControllablePage } from '../../browser';
 import * as ava from 'ava';
-import { Util, Config } from '../../util';
-import { TestVariant } from '../../util';
-import { expect } from "chai";
+import * as request from 'fc-node-requests';
+
+import { BrowserHandle, Controllable, ControllablePage } from '../../browser';
+import { Config, Util } from '../../util';
+import { TestWithGlobalBrowser, TestWithNewBrowser } from '../../test';
+
 import { AvaContext } from '..';
+import { BrowserRecipe } from '../browser_recipe';
+import { ComposePageRecipe } from '../page_recipe/compose-page-recipe';
 import { Dict } from '../../core/common';
 import { GoogleData } from '../../mock/google/google-data';
-import * as request from 'fc-node-requests';
+import { InboxPageRecipe } from '../page_recipe/inbox-page-recipe';
+import { OauthPageRecipe } from '../page_recipe/oauth-page-recipe';
+import { PageRecipe } from '../page_recipe/abstract-page-recipe';
+import { PgpHash } from '../../core/pgp-hash';
 import { PgpMsg } from '../../core/pgp-msg';
 import { SettingsPageRecipe } from '../page_recipe/settings-page-recipe';
-import { InboxPageRecipe } from '../page_recipe/inbox-page-recipe';
-import { PgpHash } from '../../core/pgp-hash';
+import { TestUrls } from './../../browser/test_urls';
+import { TestVariant } from '../../util';
+import { expect } from "chai";
 // tslint:disable:no-blank-lines-func
 
 export const defineComposeTests = (testVariant: TestVariant, testWithNewBrowser: TestWithNewBrowser, testWithSemaphoredGlobalBrowser: TestWithGlobalBrowser) => {

--- a/test/source/tests/tests/decrypt.ts
+++ b/test/source/tests/tests/decrypt.ts
@@ -1,11 +1,13 @@
-import { TestUrls } from './../../browser/test_urls';
 import * as ava from 'ava';
-import { Config, Util, TestVariant } from '../../util';
+
+import { Config, TestVariant, Util } from '../../util';
+import { TestWithGlobalBrowser, TestWithNewBrowser } from '../../test';
+
 import { BrowserRecipe } from '../browser_recipe';
-import { TestWithNewBrowser, TestWithGlobalBrowser } from '../../test';
-import { expect } from "chai";
-import { SettingsPageRecipe } from '../page_recipe/settings-page-recipe';
 import { InboxPageRecipe } from '../page_recipe/inbox-page-recipe';
+import { SettingsPageRecipe } from '../page_recipe/settings-page-recipe';
+import { TestUrls } from './../../browser/test_urls';
+import { expect } from "chai";
 
 // tslint:disable:no-blank-lines-func
 // tslint:disable:max-line-length

--- a/test/source/tests/tests/elements.ts
+++ b/test/source/tests/tests/elements.ts
@@ -1,7 +1,9 @@
-import { TestWithNewBrowser, TestWithGlobalBrowser } from '../../test';
 import * as ava from 'ava';
-import { expect } from 'chai';
+
+import { TestWithGlobalBrowser, TestWithNewBrowser } from '../../test';
+
 import { TestVariant } from '../../util';
+import { expect } from 'chai';
 
 // tslint:disable:no-blank-lines-func
 

--- a/test/source/tests/tests/flaky.ts
+++ b/test/source/tests/tests/flaky.ts
@@ -1,11 +1,13 @@
-import { TestWithNewBrowser, TestWithGlobalBrowser } from '../../test';
+import * as ava from 'ava';
+
+import { TestWithGlobalBrowser, TestWithNewBrowser } from '../../test';
+
+import { BrowserRecipe } from '../browser_recipe';
 import { ComposePageRecipe } from '../page_recipe/compose-page-recipe';
 import { PageRecipe } from '../page_recipe/abstract-page-recipe';
-import { BrowserRecipe } from '../browser_recipe';
-import * as ava from 'ava';
-import { TestVariant } from '../../util';
 import { SettingsPageRecipe } from '../page_recipe/settings-page-recipe';
 import { SetupPageRecipe } from '../page_recipe/setup-page-recipe';
+import { TestVariant } from '../../util';
 // tslint:disable:no-blank-lines-func
 
 // these tests are run serially, one after another, because they are somewhat more sensitive to parallel testing

--- a/test/source/tests/tests/gmail.ts
+++ b/test/source/tests/tests/gmail.ts
@@ -1,14 +1,16 @@
-import { TestUrls } from './../../browser/test_urls';
-import { TestWithNewBrowser, TestWithGlobalBrowser } from '../../test';
-import { BrowserHandle, ControllablePage } from '../../browser';
 import * as ava from 'ava';
-import { expect } from 'chai';
-import { BrowserRecipe } from '../browser_recipe';
+
+import { BrowserHandle, ControllablePage } from '../../browser';
 import { TestVariant, Util } from '../../util';
+import { TestWithGlobalBrowser, TestWithNewBrowser } from '../../test';
+
 import { AvaContext } from '..';
+import { BrowserRecipe } from '../browser_recipe';
 import { GmailPageRecipe } from '../page_recipe/gmail-page-recipe';
 import { OauthPageRecipe } from '../page_recipe/oauth-page-recipe';
 import { SettingsPageRecipe } from '../page_recipe/settings-page-recipe';
+import { TestUrls } from './../../browser/test_urls';
+import { expect } from 'chai';
 
 /**
  * All tests that use mail.google.com or have to operate without a Gmail API mock should go here

--- a/test/source/tests/tests/settings.ts
+++ b/test/source/tests/tests/settings.ts
@@ -1,12 +1,14 @@
-import { TestUrls } from './../../browser/test_urls';
-import { TestWithNewBrowser, TestWithGlobalBrowser, internalTestState } from '../../test';
 import * as ava from 'ava';
-import { Util, Config } from '../../util';
-import { expect } from 'chai';
+
+import { Config, Util } from '../../util';
+import { TestWithGlobalBrowser, TestWithNewBrowser, internalTestState } from '../../test';
+
 import { BrowserRecipe } from '../browser_recipe';
-import { TestVariant } from '../../util';
-import { SettingsPageRecipe } from '../page_recipe/settings-page-recipe';
 import { InboxPageRecipe } from '../page_recipe/inbox-page-recipe';
+import { SettingsPageRecipe } from '../page_recipe/settings-page-recipe';
+import { TestUrls } from './../../browser/test_urls';
+import { TestVariant } from '../../util';
+import { expect } from 'chai';
 
 // tslint:disable:no-blank-lines-func
 

--- a/test/source/tests/tests/setup.ts
+++ b/test/source/tests/tests/setup.ts
@@ -1,7 +1,9 @@
-import { TestWithNewBrowser, TestWithGlobalBrowser } from '../../test';
-import { BrowserRecipe } from '../browser_recipe';
 import * as ava from 'ava';
+
 import { TestVariant, Util } from '../../util';
+import { TestWithGlobalBrowser, TestWithNewBrowser } from '../../test';
+
+import { BrowserRecipe } from '../browser_recipe';
 import { SetupPageRecipe } from '../page_recipe/setup-page-recipe';
 import { expect } from 'chai';
 

--- a/test/source/tests/tests/unit.ts
+++ b/test/source/tests/tests/unit.ts
@@ -1,10 +1,12 @@
-import { TestWithNewBrowser, TestWithGlobalBrowser } from '../../test';
-import { expect } from 'chai';
 import * as ava from 'ava';
-import { TestVariant } from '../../util';
-import { PgpHash } from '../../core/pgp-hash';
-import { MsgBlockParser } from '../../core/msg-block-parser';
+
+import { TestWithGlobalBrowser, TestWithNewBrowser } from '../../test';
+
 import { MsgBlock } from '../../core/msg-block';
+import { MsgBlockParser } from '../../core/msg-block-parser';
+import { PgpHash } from '../../core/pgp-hash';
+import { TestVariant } from '../../util';
+import { expect } from 'chai';
 
 // tslint:disable:no-blank-lines-func
 /* eslint-disable max-len */

--- a/tooling/build-types.ts
+++ b/tooling/build-types.ts
@@ -1,5 +1,6 @@
-import { execSync as exec } from 'child_process';
 import { readFileSync, writeFileSync } from 'fs';
+
+import { execSync as exec } from 'child_process';
 
 const CHROME_CONSUMER = 'chrome-consumer';
 const CHROME_ENTERPRISE = 'chrome-enterprise';

--- a/tooling/bundle-content-scripts.ts
+++ b/tooling/bundle-content-scripts.ts
@@ -4,7 +4,8 @@
 
 // tslint:disable:no-unsafe-any
 
-import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'fs';
+
 import { getFilesInDir } from './utils/tooling-utils';
 
 const OUT_DIR = `./build/generic-extension-wip/js/content_scripts`;

--- a/tooling/tsc-compiler.ts
+++ b/tooling/tsc-compiler.ts
@@ -4,8 +4,9 @@
 
 // tslint:disable:no-unsafe-any
 
-import * as ts from 'typescript';
 import * as path from 'path';
+import * as ts from 'typescript';
+
 import { readFileSync } from 'fs';
 
 let tsconfigAbsPath: string | undefined;

--- a/tooling/utils/tooling-utils.ts
+++ b/tooling/utils/tooling-utils.ts
@@ -2,8 +2,9 @@
 
 'use strict';
 
-import { readdirSync, statSync } from 'fs';
 import * as path from 'path';
+
+import { readdirSync, statSync } from 'fs';
 
 export const getFilesInDir = (dir: string, filePattern: RegExp, recursive = true): string[] => {
   const all: string[] = [];


### PR DESCRIPTION
Issue #2358 
Time spent: 1h

I would recommend installing this VSCode extension called `sort-imports` ('https://marketplace.visualstudio.com/items?itemName=amatiasq.sort-imports').
I've done this PR using that extension and I see that the extension works well.
I could add it to our workspace recommended extensions (like `TSLint`, `ESlint`) if you approve that.