### PR TITLE
Do not show 'switch to encrypted reply' warning when replying to signed message

### DIFF
--- a/extension/js/common/xss-safe-factory.ts
+++ b/extension/js/common/xss-safe-factory.ts
@@ -8,7 +8,7 @@ import { Dict, Str, Url, UrlParams } from './core/common.js';
 import { Att } from './core/att.js';
 import { Browser } from './browser/browser.js';
 import { Catch } from './platform/catch.js';
-import { MsgBlock } from './core/msg-block.js';
+import { MsgBlock, MsgBlockType } from './core/msg-block.js';
 import { MsgBlockParser } from './core/msg-block-parser.js';
 import { PgpArmor } from './core/pgp-armor.js';
 import { Ui } from './browser/ui.js';
@@ -190,7 +190,7 @@ export class XssSafeFactory {
     return Ui.e('span', { class: 'pgp_attachment', html: this.iframe(this.srcPgpAttIframe(meta, isEncrypted)) });
   }
 
-  public embeddedMsg = (type: string, armored: string, msgId?: string, isOutgoing?: boolean, sender?: string, signature?: string | boolean) => {
+  public embeddedMsg = (type: MsgBlockType, armored: string, msgId?: string, isOutgoing?: boolean, sender?: string, signature?: string | boolean) => {
     return this.iframe(this.srcPgpBlockIframe(armored, msgId, isOutgoing, sender, signature), ['pgp_block', type]) + this.hideGmailNewMsgInThreadNotification;
   }
 

--- a/extension/js/common/xss-safe-factory.ts
+++ b/extension/js/common/xss-safe-factory.ts
@@ -56,9 +56,9 @@ export class XssSafeFactory {
     } else if (block.type === 'plainHtml') {
       return Xss.htmlSanitizeAndStripAllTags(block.content.toString(), '<br>') + '<br><br>';
     } else if (block.type === 'encryptedMsg') {
-      return factory.embeddedMsg(block.complete ? PgpArmor.normalize(block.content.toString(), 'encryptedMsg') : '', msgId, isOutgoing, senderEmail);
+      return factory.embeddedMsg('encryptedMsg', block.complete ? PgpArmor.normalize(block.content.toString(), 'encryptedMsg') : '', msgId, isOutgoing, senderEmail);
     } else if (block.type === 'signedMsg') {
-      return factory.embeddedMsg(block.content.toString(), msgId, isOutgoing, senderEmail);
+      return factory.embeddedMsg('signedMsg', block.content.toString(), msgId, isOutgoing, senderEmail);
     } else if (block.type === 'publicKey') {
       return factory.embeddedPubkey(PgpArmor.normalize(block.content.toString(), 'publicKey'), isOutgoing);
     } else if (block.type === 'privateKey') {
@@ -66,7 +66,7 @@ export class XssSafeFactory {
     } else if (['encryptedAtt', 'plainAtt'].includes(block.type)) {
       return block.attMeta ? factory.embeddedAtta(new Att(block.attMeta), block.type === 'encryptedAtt') : '[missing encrypted attachment details]';
     } else if (block.type === 'signedHtml') {
-      return factory.embeddedMsg('', msgId, isOutgoing, senderEmail, true); // empty msg so it re-fetches from api. True at the and for "signature"
+      return factory.embeddedMsg('signedHtml', '', msgId, isOutgoing, senderEmail, true); // empty msg so it re-fetches from api. True at the and for "signature"
     } else {
       Catch.report(`don't know how to process block type: ${block.type} (not a hard fail)`);
       return '';
@@ -190,8 +190,8 @@ export class XssSafeFactory {
     return Ui.e('span', { class: 'pgp_attachment', html: this.iframe(this.srcPgpAttIframe(meta, isEncrypted)) });
   }
 
-  public embeddedMsg = (armored: string, msgId?: string, isOutgoing?: boolean, sender?: string, signature?: string | boolean) => {
-    return this.iframe(this.srcPgpBlockIframe(armored, msgId, isOutgoing, sender, signature), ['pgp_block']) + this.hideGmailNewMsgInThreadNotification;
+  public embeddedMsg = (type: string, armored: string, msgId?: string, isOutgoing?: boolean, sender?: string, signature?: string | boolean) => {
+    return this.iframe(this.srcPgpBlockIframe(armored, msgId, isOutgoing, sender, signature), ['pgp_block', type]) + this.hideGmailNewMsgInThreadNotification;
   }
 
   public embeddedPubkey = (armoredPubkey: string, isOutgoing?: boolean) => {

--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -339,7 +339,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
           } else if (treatAs === 'privateKey') {
             nRenderedAtts = await this.renderBackupFromFile(a, attsContainerInner, msgEl, attSel, nRenderedAtts);
           } else if (treatAs === 'signature') {
-            const embeddedSignedMsgXssSafe = this.factory.embeddedMsg('signature', '', msgId, false, senderEmail, true);
+            const embeddedSignedMsgXssSafe = this.factory.embeddedMsg('signedMsg', '', msgId, false, senderEmail, true);
             msgEl = this.updateMsgBodyEl_DANGEROUSLY(msgEl, 'set', embeddedSignedMsgXssSafe); // xss-safe-factory
           }
         } else if (treatAs === 'plainFile' && a.name.substr(-4) === '.asc') { // normal looking attachment ending with .asc


### PR DESCRIPTION
Fixes #2720 

I recommend using `?w=1` for CR: https://github.com/FlowCrypt/flowcrypt-browser/pull/2745/files?w=1