### PR TITLE
Disable vscode tslint for test folder

### DIFF
--- a/flowcrypt-browser.code-workspace
+++ b/flowcrypt-browser.code-workspace
@@ -26,7 +26,10 @@
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": true,
       "source.fixAll.tslint": true
-    }
+    },
+    "tslint.exclude": [
+      "test/**/*.ts"
+    ]
   },
   "folders": [
     {


### PR DESCRIPTION
Closes #2478 

I didn't find a better way to get rid of distracting underlines.

The `test_tslint` task will still report tslint issues in `test` folder, but VSCode won't highlight them.