### PR TITLE
Sanitize error messages by removing all tags

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -36,7 +36,7 @@ blocks:
 
       prologue:
         commands:
-          - sudo sh -c "echo '209.250.232.81 cron.flowcrypt.com' >> /etc/hosts" && sudo sh -c "echo '127.0.0.1 google.mock.flowcrypt.com' >> /etc/hosts"
+          - sudo sh -c "echo '209.250.232.81 cron.flowcrypt.com' >> /etc/hosts" && sudo sh -c "echo '127.0.0.1 google.mock.flowcryptlocal.com' >> /etc/hosts"
           - cache restore sources-$SEMAPHORE_PIPELINE_ID
           - cd ~/git/flowcrypt-browser
           - cache restore node-modules-$SEMAPHORE_GIT_BRANCH-$(cat package.json.sum)
@@ -45,6 +45,8 @@ blocks:
 
         - name: code quality
           commands:
+            - nvm install 10.19.0
+            - nvm alias default 10.19.0
             - npm run-script test_tslint
             - npm run-script test_eslint
             - npm run-script test_stylelint

--- a/extension/chrome/elements/pgp_block_modules/pgp-block-error-module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp-block-error-module.ts
@@ -21,7 +21,7 @@ export class PgpBlockViewErrorModule {
   public renderErr = async (errBoxContent: string, renderRawMsg: string | undefined) => {
     this.view.renderModule.setFrameColor('red');
     const showRawMsgPrompt = renderRawMsg ? '<a href="#" class="action_show_raw_pgp_block">show original message</a>' : '';
-    await this.view.renderModule.renderContent(`<div class="error">${errBoxContent.replace(/\n/g, '<br>')}</div>${showRawMsgPrompt}`, true);
+    await this.view.renderModule.renderContent(`<div class="error">${errBoxContent.replace(/<.*?>/g, '')}</div>${showRawMsgPrompt}`, true);
     $('.action_show_raw_pgp_block').click(this.view.setHandler(async () => { // this may contain content missing MDC
       Xss.sanitizeAppend('#pgp_block', `<div class="raw_pgp_block">${Xss.escape(renderRawMsg!)}</div>`); // therefore the .escape is crucial
     }));

--- a/extension/chrome/elements/pgp_block_modules/pgp-block-error-module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp-block-error-module.ts
@@ -21,7 +21,7 @@ export class PgpBlockViewErrorModule {
   public renderErr = async (errBoxContent: string, renderRawMsg: string | undefined) => {
     this.view.renderModule.setFrameColor('red');
     const showRawMsgPrompt = renderRawMsg ? '<a href="#" class="action_show_raw_pgp_block">show original message</a>' : '';
-    await this.view.renderModule.renderContent(`<div class="error">${errBoxContent.replace(/<.*?>/g, '')}</div>${showRawMsgPrompt}`, true);
+    await this.view.renderModule.renderContent(`<div class="error">${errBoxContent.replace(/\n/g, '<br>')}</div>${showRawMsgPrompt}`, true);
     $('.action_show_raw_pgp_block').click(this.view.setHandler(async () => { // this may contain content missing MDC
       Xss.sanitizeAppend('#pgp_block', `<div class="raw_pgp_block">${Xss.escape(renderRawMsg!)}</div>`); // therefore the .escape is crucial
     }));
@@ -57,7 +57,7 @@ export class PgpBlockViewErrorModule {
       await this.renderErr(`FlowCrypt does not work in a Firefox Private Window (or when Firefox Containers are used). Please try in a standard window.`, undefined);
     } else {
       Catch.reportErr(e);
-      await this.renderErr(String(e), this.view.encryptedMsgUrlParam ? this.view.encryptedMsgUrlParam.toUtfStr() : undefined);
+      await this.renderErr(Xss.escape(String(e)), this.view.encryptedMsgUrlParam ? this.view.encryptedMsgUrlParam.toUtfStr() : undefined);
     }
   }
 

--- a/test/source/mock/google/google-data.ts
+++ b/test/source/mock/google/google-data.ts
@@ -110,7 +110,7 @@ export class GoogleData {
       if (acctsWithoutMockData.includes(acct)) {
         DATA[acct] = { drafts: [], messages: [], attachments: {}, labels: [] };
       } else {
-        DATA[acct] = JSON.parse(readFileSync(`./test/samples/${acct.replace(/[^a-z0-9]+/g, '')}.json`, { encoding: 'UTF-8' })) as AcctDataFile;
+        DATA[acct] = JSON.parse(readFileSync(`./test/samples/${acct.replace(/[^a-z0-9]+/g, '')}.json`, { encoding: 'utf-8' })) as AcctDataFile;
       }
       if (UserMessages[acct]) {
         DATA[acct].drafts = UserMessages[acct].drafts;

--- a/tooling/build-types.ts
+++ b/tooling/build-types.ts
@@ -4,7 +4,7 @@ import { execSync as exec } from 'child_process';
 
 const CHROME_CONSUMER = 'chrome-consumer';
 const CHROME_ENTERPRISE = 'chrome-enterprise';
-const MOCK_HOST: { [buildType: string]: string } = { 'chrome-consumer': 'http://localhost:8001', 'chrome-enterprise': 'http://google.mock.flowcrypt.com:8001' };
+const MOCK_HOST: { [buildType: string]: string } = { 'chrome-consumer': 'http://localhost:8001', 'chrome-enterprise': 'http://google.mock.flowcryptlocal.com:8001' };
 
 const buildDir = (buildType: string) => `./build/${buildType}`;
 

--- a/tooling/build-types.ts
+++ b/tooling/build-types.ts
@@ -9,7 +9,7 @@ const MOCK_HOST: { [buildType: string]: string } = { 'chrome-consumer': 'http://
 const buildDir = (buildType: string) => `./build/${buildType}`;
 
 const edit = (filepath: string, editor: (content: string) => string) => {
-  writeFileSync(filepath, editor(readFileSync(filepath, { encoding: 'UTF-8' })));
+  writeFileSync(filepath, editor(readFileSync(filepath, { encoding: 'utf8' })));
 };
 
 const makeMockBuild = (buildType: string) => {


### PR DESCRIPTION
I don't think there is any need to allow tags here, but if I'm wrong please let me know and we'll find a different way. This should prevent HTML injection via error messages per FLO-02-004 of the Cure53 report.

// tom
close #2770 