### PR TITLE
Align contacts list with gmail, put email under name

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -561,10 +561,11 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
           const parts = contact.email.split('@');
           displayEmail = parts[0].replace(/<\/?b>/g, '').substr(0, 10) + '...@' + parts[1];
         }
+        displayEmail = '<div class="select_contact_email">' + Xss.escape(displayEmail) + '</div>';
         if (contact.name) {
-          ulHtml += (Xss.escape(contact.name) + ' &lt;' + Xss.escape(displayEmail) + '&gt;');
+          ulHtml += '<div class="select_contact_name">' + Xss.escape(contact.name) + displayEmail + '</div>';
         } else {
-          ulHtml += Xss.escape(displayEmail);
+          ulHtml += displayEmail;
         }
         ulHtml += '</li>';
       }

--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -548,7 +548,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
     if ((renderableContacts.length > 0 || this.contactSearchInProgress) || !this.canSearchContacts) {
       let ulHtml = '';
       for (const contact of renderableContacts) {
-        ulHtml += `<li class="select_contact" data-test="action-select-contact" email="${Xss.escape(contact.email.replace(/<\/?b>/g, ''))}">`;
+        ulHtml += `<li class="select_contact" email="${Xss.escape(contact.email.replace(/<\/?b>/g, ''))}">`;
         if (contact.has_pgp) {
           ulHtml += '<img class="lock-icon" src="/img/svgs/locked-icon-green.svg" />';
         } else {
@@ -561,7 +561,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
           const parts = contact.email.split('@');
           displayEmail = parts[0].replace(/<\/?b>/g, '').substr(0, 10) + '...@' + parts[1];
         }
-        displayEmail = '<div class="select_contact_email">' + Xss.escape(displayEmail) + '</div>';
+        displayEmail = '<div class="select_contact_email" data-test="action-select-contact-email">' + Xss.escape(displayEmail) + '</div>';
         if (contact.name) {
           ulHtml += '<div class="select_contact_name">' + Xss.escape(contact.name) + displayEmail + '</div>';
         } else {

--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -563,7 +563,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
         }
         displayEmail = '<div class="select_contact_email" data-test="action-select-contact-email">' + Xss.escape(displayEmail) + '</div>';
         if (contact.name) {
-          ulHtml += '<div class="select_contact_name">' + Xss.escape(contact.name) + displayEmail + '</div>';
+          ulHtml += '<div class="select_contact_name" data-test="action-select-contact-name">' + Xss.escape(contact.name) + displayEmail + '</div>';
         } else {
           ulHtml += displayEmail;
         }

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -2004,6 +2004,24 @@ div#contacts ul li {
   text-overflow: ellipsis;
 }
 
+div#contacts .select_contact {
+  display: flex;
+  align-items: center;
+}
+
+div#contacts .select_contact .select_contact_name {
+  max-width: 90%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+div#contacts .select_contact .select_contact_email {
+  font-size: 0.85em;
+  color: #333;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 div#contacts ul li img,
 div#contacts div.allow-google-contact-search img {
   padding-left: 6px;
@@ -2012,7 +2030,12 @@ div#contacts div.allow-google-contact-search img {
   position: relative;
   top: 1px;
 }
-div#contacts ul li:not(.loading) { cursor: pointer; }
+
+div#contacts ul li:not(.loading) {
+  height: 20px;
+  cursor: pointer;
+}
+
 div#contacts ul li.active:not(.loading) { background: #d6d6d6; }
 
 div#contacts ul li.auth_contacts {

--- a/test/source/tests/tests/compose.ts
+++ b/test/source/tests/tests/compose.ts
@@ -68,10 +68,12 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       // works on first search
       const composePage1 = await ComposePageRecipe.openStandalone(t, browser, 'compose');
       await composePage1.type('@input-to', 'human'); // test guessing of contacts
+      await composePage1.waitAll(['@container-contacts', '@action-select-contact-name(Human at FlowCrypt)']);
       await composePage1.waitAll(['@container-contacts', '@action-select-contact-email(human@flowcrypt.com)']);
       // works on subsequent search
       const composePage2 = await ComposePageRecipe.openStandalone(t, browser, 'compose');
       await composePage2.type('@input-to', 'human'); // test guessing of contacts
+      await composePage2.waitAll(['@container-contacts', '@action-select-contact-name(Human at FlowCrypt)']);
       await composePage2.waitAll(['@container-contacts', '@action-select-contact-email(human@flowcrypt.com)']);
     }));
 

--- a/test/source/tests/tests/compose.ts
+++ b/test/source/tests/tests/compose.ts
@@ -68,30 +68,30 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       // works on first search
       const composePage1 = await ComposePageRecipe.openStandalone(t, browser, 'compose');
       await composePage1.type('@input-to', 'human'); // test guessing of contacts
-      await composePage1.waitAll(['@container-contacts', '@action-select-contact(human@flowcrypt.com)']);
+      await composePage1.waitAll(['@container-contacts', '@action-select-contact-email(human@flowcrypt.com)']);
       // works on subsequent search
       const composePage2 = await ComposePageRecipe.openStandalone(t, browser, 'compose');
       await composePage2.type('@input-to', 'human'); // test guessing of contacts
-      await composePage2.waitAll(['@container-contacts', '@action-select-contact(human@flowcrypt.com)']);
+      await composePage2.waitAll(['@container-contacts', '@action-select-contact-email(human@flowcrypt.com)']);
     }));
 
     ava.default('compose - can load contact based on name different from email', testWithBrowser('compose', async (t, browser) => {
       // works on the first search
       const composePage1 = await ComposePageRecipe.openStandalone(t, browser, 'compose');
       await composePage1.type('@input-to', 'FirstName'); // test guessing of contacts when the name is not included in email address
-      await composePage1.waitAll(['@container-contacts', '@action-select-contact(therecipient@theirdomain.com)']);
+      await composePage1.waitAll(['@container-contacts', '@action-select-contact-email(therecipient@theirdomain.com)']);
       // works on subsequent search
       const composePage2 = await ComposePageRecipe.openStandalone(t, browser, 'compose');
       await composePage2.type('@input-to', 'FirstName'); // test guessing of contacts when the name is not included in email address
-      await composePage2.waitAll(['@container-contacts', '@action-select-contact(therecipient@theirdomain.com)']);
+      await composePage2.waitAll(['@container-contacts', '@action-select-contact-email(therecipient@theirdomain.com)']);
     }));
 
     ava.default(`compose - can choose found contact`, testWithBrowser('compose', async (t, browser) => {
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compose');
       // composePage.enable_debugging('choose-contact');
       await composePage.type('@input-to', 'human'); // test loading of contacts
-      await composePage.waitAll(['@container-contacts', '@action-select-contact(human@flowcrypt.com)'], { timeout: 30 });
-      await composePage.waitAndClick('@action-select-contact(human@flowcrypt.com)', { retryErrs: true, confirmGone: true, delay: 0 });
+      await composePage.waitAll(['@container-contacts', '@action-select-contact-email(human@flowcrypt.com)'], { timeout: 30 });
+      await composePage.waitAndClick('@action-select-contact-email(human@flowcrypt.com)', { retryErrs: true, confirmGone: true, delay: 0 });
       // todo - verify that the contact/pubkey is showing in green once clicked
       await composePage.waitAndClick('@input-subject');
       await composePage.type('@input-subject', `Automated puppeteer test: pubkey chosen by clicking found contact`);


### PR DESCRIPTION
Fixes #2577 

![image](https://user-images.githubusercontent.com/6059356/75666149-00f65600-5c7e-11ea-92f0-205932f85c9a.png)

Long names and emails are handled with `text-overflow: ellispsis`:

![image](https://user-images.githubusercontent.com/6059356/75666298-3a2ec600-5c7e-11ea-92d6-75bd53397294.png)

