### PR TITLE
Add RTL support

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-input-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-input-module.ts
@@ -106,6 +106,9 @@ export class ComposeInputModule extends ViewModule<ComposeView> {
 
   private handleRTL = () => {
     const checkRTL = (e: KeyboardEvent) => {
+      if (!this.isRichText()) { // RTL is supported for pgp/mime (rich text) only
+        return;
+      }
       if (e.key.length > 1) {
         return; // 'Enter', 'Space', etc.
       }

--- a/extension/chrome/elements/compose-modules/compose-input-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-input-module.ts
@@ -113,8 +113,8 @@ export class ComposeInputModule extends ViewModule<ComposeView> {
       if (container.prop('tagName') !== 'DIV') { // commonAncestorContainer might be a text node
         container = container.closest('div');
       }
-      if (container.text().length === 1) {
-        const firstCharacter = container.text();
+      if (container.text()) {
+        const firstCharacter = container.text()[0];
         // ranges are taken from https://stackoverflow.com/a/14824756
         // with the '\u0300' -> '\u0370' modification, because from '\u0300' to '\u0370' there are only punctuation marks
         // see https://www.utf8-chartable.de/unicode-utf8-table.pl

--- a/extension/chrome/elements/compose.ts
+++ b/extension/chrome/elements/compose.ts
@@ -77,7 +77,7 @@ export class ComposeView extends View {
     header: '#section_header',
     subject: '#section_subject',
     footer: '#section_footer',
-    title: 'table#compose th h1',
+    title: '#header_title',
     input_text: 'div#input_text',
     input_to: '#input_to',
     input_from: '#input_from',

--- a/test/source/browser/controllable.ts
+++ b/test/source/browser/controllable.ts
@@ -186,6 +186,10 @@ abstract class ControllableBase {
     }
   }
 
+  public readHtml = async (selector: string): Promise<string> => {
+    return await this.target.evaluate((s) => document.querySelector(s).innerHTML, this.selector(selector));
+  }
+
   public selectOption = async (selector: string, choice: string) => {
     await this.waitAll(selector, { visible: true });
     await this.target.evaluate((s, v) => jQuery(s).val(v).trigger('change'), this.selector(selector), choice);

--- a/test/source/mock/google/google-endpoints.ts
+++ b/test/source/mock/google/google-endpoints.ts
@@ -203,6 +203,10 @@ export const mockGoogleEndpoints: HandlersDefinition = {
         const data = new GoogleData(acct);
         data.addDraft('draft_with_image', raw, mimeMsg);
       }
+      if ((mimeMsg.subject || '').includes('saving and rendering a draft with RTL text')) {
+        const data = new GoogleData(acct);
+        data.addDraft('draft_with_rtl_text', raw, mimeMsg);
+      }
       return {};
     } else if (isDelete(req)) {
       return {};

--- a/test/source/tests/page-recipe/compose-page-recipe.ts
+++ b/test/source/tests/page-recipe/compose-page-recipe.ts
@@ -60,8 +60,6 @@ export class ComposePageRecipe extends PageRecipe {
       await Util.sleep(1);
       await composePageOrFrame.type('@input-subject', `Automated puppeteer test: ${subject}`);
     }
-    const body = `This is an automated puppeteer test: ${subject || '(no-subject)'}`;
-    await composePageOrFrame.type('@input-body', body);
     const sendingOpts = sendingOpt as { [key: string]: boolean | undefined };
     for (const opt of Object.keys(sendingOpts)) {
       const shouldBeTicked = sendingOpts[opt];
@@ -69,6 +67,8 @@ export class ComposePageRecipe extends PageRecipe {
         await ComposePageRecipe.setPopoverToggle(composePageOrFrame, opt as PopoverOpt, shouldBeTicked);
       }
     }
+    const body = subject?.match(/RTL/) ? 'مرحبا' : `This is an automated puppeteer test: ${subject || '(no-subject)'}`;
+    await composePageOrFrame.type('@input-body', body);
     return { subject, body };
   }
 


### PR DESCRIPTION
Closes #1114 

I'm personally very excited about this feature because even though the change is small in terms of LoC, the impact could be quite big because Arabic is the 5th most popular language in the world. And people who speak Hebrew will be excited as well, Israel has the largest number of startups per capita in the world, around one startup per 1,400 people, so people out there would appreciate our effort.

You might want to announce the RTL support in release notes, blog and in the news section of `settings/index.htm`.

TODO: 
- [x] add test for 1. typing RTL message 2. saving it to drafts 3. checking that draft contains `<div dir="rtl">`