### PR TITLE
Add strict Content Security Policy

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -89,5 +89,5 @@
     "/chrome/elements/shared/footer.htm"
   ],
   "minimum_chrome_version": "61",
-  "content_security_policy": "'self'; object-src 'self'; frame-ancestors https://mail.google.com 'self';"
+  "content_security_policy": "script-src 'self'; frame-ancestors https://mail.google.com 'self';"
 }


### PR DESCRIPTION
This change enables very strict CSP that doesn't allow inline styles or scripts.

Not everything works with it though! (e.g. popup) but it seems like there are not many changes. I'll check out later if it's feasible to remove all inline styles, if so - I'll fix them, if not, I'll allow them but disallow everything else.

DO NOT MERGE this yet!

------------

close #2693 