### PR TITLE
Remove fixed heigth from #attachments .attachment

### DIFF
--- a/extension/chrome/elements/pgp_block_modules/pgp-block-attachmens-module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp-block-attachmens-module.ts
@@ -24,9 +24,10 @@ export class PgpBlockViewAttachmentsModule {
     this.includedAtts = atts;
     for (const i of atts.keys()) {
       const name = (atts[i].name ? Xss.escape(atts[i].name) : 'noname').replace(/\.(pgp|gpg)$/, '');
+      const nameVisible = name.length > 100 ? name.slice(0, 100) + '…' : name;
       const size = Str.numberFormat(Math.ceil(atts[i].length / 1024)) + 'KB';
-      const htmlContent = `<b>${Xss.escape(name)}</b>&nbsp;&nbsp;&nbsp;${size}<span class="progress"><span class="percent"></span></span>`;
-      Xss.sanitizeAppend('#attachments', `<div class="attachment" index="${Number(i)}">${htmlContent}</div>`);
+      const htmlContent = `<b>${nameVisible}</b>&nbsp;&nbsp;&nbsp;${size}<span class="progress"><span class="percent"></span></span>`;
+      Xss.sanitizeAppend('#attachments', `<div class="attachment" title="${name}" index="${Number(i)}">${htmlContent}</div>`);
     }
     this.view.renderModule.resizePgpBlockFrame();
     $('div.attachment').click(this.view.setHandlerPrevent('double', async target => {

--- a/extension/chrome/elements/pgp_block_modules/pgp-block-attachmens-module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp-block-attachmens-module.ts
@@ -23,11 +23,11 @@ export class PgpBlockViewAttachmentsModule {
     Xss.sanitizeAppend('#pgp_block', '<div id="attachments"></div>');
     this.includedAtts = atts;
     for (const i of atts.keys()) {
-      const name = (atts[i].name ? Xss.escape(atts[i].name) : 'noname').replace(/\.(pgp|gpg)$/, '');
+      const name = (atts[i].name ? atts[i].name : 'noname').replace(/\.(pgp|gpg)$/, '');
       const nameVisible = name.length > 100 ? name.slice(0, 100) + '…' : name;
       const size = Str.numberFormat(Math.ceil(atts[i].length / 1024)) + 'KB';
-      const htmlContent = `<b>${nameVisible}</b>&nbsp;&nbsp;&nbsp;${size}<span class="progress"><span class="percent"></span></span>`;
-      Xss.sanitizeAppend('#attachments', `<div class="attachment" title="${name}" index="${Number(i)}">${htmlContent}</div>`);
+      const htmlContent = `<b>${Xss.escape(nameVisible)}</b>&nbsp;&nbsp;&nbsp;${size}<span class="progress"><span class="percent"></span></span>`;
+      Xss.sanitizeAppend('#attachments', `<div class="attachment" title="${Xss.escape(name)}" index="${Number(i)}">${htmlContent}</div>`);
     }
     this.view.renderModule.resizePgpBlockFrame();
     $('div.attachment').click(this.view.setHandlerPrevent('double', async target => {

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -1202,7 +1202,6 @@ td {
   border-left: 4px solid #31a217;
   margin-right: 12px;
   display: inline-block;
-  height: 15px;
 }
 
 #pgp_block #attachments .attachment .file-download-right-click-link {


### PR DESCRIPTION
Fixes #2644 

Visible filenames are limited to 100 chars. Here's the simulated example:

![image](https://user-images.githubusercontent.com/6059356/76506203-710d9480-6453-11ea-88be-b888c81f8bdb.png)
