### PR TITLE
Fix redirectToInitSetup() for Firefox

### DIFF
--- a/extension/chrome/popups/default.ts
+++ b/extension/chrome/popups/default.ts
@@ -51,7 +51,7 @@ View.run(class DefaultPopupView extends View {
   }
 
   private redirectToInitSetup = async (acctEmail?: string) => {
-    await Browser.openSettingsPage('index.htm', acctEmail || undefined);
+    BrowserMsg.send.bg.settings({ acctEmail: acctEmail || undefined });
     await Ui.time.sleep(100);
     window.close();
   }


### PR DESCRIPTION
Fixes #2854 

This is the regression from my PR https://github.com/FlowCrypt/flowcrypt-browser/pull/2714 Either I somehow skipped testing that functionality in Firefox or Firefox added something in one of the latest versions which doesn't allow `window.open` to work. Luckily, there's the fallback through the bg page.