### PR TITLE
Switch from plain to encrypted reply (from toolbar)

### DIFF
--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -191,6 +191,10 @@ export class GmailElementReplacer implements WebmailElementReplacer {
 
   private actionActivateSecureReplyHandler = async (btn: HTMLElement, event: JQuery.Event) => {
     event.stopImmediatePropagation();
+    if ($('#switch_to_encrypted_reply').length) {
+      $('#switch_to_encrypted_reply').click();
+      return;
+    }
     const messageContainer = $(btn.closest('.h7') as HTMLElement);
     if (messageContainer.is(':last-child')) {
       if (this.isEncrypted()) {

--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -170,7 +170,11 @@ export class GmailElementReplacer implements WebmailElementReplacer {
             $(secureReplyBtn).click();
           }
         });
-        gmailReplyBtn.click(Ui.event.handle(() => { this.keepNextStandardReplyBox = true; }));
+        gmailReplyBtn.click(Ui.event.handle(() => {
+          if (!$('#switch_to_encrypted_reply').length) {
+            this.keepNextStandardReplyBox = true;
+          }
+        }));
       }
     }
     // conversation top-right icon buttons
@@ -529,7 +533,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
           for (const replyBoxEl of newReplyBoxes) {
             $(replyBoxEl).addClass('reply_message_evaluated');
             const notification = $('<div class="error_notification">The last message was encrypted, but you are composing a reply without encryption. </div>');
-            const swithToEncryptedReply = $('<a href>Switch to encrypted reply</a>');
+            const swithToEncryptedReply = $('<a href id="switch_to_encrypted_reply">Switch to encrypted reply</a>');
             swithToEncryptedReply.click(Ui.event.handle((el, ev: JQuery.Event) => {
               ev.preventDefault();
               $(el).closest('.reply_message_evaluated').removeClass('reply_message_evaluated');

--- a/test/source/tests/tests/gmail.ts
+++ b/test/source/tests/tests/gmail.ts
@@ -166,6 +166,9 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       await pageDoesNotHaveReplyContainer(gmailPage);
       await gmailPage.waitAll('[data-tooltip^="Send"]'); // The Send button from the Standard reply box
       await gmailPage.waitForContent('.reply_message_evaluated .error_notification', 'The last message was encrypted, but you are composing a reply without encryption.');
+      await gmailPage.waitAndClick('[data-tooltip="Secure Reply"]'); // Switch to encrypted reply
+      await Util.sleep(5);
+      await pageHasReplyContainer(t, browser, gmailPage, { isReplyPromptAccepted: false });
     }));
 
     ava.default('mail.google.com - pubkey file gets rendered', testWithBrowser('compatibility', async (t, browser) => {


### PR DESCRIPTION
Connected to #2683 

Fixes the scenario described in https://github.com/FlowCrypt/flowcrypt-browser/issues/2683#issuecomment-602902847 but it will work only once:

![Peek 2020-03-27 22-50](https://user-images.githubusercontent.com/6059356/77799432-7555c680-707d-11ea-9f45-06139fce5f1d.gif)

The proper (infinite) switching between plain and secure should be done separately.

This could theoretically fix the "reply box does not always get replaced" issue, but I'm not 100% sure. @tomholub I'll need your feedback in #2683 on the initial issue is it's still happening after we merge this PR.