### PR TITLE
Remove advanced options toggle

### DIFF
--- a/extension/chrome/settings/modules/add_key.htm
+++ b/extension/chrome/settings/modules/add_key.htm
@@ -49,12 +49,10 @@
           <input id="input_passphrase" class="input_passphrase" type="text" placeholder="Private Key Passphrase" />
         </div>
         <div class="line">
-          <div class="squaredFour">
-            <input type="checkbox" value="" id="e_rememberPassphrase" name="check"
-              class="input_passphrase_save squaredFour" checked="">
-            <label class="checkboxSquaredOne" for="e_rememberPassphrase"></label>
-          </div>
-          <span class="labelCopy">Remember Pass Phrase after closing browser.</span>
+          <label>
+            <input type="checkbox" value="" name="check" class="input_passphrase_save" checked="">
+            Remember Pass Phrase after closing browser.
+          </label>
         </div>
         <div class="line">
           <br />
@@ -62,14 +60,15 @@
         </div>
       </div>
     </div>
+  </div>
 
-    <script src="/lib/purify.min.js"></script>
-    <script src="/lib/fine-uploader.js"></script>
-    <script src="/lib/jquery.min.js"></script>
-    <script src="/lib/sweetalert2.js"></script>
-    <script src="/lib/openpgp.js"></script>
-    <script src="/lib/zxcvbn.js"></script>
-    <script src="add_key.js" type="module"></script>
+  <script src="/lib/purify.min.js"></script>
+  <script src="/lib/fine-uploader.js"></script>
+  <script src="/lib/jquery.min.js"></script>
+  <script src="/lib/sweetalert2.js"></script>
+  <script src="/lib/openpgp.js"></script>
+  <script src="/lib/zxcvbn.js"></script>
+  <script src="add_key.js" type="module"></script>
 </body>
 
 </html>

--- a/extension/chrome/settings/setup.htm
+++ b/extension/chrome/settings/setup.htm
@@ -129,8 +129,8 @@
 
       <div class="line left">
         <label data-test="input-step2bmanualcreate-save-passphrase">
-          <input type="checkbox" class="input_passphrase_save" value="" name="check" checked="" />
-          Remember Pass Phrase after closing browser (recommended)
+          <input type="checkbox" class="input_passphrase_save" value="" name="check" />
+          Remember Pass Phrase after closing browser
         </label>
       </div>
       <div class="line left">
@@ -196,7 +196,7 @@
           </div>
           <div class="line left">
             <label data-test="input-step2bmanualenter-save-passphrase">
-              <input type="checkbox" value="" name="check" class="input_passphrase_save" checked="">
+              <input type="checkbox" value="" name="check" class="input_passphrase_save">
               Remember Pass Phrase after closing browser
             </label>
           </div>

--- a/extension/chrome/settings/setup.htm
+++ b/extension/chrome/settings/setup.htm
@@ -164,10 +164,11 @@
 
     <div id="step_2b_manual_enter" class="manual">
       <div class="aligncenter">
-        <div class="wide line">Import your private key. Keys are stored safely in your local browser extension storage.
+        <div class="line left">
+          Import your private key. Keys are stored safely in your local browser extension storage.<br>
+          The key will not leave your browser.
         </div>
-        <div class="wide line">The key will not leave your browser.</div>
-        <div class="wide line">
+        <div class="line left">
           <ul style="list-style: none; margin-left: 0; padding-left: 0;" class="source_selector">
             <li><input type="radio" name="source" id="source_file" value="file"> <label for="source_file">Load from a
                 file</label></li>
@@ -181,7 +182,7 @@
           <div class="line display_none" id="fineuploader"></div>
         </div>
         <div class="source_paste_container setup_page display_none">
-          <div class="wide line">
+          <div class="line left">
             <textarea class="input_private_key" placeholder="ASCII Armored Private Key"
               data-test="input-step2bmanualenter-ascii-key"></textarea>
           </div>
@@ -190,7 +191,7 @@
               data-test="action-step2bmanualenter-new-random-passphrase">use
               a random one</a>.
           </div>
-          <div class="line pp_container">
+          <div class="line left">
             <input class="input_passphrase" type="text" placeholder="Private Key Passphrase"
               id="step_2b_manual_enter_passphrase" data-test="input-step2bmanualenter-passphrase" />
           </div>

--- a/extension/chrome/settings/setup.htm
+++ b/extension/chrome/settings/setup.htm
@@ -128,41 +128,31 @@
       </div>
 
       <div class="line left">
-        <div class="squaredFour">
-          <input type="checkbox" class="input_passphrase_save" value="" id="c_rememberPassphraseAfterClosing"
-            name="check" checked="" />
-          <label class="checkboxSquaredOne" for="c_rememberPassphraseAfterClosing"
-            data-test="input-step2bmanualcreate-save-passphrase"></label>
-        </div>
-        <span class="labelCopy">Remember Pass Phrase after closing browser (recommended)</span>
+        <label>
+          <input type="checkbox" class="input_passphrase_save" value="" name="check" checked="" />
+          Remember Pass Phrase after closing browser (recommended)
+        </label>
       </div>
       <div class="line left">
-        <div class="squaredFour">
-          <input type="checkbox" class="input_backup_inbox" value="" id="c_backupInInbox" name="check"
-            checked="" />
-          <label class="checkboxSquaredOne" for="c_backupInInbox"
-            data-test="input-step2bmanualcreate-backup-inbox"></label>
-        </div>
-        <span class="labelCopy">Back up encrypted private key in inbox (recommended)</span>
+        <label>
+          <input type="checkbox" class="input_backup_inbox" value="" name="check" checked="" />
+          Back up encrypted private key in inbox (recommended)
+        </label>
       </div>
 
       <div class="line left remove_if_enforce_submit_to_attester">
-        <div class="squaredFour">
-          <input type="checkbox" class="input_submit_key" value="" id="c_submitPubkeytoKeyserver" name="check"
-            checked="">
-          <label class="checkboxSquaredOne" for="c_submitPubkeytoKeyserver"
-            data-test="input-step2bmanualcreate-submit-pubkey"></label>
-        </div>
-        <span class="labelCopy">Submit corresponding pubkey to FlowCrypt Attester (recommended)</span>
+        <label>
+          <input type="checkbox" class="input_submit_key" value="" name="check" checked="">
+          Submit corresponding pubkey to FlowCrypt Attester (recommended)
+        </label>
       </div>
       <div class="line left display_none remove_if_enforce_submit_to_attester">
-        <div class="squaredFour">
-          <input type="checkbox" class="input_submit_all" disabled="disabled" id="c_submitAll" />
-          <label class="checkboxSquaredOne" for="c_submitAll"></label>
-        </div>
-        <label class="checkboxSquaredOne" for="c_submitAll" style="position: relative; left: 25px;">
-          Also submit the same pubkey for:
-          <br /><span class="addresses" style="padding-left: 35px;"></span>
+        <label>
+          <input type="checkbox" class="input_submit_all" disabled="disabled" />
+          <span>
+            Also submit the same pubkey for:
+            <br /><span class="addresses"></span>
+          </span>
         </label>
       </div>
 
@@ -205,30 +195,24 @@
               id="step_2b_manual_enter_passphrase" data-test="input-step2bmanualenter-passphrase" />
           </div>
           <div class="line left">
-            <div class="squaredFour">
-              <input type="checkbox" value="" id="e_rememberPassphrase" name="check"
-                class="input_passphrase_save squaredFour" checked="">
-              <label class="checkboxSquaredOne" for="e_rememberPassphrase"
-                data-test="input-step2bmanualenter-save-passphrase"></label>
-            </div>
-            <span class="labelCopy">Remember Pass Phrase after closing browser</span>
+            <label>
+              <input type="checkbox" value="" name="check" class="input_passphrase_save" checked="">
+              Remember Pass Phrase after closing browser
+            </label>
           </div>
           <div class="line left remove_if_enforce_submit_to_attester">
-            <div class="squaredFour">
-              <input type="checkbox" value="" id="e_submitPubkey" name="check" checked="" class="input_submit_key">
-              <label class="checkboxSquaredOne" for="e_submitPubkey"
-                data-test="input-step2bmanualenter-submit-pubkey"></label>
-            </div>
-            <span class="labelCopy">Submit corresponding pubkey to FlowCrypt Attester</span>
+            <label>
+              <input type="checkbox" value="" name="check" checked="" class="input_submit_key">
+              Submit corresponding pubkey to FlowCrypt Attester
+            </label>
           </div>
           <div class="line left remove_if_enforce_submit_to_attester" style="visibility: hidden;">
-            <div class="squaredFour">
-              <input type="checkbox" class="input_submit_all" disabled="disabled" id="e_submitAll" />
-              <label class="checkboxSquaredOne" for="e_submitAll"></label>
-            </div>
-            <label class="checkboxSquaredOne" for="e_submitAll" style="position: relative; left: 25px;">
-              Also submit the same pubkey for:
-              <br /><span class="addresses" style="padding-left: 35px; font-size: 14px;"></span>
+            <label>
+              <input type="checkbox" class="input_submit_all" disabled="disabled" />
+              <span>
+                Also submit the same pubkey for:
+                <br /><span class="addresses"></span>
+              </span>
             </label>
           </div>
 

--- a/extension/chrome/settings/setup.htm
+++ b/extension/chrome/settings/setup.htm
@@ -128,20 +128,20 @@
       </div>
 
       <div class="line left">
-        <label>
+        <label data-test="input-step2bmanualcreate-save-passphrase">
           <input type="checkbox" class="input_passphrase_save" value="" name="check" checked="" />
           Remember Pass Phrase after closing browser (recommended)
         </label>
       </div>
       <div class="line left">
-        <label>
+        <label data-test="input-step2bmanualcreate-backup-inbox">
           <input type="checkbox" class="input_backup_inbox" value="" name="check" checked="" />
           Back up encrypted private key in inbox (recommended)
         </label>
       </div>
 
       <div class="line left remove_if_enforce_submit_to_attester">
-        <label>
+        <label data-test="input-step2bmanualcreate-submit-pubkey">
           <input type="checkbox" class="input_submit_key" value="" name="check" checked="">
           Submit corresponding pubkey to FlowCrypt Attester (recommended)
         </label>
@@ -195,13 +195,13 @@
               id="step_2b_manual_enter_passphrase" data-test="input-step2bmanualenter-passphrase" />
           </div>
           <div class="line left">
-            <label>
+            <label data-test="input-step2bmanualenter-save-passphrase">
               <input type="checkbox" value="" name="check" class="input_passphrase_save" checked="">
               Remember Pass Phrase after closing browser
             </label>
           </div>
           <div class="line left remove_if_enforce_submit_to_attester">
-            <label>
+            <label data-test="input-step2bmanualenter-submit-pubkey">
               <input type="checkbox" value="" name="check" checked="" class="input_submit_key">
               Submit corresponding pubkey to FlowCrypt Attester
             </label>

--- a/extension/chrome/settings/setup.htm
+++ b/extension/chrome/settings/setup.htm
@@ -128,53 +128,42 @@
       </div>
 
       <div class="line left">
-        <div class="advanced_create_settings_container">
-          <div class="action_show_advanced_create_settings"
-            data-test="action-step2bmanualcreate-show-advanced-create-settings"><img
-              src="/img/svgs/settings-icon.svg" /><span>Show
-              Advanced Settings</span></div>
-          <div class="line advanced_create_settings display_none">
-            <hr style="border: 1px dotted rgba(0, 0, 0, 0.25); height: 1px; border-bottom: none; margin: 0;">
-            <div class="line left">
-              <div class="squaredFour">
-                <input type="checkbox" class="input_passphrase_save" value="" id="c_rememberPassphraseAfterClosing"
-                  name="check" checked="" />
-                <label class="checkboxSquaredOne" for="c_rememberPassphraseAfterClosing"
-                  data-test="input-step2bmanualcreate-save-passphrase"></label>
-              </div>
-              <span class="labelCopy">Remember Pass Phrase after closing browser (recommended)</span>
-            </div>
-            <div class="line left">
-              <div class="squaredFour">
-                <input type="checkbox" class="input_backup_inbox" value="" id="c_backupInInbox" name="check"
-                  checked="" />
-                <label class="checkboxSquaredOne" for="c_backupInInbox"
-                  data-test="input-step2bmanualcreate-backup-inbox"></label>
-              </div>
-              <span class="labelCopy">Back up encrypted private key in inbox (recommended)</span>
-            </div>
-
-            <div class="line left remove_if_enforce_submit_to_attester">
-              <div class="squaredFour">
-                <input type="checkbox" class="input_submit_key" value="" id="c_submitPubkeytoKeyserver" name="check"
-                  checked="">
-                <label class="checkboxSquaredOne" for="c_submitPubkeytoKeyserver"
-                  data-test="input-step2bmanualcreate-submit-pubkey"></label>
-              </div>
-              <span class="labelCopy">Submit corresponding pubkey to FlowCrypt Attester (recommended)</span>
-            </div>
-            <div class="line left display_none remove_if_enforce_submit_to_attester">
-              <div class="squaredFour">
-                <input type="checkbox" class="input_submit_all" disabled="disabled" id="c_submitAll" />
-                <label class="checkboxSquaredOne" for="c_submitAll"></label>
-              </div>
-              <label class="checkboxSquaredOne" for="c_submitAll" style="position: relative; left: 25px;">
-                Also submit the same pubkey for:
-                <br /><span class="addresses" style="padding-left: 35px;"></span>
-              </label>
-            </div>
-          </div>
+        <div class="squaredFour">
+          <input type="checkbox" class="input_passphrase_save" value="" id="c_rememberPassphraseAfterClosing"
+            name="check" checked="" />
+          <label class="checkboxSquaredOne" for="c_rememberPassphraseAfterClosing"
+            data-test="input-step2bmanualcreate-save-passphrase"></label>
         </div>
+        <span class="labelCopy">Remember Pass Phrase after closing browser (recommended)</span>
+      </div>
+      <div class="line left">
+        <div class="squaredFour">
+          <input type="checkbox" class="input_backup_inbox" value="" id="c_backupInInbox" name="check"
+            checked="" />
+          <label class="checkboxSquaredOne" for="c_backupInInbox"
+            data-test="input-step2bmanualcreate-backup-inbox"></label>
+        </div>
+        <span class="labelCopy">Back up encrypted private key in inbox (recommended)</span>
+      </div>
+
+      <div class="line left remove_if_enforce_submit_to_attester">
+        <div class="squaredFour">
+          <input type="checkbox" class="input_submit_key" value="" id="c_submitPubkeytoKeyserver" name="check"
+            checked="">
+          <label class="checkboxSquaredOne" for="c_submitPubkeytoKeyserver"
+            data-test="input-step2bmanualcreate-submit-pubkey"></label>
+        </div>
+        <span class="labelCopy">Submit corresponding pubkey to FlowCrypt Attester (recommended)</span>
+      </div>
+      <div class="line left display_none remove_if_enforce_submit_to_attester">
+        <div class="squaredFour">
+          <input type="checkbox" class="input_submit_all" disabled="disabled" id="c_submitAll" />
+          <label class="checkboxSquaredOne" for="c_submitAll"></label>
+        </div>
+        <label class="checkboxSquaredOne" for="c_submitAll" style="position: relative; left: 25px;">
+          Also submit the same pubkey for:
+          <br /><span class="addresses" style="padding-left: 35px;"></span>
+        </label>
       </div>
 
       <div class="line left">

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -669,11 +669,13 @@ body#settings > div#content.setup div.manual a.back i {
 
 body#settings > div#content.setup div.manual input[type=checkbox] {
   margin: 0 6px;
-  margin-right: 0;
-  -webkit-transform: scale(1.6);
   transform: scale(1.6);
   position: relative;
   top: 2px;
+}
+
+body#settings > div#content.setup div.manual label {
+  font-weight: 400;
 }
 
 body#settings > div#content.setup div.action_add_private_key {
@@ -729,56 +731,6 @@ body#settings > div#content.setup div#step_2_recovery div#error_text {
   -webkit-animation: fadeInDown 0.7s;
   animation: fadeInDown 0.7s;
 }
-
-body#settings > div#content.setup .squaredFour {
-  width: 20px;
-  margin: 5px;
-  display: inline-block;
-  position: relative;
-  left: 16px;
-}
-
-body#settings > div#content.setup .squaredFour label {
-  width: 20px;
-  height: 20px;
-  cursor: pointer;
-  position: absolute;
-  top: 0;
-  left: 0;
-  background: #fcfff4;
-  background: -webkit-linear-gradient(top, #fcfff4 0%, #dfe5d7 40%, #b3bead 100%);
-  background: linear-gradient(to bottom, #fcfff4 0%, #dfe5d7 40%, #b3bead 100%);
-  border-radius: 4px;
-  box-shadow: inset 0 1px 1px white, 0 1px 3px rgba(0, 0, 0, 0.5);
-}
-
-body#settings > div#content.setup .squaredFour label::after {
-  content: '';
-  width: 9px;
-  height: 5px;
-  position: absolute;
-  top: 4px;
-  left: 4px;
-  border: 3px solid #333;
-  border-top: none;
-  border-right: none;
-  background: transparent;
-  opacity: 0;
-  -webkit-transform: rotate(-45deg);
-  transform: rotate(-45deg);
-}
-body#settings > div#content.setup .squaredFour label:hover::after { opacity: 0.5; }
-body#settings > div#content.setup .squaredFour input[type=checkbox] { visibility: hidden; }
-body#settings > div#content.setup .squaredFour input[type=checkbox]:checked + label::after { opacity: 1; }
-
-body#settings > div#content.setup .labelCopy {
-  margin-top: 7px;
-  position: absolute;
-  text-align: left;
-  text-indent: 30px;
-  z-index: -10;
-}
-body#settings > div#content.setup label.checkboxSquaredOne { padding-left: 0 !important; }
 
 .passphrase-sticky-note {
   position: relative;

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -780,22 +780,6 @@ body#settings > div#content.setup .labelCopy {
 }
 body#settings > div#content.setup label.checkboxSquaredOne { padding-left: 0 !important; }
 
-body#settings > div#content.setup #step_2a_manual_create .advanced_create_settings_container {
-  border: 1px solid rgba(0, 0, 0, 0.25);
-  padding-top: 6px;
-  margin-top: 20px;
-  width: 360px;
-  padding-bottom: 10px;
-}
-body#settings > div#content.setup #step_2a_manual_create .action_show_advanced_create_settings { cursor: pointer; }
-
-body#settings > div#content.setup #step_2a_manual_create .action_show_advanced_create_settings img {
-  height: 22px;
-  padding: 0 20px;
-  position: relative;
-  top: 5px;
-}
-
 .passphrase-sticky-note {
   position: relative;
   margin: 20px auto;

--- a/test/source/tests/browser_recipe.ts
+++ b/test/source/tests/browser_recipe.ts
@@ -65,7 +65,7 @@ export class BrowserRecipe {
     const acctEmail = 'flowcrypt.test.key.imported@gmail.com';
     const k = Config.key('flowcrypt.test.key.used.pgp');
     const settingsPage = await BrowserRecipe.openSettingsLoginApprove(t, browser, acctEmail);
-    await SetupPageRecipe.manualEnter(settingsPage, k.title, { usedPgpBefore: false, submitPubkey: false });
+    await SetupPageRecipe.manualEnter(settingsPage, k.title, { usedPgpBefore: false, submitPubkey: false, savePassphrase: true });
     return { acctEmail, k, settingsPage };
   }
 

--- a/test/source/tests/page_recipe/setup-page-recipe.ts
+++ b/test/source/tests/page_recipe/setup-page-recipe.ts
@@ -43,7 +43,6 @@ export class SetupPageRecipe extends PageRecipe {
   // eslint-disable-next-line max-len
   public static createAdvanced = async (settingsPage: ControllablePage, keyTitle: string, backup: "none" | "email" | "file", { usedPgpBefore = false, submitPubkey = false }: { usedPgpBefore?: boolean, submitPubkey?: boolean } = {}) => {
     await SetupPageRecipe.createBegin(settingsPage, keyTitle, { usedPgpBefore });
-    await settingsPage.waitAndClick('@action-step2bmanualcreate-show-advanced-create-settings'); // unfold
     await settingsPage.waitAndClick('@input-step2bmanualcreate-backup-inbox'); // uncheck
     if (!submitPubkey) {
       await settingsPage.waitAndClick('@input-step2bmanualcreate-submit-pubkey'); // uncheck

--- a/test/source/tests/page_recipe/setup-page-recipe.ts
+++ b/test/source/tests/page_recipe/setup-page-recipe.ts
@@ -9,6 +9,7 @@ import { expect } from 'chai';
 
 type ManualEnterOpts = {
   usedPgpBefore?: boolean,
+  savePassphrase?: boolean,
   submitPubkey?: boolean,
   fixKey?: boolean,
   naked?: boolean,
@@ -20,17 +21,6 @@ type ManualEnterOpts = {
 };
 
 export class SetupPageRecipe extends PageRecipe {
-
-  private static createBegin = async (settingsPage: ControllablePage, keyTitle: string, { usedPgpBefore = false }: { usedPgpBefore?: boolean } = {}) => {
-    const k = Config.key(keyTitle);
-    if (usedPgpBefore) {
-      await settingsPage.waitAndClick('@action-step0foundkey-choose-manual-create');
-    } else {
-      await settingsPage.waitAndClick('@action-step1easyormanual-choose-manual-create');
-    }
-    await settingsPage.waitAndType('@input-step2bmanualcreate-passphrase-1', k.passphrase);
-    await settingsPage.waitAndType('@input-step2bmanualcreate-passphrase-2', k.passphrase);
-  }
 
   // public static setup_create_simple = async (settingsPage: ControllablePage, key_title: string, {used_pgp_before=false}: {used_pgp_before?: boolean}={}) => {
   //   await PageRecipe.setup_create_begin(settingsPage, key_title, {used_pgp_before});
@@ -72,6 +62,7 @@ export class SetupPageRecipe extends PageRecipe {
     keyTitle: string,
     {
       usedPgpBefore = false,
+      savePassphrase = false,
       submitPubkey = false,
       fixKey = false,
       naked = false,
@@ -95,6 +86,9 @@ export class SetupPageRecipe extends PageRecipe {
     await settingsPage.waitAndClick('@input-step2bmanualenter-passphrase'); // blur ascii key input
     if (noPrvCreateOrgRule) { // NO_PRV_CREATE cannot use the back button, so that they cannot select another setup method
       await settingsPage.notPresent('@action-setup-go-back');
+    }
+    if (savePassphrase) {
+      await settingsPage.waitAndClick('@input-step2bmanualenter-save-passphrase');
     }
     if (!naked) {
       await Util.sleep(1);
@@ -193,6 +187,17 @@ export class SetupPageRecipe extends PageRecipe {
         }
       }
     }
+  }
+
+  private static createBegin = async (settingsPage: ControllablePage, keyTitle: string, { usedPgpBefore = false }: { usedPgpBefore?: boolean } = {}) => {
+    const k = Config.key(keyTitle);
+    if (usedPgpBefore) {
+      await settingsPage.waitAndClick('@action-step0foundkey-choose-manual-create');
+    } else {
+      await settingsPage.waitAndClick('@action-step1easyormanual-choose-manual-create');
+    }
+    await settingsPage.waitAndType('@input-step2bmanualcreate-passphrase-1', k.passphrase);
+    await settingsPage.waitAndType('@input-step2bmanualcreate-passphrase-2', k.passphrase);
   }
 
 }


### PR DESCRIPTION
Closes #2114 
Closes #1807

As promised, keyboard a11y is there for free:

![1](https://user-images.githubusercontent.com/6059356/71745501-f92f5680-2e72-11ea-8218-3de99b1d0e72.gif)

As well as in `add_key.html`:

![1](https://user-images.githubusercontent.com/6059356/71745639-5aefc080-2e73-11ea-92d1-bd080f99c6bc.gif)
