### PR TITLE
Add white-space: nowrap to the Secure Compose button

### DIFF
--- a/extension/css/settings.css
+++ b/extension/css/settings.css
@@ -746,9 +746,10 @@ body#settings .settings-border .key_list {
 }
 
 #settings.client > table td.menu .button {
-  width: 160px !important;
+  min-width: 160px !important;
   margin-bottom: 8px !important;
   text-align: left !important;
+  white-space: nowrap;
 }
 
 #settings.client > table td.menu span.label {


### PR DESCRIPTION
Closes #2566 

![image](https://user-images.githubusercontent.com/6059356/74977805-1ecceb00-5434-11ea-8fb0-b9d6fa71c911.png)

The Secure Compose button is wider than other buttons now, @tomholub let me know if that bothers your eye (mine is fine with that).

I intentionally didn't use the `issue-xxxx` in the branch name to avoid unnecessarily testing since there are no significant changes.