### PR TITLE
Use ChildNode.remove()

### DIFF
--- a/extension/js/common/browser/browser.ts
+++ b/extension/js/common/browser/browser.ts
@@ -57,7 +57,7 @@ export class Browser {
         }
         if (Catch.browser().name === 'firefox') {
           try {
-            document.body.removeChild(a);
+            a.remove();
           } catch (err) {
             if (!(err instanceof Error && err.message === 'Node was not found')) {
               throw err;


### PR DESCRIPTION
Use [ChildNode.remove()](https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/remove) for removing node, `document.body.removeChild` produces `The node to be removed is not a child of this node` exception.

Fixes #2764