### PR TITLE
Do not raise keepNextStandardReplyBox for plain replies to plain messages

### DIFF
--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -172,7 +172,8 @@ export class GmailElementReplacer implements WebmailElementReplacer {
           }
         });
         gmailReplyBtn.click(Ui.event.handle(() => {
-          if (!$('#switch_to_encrypted_reply').length) {
+          const replyContainerIframe = $('.reply_message_iframe_container > iframe').last();
+          if (replyContainerIframe.length && !$('#switch_to_encrypted_reply').length) {
             this.keepNextStandardReplyBox = true;
           }
         }));

--- a/test/source/tests/tests/gmail.ts
+++ b/test/source/tests/tests/gmail.ts
@@ -163,8 +163,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       const gmailPage = await openGmailPage(t, browser, '/WhctKJVjMccKbJcxpHPNZKwzZdwqJlWBFKchGNPBQRWLtvvpxmWbPZnpDncWTKhKRfTHWmB'); // plain convo
       await Util.sleep(1);
       await gmailPage.waitAndClick('[data-tooltip="Reply"]');
-      gmailPage.goto(TestUrls.gmail(0, '/CllgCJTGnFpCNKgMrsvvbpdFsLFMxHHrfLtjZZHwbXccPDdNPvcmQGCDvfQCLBBkvlRngZzhJhL')); // encrypted convo
-      await Util.sleep(1);
+      await gmailPage.goto(TestUrls.gmail(0, '/CllgCJTGnFpCNKgMrsvvbpdFsLFMxHHrfLtjZZHwbXccPDdNPvcmQGCDvfQCLBBkvlRngZzhJhL')); // encrypted convo
       await gmailPage.waitAndClick('[data-tooltip="Reply"]');
       await Util.sleep(5);
       await pageDoesNotHaveReplyContainer(gmailPage);

--- a/test/source/tests/tests/gmail.ts
+++ b/test/source/tests/tests/gmail.ts
@@ -160,7 +160,11 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
     }));
 
     ava.default('mail.google.com - plain reply to encrypted message', testWithBrowser('compatibility', async (t, browser) => {
-      const gmailPage = await openGmailPage(t, browser, '/WhctKJTrdTXcmgcCRgXDpVnfjJNnjjLzSvcMDczxWPMsBTTfPxRDMrKCJClzDHtbXlhnwtV'); // encrypted convo
+      const gmailPage = await openGmailPage(t, browser, '/WhctKJVjMccKbJcxpHPNZKwzZdwqJlWBFKchGNPBQRWLtvvpxmWbPZnpDncWTKhKRfTHWmB'); // plain convo
+      await Util.sleep(1);
+      await gmailPage.waitAndClick('[data-tooltip="Reply"]');
+      gmailPage.goto(TestUrls.gmail(0, '/CllgCJTGnFpCNKgMrsvvbpdFsLFMxHHrfLtjZZHwbXccPDdNPvcmQGCDvfQCLBBkvlRngZzhJhL')); // encrypted convo
+      await Util.sleep(1);
       await gmailPage.waitAndClick('[data-tooltip="Reply"]');
       await Util.sleep(5);
       await pageDoesNotHaveReplyContainer(gmailPage);
@@ -173,7 +177,6 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
 
     ava.default('mail.google.com - plain reply draft', testWithBrowser('compatibility', async (t, browser) => {
       const gmailPage = await openGmailPage(t, browser, '/CllgCJTGnFpCNKgMrsvvbpdFsLFMxHHrfLtjZZHwbXccPDdNPvcmQGCDvfQCLBBkvlRngZzhJhL'); // encrypted convo
-      await Util.sleep(3); // TODO(@limonte): this is the clue for #2683, remove this line in the corresponding PR
       await gmailPage.waitAndClick('[data-tooltip="Reply"]');
       await Util.sleep(5);
       await gmailPage.type('div[aria-label="Message Body"]', 'plain reply', true);


### PR DESCRIPTION
The issue was in raising `keepNextStandardReplyBox` when clicking the "Reply" button to plain messages. Silly oversight by me :man_facepalming: 

Fixes #2683 