### PR TITLE
Fix unexpected value when sending e-mail

### DIFF
--- a/extension/js/common/core/crypto/key.ts
+++ b/extension/js/common/core/crypto/key.ts
@@ -184,7 +184,9 @@ export class KeyUtil {
     if (!exp) {
       return false;
     }
-    if (exp instanceof Date) {
+    // exp instanceof Date does not work if the date objects
+    // are from another realm (e.g. iframe)
+    if (typeof exp.getTime === 'function') {
       return Date.now() > exp.getTime();
     }
     throw new Error(`Got unexpected value for expiration: ${exp}`);

--- a/extension/js/common/core/crypto/key.ts
+++ b/extension/js/common/core/crypto/key.ts
@@ -185,7 +185,7 @@ export class KeyUtil {
       return false;
     }
     // exp instanceof Date does not work if the date objects, are from another realm (e.g. iframe)
-    // see https://github.com/FlowCrypt/flowcrypt-browser/pull/2816/files
+    // see https://github.com/FlowCrypt/flowcrypt-browser/pull/2816
     if (typeof exp.getTime === 'function') {
       return Date.now() > exp.getTime();
     }

--- a/extension/js/common/core/crypto/key.ts
+++ b/extension/js/common/core/crypto/key.ts
@@ -184,12 +184,7 @@ export class KeyUtil {
     if (!exp) {
       return false;
     }
-    // exp instanceof Date does not work if the date objects, are from another realm (e.g. iframe)
-    // see https://github.com/FlowCrypt/flowcrypt-browser/pull/2816
-    if (typeof exp.getTime === 'function') {
-      return Date.now() > exp.getTime();
-    }
-    throw new Error(`Got unexpected value for expiration: ${exp}`);
+    return Date.now() > exp.getTime();
   }
 
   public static dateBeforeExpirationIfAlreadyExpired = (key: Key): Date | undefined => {

--- a/extension/js/common/core/crypto/key.ts
+++ b/extension/js/common/core/crypto/key.ts
@@ -184,8 +184,8 @@ export class KeyUtil {
     if (!exp) {
       return false;
     }
-    // exp instanceof Date does not work if the date objects
-    // are from another realm (e.g. iframe)
+    // exp instanceof Date does not work if the date objects, are from another realm (e.g. iframe)
+    // see https://github.com/FlowCrypt/flowcrypt-browser/pull/2816/files
     if (typeof exp.getTime === 'function') {
       return Date.now() > exp.getTime();
     }

--- a/extension/js/common/core/crypto/pgp/openpgp-key.ts
+++ b/extension/js/common/core/crypto/pgp/openpgp-key.ts
@@ -159,10 +159,13 @@ export class OpenPGPKey {
       if (exp === Infinity || !exp) {
         return false;
       }
-      if (typeof exp !== 'number') {
-        return Date.now() > exp.getTime();
+      // According to the documentation expiration is either undefined, Infinity
+      // (typeof number) or a Date object. So in this case `exp` should never
+      // be of type number.
+      if (typeof exp === 'number') {
+        throw new Error(`Got unexpected value for expiration: ${exp}`);
       }
-      throw new Error(`Got unexpected value for expiration: ${exp}`);
+      return Date.now() > exp.getTime();
     };
     const emails = pubkey.users
       .map(user => user.userId)

--- a/extension/js/common/core/crypto/pgp/openpgp-key.ts
+++ b/extension/js/common/core/crypto/pgp/openpgp-key.ts
@@ -159,7 +159,7 @@ export class OpenPGPKey {
       if (exp === Infinity || !exp) {
         return false;
       }
-      if (exp instanceof Date) {
+      if (typeof exp !== 'number') {
         return Date.now() > exp.getTime();
       }
       throw new Error(`Got unexpected value for expiration: ${exp}`);


### PR DESCRIPTION
To reproduce:
  - Use Firefox,
  - Open Secure Compose on gmail.com (*not* internal inbox),
  - Send an e-mail to a key that has expiration set.

The bug is caused by Date objects arriving from another realm (extension vs gmail.com page). They are full-fledged Date objects but they are not `instanceof Date` because `Date` points to the Date constructor from current frame (gmail.com).

The fix checks the existance of the function we need (`getTime`).

This was kind of hard to debug until I found a toggle in Firefox devtools to allow debugging extensions :)