### PR TITLE
COMPOSE ENCRYPTED EMAIL should be a link

### DIFF
--- a/extension/chrome/settings/setup.htm
+++ b/extension/chrome/settings/setup.htm
@@ -304,7 +304,7 @@
           REMAINING KEYS</button>
       </div>
       <div class="wide line">
-        <button class="button longer gray action_send">COMPOSE ENCRYPTED EMAIL</button>
+        <a class="button longer gray action_send" target="_blank">COMPOSE ENCRYPTED EMAIL</a>
       </div>
       <div class="wide line">
         <button class="button longer gray action_account_settings" data-test="action-step4more-account-settings">MORE


### PR DESCRIPTION
Closes #2490 

It was changed from `<div>` to `<button>` by me in https://github.com/FlowCrypt/flowcrypt-browser/commit/f73d125a3dae7495bccd27518b40802460f628d9#diff-2dcb80916f2c15c0faa1e89f30197eefR322 not sure if it was somehow working with `<div>`, probably noe). It should definitely be `<a>` because we're setting `href` in https://github.com/FlowCrypt/flowcrypt-browser/blob/master/extension/chrome/settings/setup.ts#L118