### PR TITLE
Issue #2272, aligned icon and fixed bug when Backup wasn't rendered b…

### DIFF
--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -1327,7 +1327,7 @@ td {
 #backup_block label#toggle_pass_phrase.toggle_show_hide_pass_phrase {
   padding-top: 3px;
   margin-top: 1px;
-  height: 32px;
+  height: 37px;
 }
 #backup_block.backup .line { margin: 0; }
 

--- a/extension/js/common/core/att.ts
+++ b/extension/js/common/core/att.ts
@@ -15,7 +15,7 @@ export type FcAttLinkData = { name: string, type: string, size: number };
 
 export class Att {
 
-  public static readonly attachmentsPattern = /^(((cryptup|flowcrypt)-backup-[a-z]+\.(key|asc))|(.+\.pgp)|(.+\.gpg)|(.+\.asc)|(noname)|(message)|(PGPMIME version identification)|())$/gm;
+  public static readonly attachmentsPattern = /^(((cryptup|flowcrypt)-backup-[a-z0-9]+\.(key|asc))|(.+\.pgp)|(.+\.gpg)|(.+\.asc)|(noname)|(message)|(PGPMIME version identification)|())$/gm;
 
   public static keyinfoAsPubkeyAtt = (ki: { public: string, longid: string }) => {
     return new Att({ data: Buf.fromUtfStr(ki.public), type: 'application/pgp-keys', name: `0x${ki.longid}.asc` });


### PR DESCRIPTION
…ecause email contains number(s)
Closes #2272 
Time Spent: ~45m

The reason icon wasn't aligned correctly is that when we render `backup` element we make this input (along with the icon) thinner and we use custom styles for that. Maybe, it would be better to add functionality to `initPassphraseToggle` to accept another parameter called `size` (for now, it could be only `thin` | `normal`) and render the PP toggle depending on that parameter.
But this PR only fixes styles.

This PR also fixes one more bug. The bug is that the `backup` element won't be rendered if the email address contains numbers (e.g. michael.flowcrypt<b>2</b>@gmail.com). To fix that I had to correct one RegEx.