### PR TITLE
Fix Firefox account recovery / Move `checkPassPhrase` outside of Key object

### DIFF
--- a/extension/chrome/elements/backup.ts
+++ b/extension/chrome/elements/backup.ts
@@ -71,7 +71,7 @@ View.run(class BackupView extends View {
   }
 
   private testPassphraseHandler = async () => {
-    if (await (await KeyUtil.parse(this.armoredPrvBackup)).checkPassPhrase(String($('#pass_phrase').val())) === true) {
+    if (await KeyUtil.checkPassPhrase(this.armoredPrvBackup, String($('#pass_phrase').val())) === true) {
       await Ui.modal.info('Success - your pass phrase matches this backup!');
     } else {
       await Ui.modal.warning('Pass phrase did not match. Please try again. If you forgot your pass phrase, please change it, so that you don\'t get' +

--- a/extension/chrome/settings/setup/setup-recover-key.ts
+++ b/extension/chrome/settings/setup/setup-recover-key.ts
@@ -32,7 +32,7 @@ export class SetupRecoverKeyModule {
       }
       let matchedPreviouslyRecoveredKey = false;
       for (const fetchedKey of this.view.fetchedKeyBackups) {
-        if (await (await KeyUtil.parse(fetchedKey.private)).checkPassPhrase(passphrase) === true) {
+        if (await KeyUtil.checkPassPhrase(fetchedKey.private, passphrase) === true) {
           if (!this.view.mathingPassphrases.includes(passphrase)) {
             this.view.mathingPassphrases.push(passphrase);
           }

--- a/extension/js/common/core/crypto/pgp/openpgp-key.ts
+++ b/extension/js/common/core/crypto/pgp/openpgp-key.ts
@@ -203,13 +203,11 @@ export class OpenPGPKey {
       lastModified,
       expiration: exp instanceof Date ? exp : undefined,
       created: pubkey.getCreationTime(),
-      checkPassPhrase: _text => Promise.resolve(false), // this is assigned right below
       fullyDecrypted: pubkey.isPublic() ? true /* public keys are always decrypted */ : pubkey.isFullyDecrypted(),
       fullyEncrypted: pubkey.isPublic() ? false /* public keys are never encrypted */ : pubkey.isFullyEncrypted(),
       isPublic: pubkey.isPublic(),
       isPrivate: pubkey.isPrivate(),
     } as Key);
-    pkey.checkPassPhrase = async passphrase => PgpKey.decrypt(await OpenPGPKey.parse(OpenPGPKey.armor(pkey)), passphrase);
     const extensions = pkey as unknown as { raw: string, [internal]: OpenPGP.key.Key };
     extensions[internal] = pubkey;
     extensions.raw = raw || pubkey.armor();

--- a/extension/js/common/core/crypto/smime/smime-key.ts
+++ b/extension/js/common/core/crypto/smime/smime-key.ts
@@ -25,7 +25,6 @@ export class SmimeKey {
       created: certificate.validity.notBefore,
       lastModified: certificate.validity.notBefore,
       expiration: certificate.validity.notAfter,
-      checkPassPhrase: _ => { throw new Error('Not implemented yet.'); },
       fullyDecrypted: false,
       fullyEncrypted: false,
       isPublic: true,


### PR DESCRIPTION
This aligns `checkPassPhrase` with other key functions and also allows the Key object to be serialized using structured clone algorithm in Firefox.

Fixes #2804.

I've tested this in Firefox while first reproducing it. It failed on each time when setting up an already used account but if you can test it too I'd be really glad ;)