### PR TITLE
Issue 2615 secure reply button handlers

### DIFF
--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -69,7 +69,7 @@ body.cryptup_gmail .inserted div.reply_message_button {
   height: auto;
 }
 
-@-moz-document url-prefix() {
+@-moz-document url-prefix() { /* Firefox specific */
   body.cryptup_gmail .inserted div.reply_message_button {
     padding-bottom: 4px;
   }

--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -62,12 +62,19 @@ body.cryptup_inbox .pgp_message_container .nk .tq:first-child { display: none !i
 body.cryptup_gmail .inserted div.reply_message_button {
   position: relative;
   display: inline-flex;
-  padding: 20px 12px 4px 10px;
+  padding: 20px 12px 0 10px;
   opacity: 0.75;
   margin-left: 18px;
   margin-right: 8px;
   height: auto;
 }
+
+@-moz-document url-prefix() {
+  body.cryptup_gmail .inserted div.reply_message_button {
+    padding-bottom: 4px;
+  }
+}
+
 body.cryptup_gmail.firefox .inserted div.reply_message_button { padding-top: 16px; } /* else buttons misaligned vertically on FF */
 body.cryptup_gmail .inserted div.reply_message_button:hover {
   opacity: 0.9;

--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -156,12 +156,12 @@ export class GmailElementReplacer implements WebmailElementReplacer {
         const gmailReplyBtn = $(elem).find('[aria-label="Reply"]');
         const secureReplyBtn = $(this.factory.btnSecureReply()).insertAfter(gmailReplyBtn);  // xss-safe-factory
         secureReplyBtn.addClass(gmailReplyBtn.attr('class') || '');
+        secureReplyBtn.off();
         secureReplyBtn.on('focusin', Ui.event.handle((target) => { $(target).addClass('T-I-JO'); }));
         secureReplyBtn.on('focusout', Ui.event.handle((target) => { $(target).removeClass('T-I-JO'); }));
-        secureReplyBtn.off();
         secureReplyBtn.click(Ui.event.handle((el, ev: JQuery.Event) => this.actionActivateSecureReplyHandler(el, ev)));
         secureReplyBtn.keydown(event => {
-          if (event.which === 13) {
+          if (event.key === 'Enter') {
             event.stopImmediatePropagation();
             $(secureReplyBtn).click();
           }

--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -159,6 +159,8 @@ export class GmailElementReplacer implements WebmailElementReplacer {
         secureReplyBtn.off();
         secureReplyBtn.on('focusin', Ui.event.handle((target) => { $(target).addClass('T-I-JO'); }));
         secureReplyBtn.on('focusout', Ui.event.handle((target) => { $(target).removeClass('T-I-JO'); }));
+        secureReplyBtn.on('mouseenter', Ui.event.handle((target) => { $(target).addClass('T-I-JW'); }));
+        secureReplyBtn.on('mouseleave', Ui.event.handle((target) => { $(target).removeClass('T-I-JW'); }));
         secureReplyBtn.click(Ui.event.handle((el, ev: JQuery.Event) => this.actionActivateSecureReplyHandler(el, ev)));
         secureReplyBtn.keydown(event => {
           if (event.key === 'Enter') {


### PR DESCRIPTION
Fixes #2615 

![Peek 2020-03-03 14-28](https://user-images.githubusercontent.com/6059356/75775768-548aa180-5d5b-11ea-8d56-5111c742c459.gif)

Also fixed the vertical alignment of the Secure Reply button in Chrome:

Before | After
-|-
![image](https://user-images.githubusercontent.com/6059356/75775654-15f4e700-5d5b-11ea-980a-42270e78b23d.png) | ![image](https://user-images.githubusercontent.com/6059356/75775702-30c75b80-5d5b-11ea-8928-731e2b68d76e.png)
