### PR TITLE
Add confirmation after private key has been backed up

### DIFF
--- a/extension/chrome/settings/modules/backup-manual-module.ts
+++ b/extension/chrome/settings/modules/backup-manual-module.ts
@@ -133,7 +133,7 @@ export class BackupManualActionModule extends ViewModule<BackupView> {
   }
 
   private backupRefused = async (ki: KeyInfo) => {
-    BrowserMsg.send.closePage(this.view.parentTabId as string);
+    await this.view.renderBackupDone(false);
   }
 
   private isPassPhraseStrongEnough = async (ki: KeyInfo, passphrase: string) => {

--- a/extension/chrome/settings/modules/backup-manual-module.ts
+++ b/extension/chrome/settings/modules/backup-manual-module.ts
@@ -133,7 +133,7 @@ export class BackupManualActionModule extends ViewModule<BackupView> {
   }
 
   private backupRefused = async (ki: KeyInfo) => {
-    await this.view.renderBackupDone();
+    BrowserMsg.send.closePage(this.view.parentTabId as string);
   }
 
   private isPassPhraseStrongEnough = async (ki: KeyInfo, passphrase: string) => {

--- a/extension/chrome/settings/modules/backup.ts
+++ b/extension/chrome/settings/modules/backup.ts
@@ -7,6 +7,7 @@ import { Url } from '../../../js/common/core/common.js';
 import { Assert } from '../../../js/common/assert.js';
 import { Gmail } from '../../../js/common/api/email-provider/gmail/gmail.js';
 import { OrgRules } from '../../../js/common/org-rules.js';
+import { Ui } from '../../../js/common/browser/ui.js';
 import { View } from '../../../js/common/view.js';
 import { Xss } from '../../../js/common/platform/xss.js';
 import { BackupStatusModule } from './backup-status-module.js';
@@ -80,7 +81,8 @@ export class BackupView extends View {
     if (this.action === 'setup_automatic' || this.action === 'setup_manual') {
       window.location.href = Url.create('/chrome/settings/setup.htm', { acctEmail: this.acctEmail, action: 'finalize', idToken: this.idToken });
     } else {
-      window.location.reload();
+      await Ui.modal.info('Your private key has been successfully backed up');
+      BrowserMsg.send.closePage(this.parentTabId as string);
     }
   }
 

--- a/extension/chrome/settings/modules/backup.ts
+++ b/extension/chrome/settings/modules/backup.ts
@@ -77,12 +77,14 @@ export class BackupView extends View {
     }
   }
 
-  public renderBackupDone = async () => {
+  public renderBackupDone = async (backedUp = true) => {
     if (this.action === 'setup_automatic' || this.action === 'setup_manual') {
       window.location.href = Url.create('/chrome/settings/setup.htm', { acctEmail: this.acctEmail, action: 'finalize', idToken: this.idToken });
-    } else {
+    } else if (backedUp) {
       await Ui.modal.info('Your private key has been successfully backed up');
       BrowserMsg.send.closePage(this.parentTabId as string);
+    } else {
+      window.location.href = Url.create('/chrome/settings/modules/backup.htm', { acctEmail: this.acctEmail, parentTabId: this.parentTabId as string });
     }
   }
 

--- a/extension/chrome/settings/modules/change_passphrase.htm
+++ b/extension/chrome/settings/modules/change_passphrase.htm
@@ -51,7 +51,7 @@
         <button class="button long green action_change" data-test="action-confirm-new-pp">CONFIRM PASS PHRASE</button>
       </div>
       <div class="line">
-        <button class="button long gray action_use_another">USE ANOTHER PASS PHRASE</button>
+        <button class="button longer gray action_use_another">USE ANOTHER PASS PHRASE</button>
       </div>
     </div>
 

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -147,7 +147,7 @@ span.gray { color: #b7b7b7; }
 }
 
 .swal2-popup.ui-modal-iframe .swal2-close { color: #666; }
-.swal2-popup.ui-modal-iframe iframe { max-width: 100%; }
+.swal2-popup.ui-modal-iframe iframe { width: 100%; }
 .swal2-container.ui-modal-page { background: rgba(0, 0, 0, 0.6) !important; }
 
 .swal2-container.ui-modal-fullscreen { padding: 0; }
@@ -195,7 +195,7 @@ span.gray { color: #b7b7b7; }
 i.small_spinner {
   display: inline-block;
   width: 40px;
-  height: 18px;
+  height: 26px;
   text-align: center;
   position: relative;
 }

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -147,7 +147,7 @@ span.gray { color: #b7b7b7; }
 }
 
 .swal2-popup.ui-modal-iframe .swal2-close { color: #666; }
-.swal2-popup.ui-modal-iframe iframe { width: 100%; }
+.swal2-popup.ui-modal-iframe iframe { max-width: 100%; }
 .swal2-container.ui-modal-page { background: rgba(0, 0, 0, 0.6) !important; }
 
 .swal2-container.ui-modal-fullscreen { padding: 0; }

--- a/test/source/tests/page-recipe/settings-page-recipe.ts
+++ b/test/source/tests/page-recipe/settings-page-recipe.ts
@@ -55,8 +55,10 @@ export class SettingsPageRecipe extends PageRecipe {
     await securityFrame.waitAndClick('@action-confirm-new-pp', { delay: 1 });
     await securityFrame.waitAndRespondToModal('info', 'confirm', 'Now that you changed your pass phrase, you should back up your key');
     await securityFrame.waitAll('@container-backup-dialog'); // offers a new backup
-    await Util.sleep(3);
-    await SettingsPageRecipe.closeDialog(settingsPage);
+    await securityFrame.waitAndClick('@input-backup-step3manual-file');
+    await securityFrame.waitAndClick('@action-backup-step3manual-continue');
+    await securityFrame.waitAndRespondToModal('info', 'confirm', 'Downloading private key backup file');
+    await securityFrame.waitAndRespondToModal('info', 'confirm', 'Your private key has been successfully backed up');
   }
 
   public static forgetAllPassPhrasesInStorage = async (settingsPage: ControllablePage, passphrase: string) => {


### PR DESCRIPTION
Fixes #2684 

Added this confirmation popup:

![image](https://user-images.githubusercontent.com/6059356/80398148-da404e80-88bf-11ea-97f0-29a57fbbebcd.png)

---

Also, fixed these UI details:

before: 

![image](https://user-images.githubusercontent.com/6059356/80398190-e7f5d400-88bf-11ea-8f0c-7d54b94fd1e0.png)

after:

![image](https://user-images.githubusercontent.com/6059356/80398205-ec21f180-88bf-11ea-9da4-c164f4605616.png)

---

before:

![image](https://user-images.githubusercontent.com/6059356/80398238-f9d77700-88bf-11ea-8925-2c0a9dfa076c.png)

after:

![image](https://user-images.githubusercontent.com/6059356/80398249-ff34c180-88bf-11ea-84ef-fc3c29403be0.png)