### PR TITLE
Downgrade puppeteer to 1.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "mailparser": "2.7.1",
     "mkdirp": "^1.0.3",
     "openpgp": "4.5.4",
-    "puppeteer": "1.20.0",
+    "puppeteer": "1.19.0",
     "speakeasy": "2.0.0",
     "stylelint": "^11.1.1",
     "stylelint-config-standard": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@types/jquery": "3.3.31",
     "@types/mailparser": "2.4.0",
     "@types/mkdirp": "^0.5.2",
-    "@types/puppeteer": "1.20.3",
+    "@types/puppeteer": "1.19.0",
     "@types/request": "2.47.1",
     "@types/speakeasy": "2.0.5",
     "@typescript-eslint/eslint-plugin": "^2.10.0",


### PR DESCRIPTION
Closes #2575

The same as #2576, for some reason GH is not allowing to reopen that PR.

I'll check if the reason for the failures in #2576 was fixed in the recently fixed flaky test.