### PR TITLE
Add test for offline mode

### DIFF
--- a/test/source/tests/tests/gmail.ts
+++ b/test/source/tests/tests/gmail.ts
@@ -116,6 +116,19 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       const composePage = await GmailPageRecipe.openSecureCompose(t, gmailPage, browser);
     }));
 
+    ava.default.only('mail.google.com - decrypt message in offline mode', testWithBrowser('compatibility', async (t, browser) => {
+      const gmailPage = await BrowserRecipe.openGmailPage(t, browser);
+      await gmailPage.type('[aria-label="Search mail"]', 'encrypted + signed with gpg');
+      await gmailPage.press('Enter'); // submit search
+      await gmailPage.page.waitFor(1000); // wait for search results
+      await gmailPage.page.setOfflineMode(true); // go OFFLINE
+      await gmailPage.press('Enter'); // open the message
+      // getFramesUrls will return one iframe which is expected
+      const urls = await gmailPage.getFramesUrls(['/chrome/elements/pgp_block.htm'], { sleep: 1 });
+      // but getFrame will fail, why?
+      const pgpBlockPage = await gmailPage.getFrame(['pgp_block.htm']);
+    }));
+
     ava.default('mail.google.com - msg.asc message content renders', testWithBrowser('compatibility', async (t, browser) => {
       const gmailPage = await openGmailPage(t, browser, '/WhctKJTrdTXcmgcCRgXDpVnfjJNnjjLzSvcMDczxWPMsBTTfPxRDMrKCJClzDHtbXlhnwtV');
       const urls = await gmailPage.getFramesUrls(['/chrome/elements/pgp_block.htm'], { sleep: 10, appearIn: 20 });


### PR DESCRIPTION
Closes #2622 

@tomholub first of all, please give your feedback on the test. I decided to add the Gmail test to simulate the real use-case, but if you think that's not the best way, let me know.

Secondly, if the first part is alright and Gmail test is fine here, I'm struggling to get the `pgp_block.htm` frame, for some reason the `getFrame()` method can't find it and throwing the `Error: Frame not found: pgp_block.htm` exception.