### PR TITLE
Remove amatiasq.sort-imports from recommended extensions

### DIFF
--- a/flowcrypt-browser.code-workspace
+++ b/flowcrypt-browser.code-workspace
@@ -41,7 +41,6 @@
   ],
   "extensions": {
     "recommendations": [
-      "amatiasq.sort-imports",
       "dbaeumer.vscode-eslint",
       "hex-ci.stylelint-plus",
       "ms-vscode.vscode-typescript-tslint-plugin"


### PR DESCRIPTION
As per https://github.com/FlowCrypt/flowcrypt-browser/pull/2712#discussion_r400281551