### PR TITLE
Add offline drafts

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,8 @@
       "program": "${workspaceFolder}/node_modules/ava/profile.js",
       "args": [
         "build/test/test/source/test.js",
-        "CONSUMER-MOCK"
+        "CONSUMER-MOCK",
+        "--pool-size=1"
       ],
       "skipFiles": [
         "<node_internals>/**/*.js"

--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -46,6 +46,9 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
     this.view.recipientsModule.onRecipientAdded(async () => await this.draftSave(true));
   }
 
+  /**
+   * Returns true when a draft was loaded
+   */
   public initialDraftLoad = async (draftId: string): Promise<boolean> => {
     if (this.view.isReplyBox) {
       Xss.sanitizeRender(this.view.S.cached('prompt'), `Loading draft.. ${Ui.spinner('green')}`);

--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -174,7 +174,9 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
     }
   }
 
-  private isLocalDraftId = (draftId: string) => !!draftId.match(this.localDraftPrefix);
+  private isLocalDraftId = (draftId: string) => {
+    return !!draftId.match(this.localDraftPrefix);
+  }
 
   private localDraftCreate = async (mimeMsg: string, threadId: string, recipients: string[], subject: string) => {
     const draftId = `${this.localDraftPrefix}${threadId}`;

--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -3,6 +3,7 @@
 'use strict';
 
 import { Mime, MimeContent, MimeProccesedMsg } from '../../../js/common/core/mime.js';
+import { AcctStore } from '../../../js/common/platform/store/acct-store.js';
 import { AjaxErr } from '../../../js/common/api/error/api-error-types.js';
 import { ApiErr } from '../../../js/common/api/error/api-error.js';
 import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
@@ -10,8 +11,10 @@ import { Buf } from '../../../js/common/core/buf.js';
 import { Catch } from '../../../js/common/platform/catch.js';
 import { EncryptedMsgMailFormatter } from './formatters/encrypted-mail-msg-formatter.js';
 import { Env } from '../../../js/common/browser/env.js';
+import { GmailRes } from '../../../js/common/api/email-provider/gmail/gmail-parser.js';
 import { MsgBlockParser } from '../../../js/common/core/msg-block-parser.js';
 import { PgpMsg } from '../../../js/common/core/crypto/pgp/pgp-msg.js';
+import { storageLocalGet, storageLocalSet, storageLocalRemove } from '../../../js/common/api/chrome.js';
 import { Ui } from '../../../js/common/browser/ui.js';
 import { Url } from '../../../js/common/core/common.js';
 import { Xss } from '../../../js/common/platform/xss.js';
@@ -23,6 +26,7 @@ import { KeyUtil } from '../../../js/common/core/crypto/key.js';
 export class ComposeDraftModule extends ViewModule<ComposeView> {
 
   public wasMsgLoadedFromDraft = false;
+  public localDraftPrefix = 'local-draft-';
 
   private currentlySavingDraft = false;
   private saveDraftInterval?: number;
@@ -47,7 +51,7 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
       Xss.sanitizeRender(this.view.S.cached('prompt'), `Loading draft.. ${Ui.spinner('green')}`);
     }
     try {
-      const draftGetRes = await this.view.emailProvider.draftGet(draftId, 'raw');
+      const draftGetRes = this.isLocalDraftId(draftId) ? await this.localDraftGet(draftId) : await this.view.emailProvider.draftGet(draftId, 'raw');
       if (!draftGetRes) {
         return await this.abortAndRenderReplyMsgComposeTableIfIsReplyBox('!draftGetRes');
       }
@@ -81,7 +85,7 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
     if (this.view.draftId) {
       await this.view.storageModule.draftMetaDelete(this.view.draftId, this.view.threadId);
       try {
-        await this.view.emailProvider.draftDelete(this.view.draftId);
+        this.isLocalDraftId(this.view.draftId) ? await storageLocalRemove([this.view.draftId]) : await this.view.emailProvider.draftDelete(this.view.draftId);
         this.view.draftId = '';
       } catch (e) {
         if (ApiErr.isAuthPopupNeeded(e)) {
@@ -111,23 +115,43 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
           sendable.body['text/plain'] = `[cryptup:link:draft_compose:${this.view.draftId}]\n\n${sendable.body['text/plain'] || ''}`;
         }
         const mimeMsg = await sendable.toMime();
-        if (!this.view.draftId) {
-          const { id } = await this.view.emailProvider.draftCreate(mimeMsg, this.view.threadId);
+        if (!this.view.draftId || this.isLocalDraftId(this.view.draftId)) {
+          let draftId: string;
+          try {
+            ({ id: draftId } = await this.view.emailProvider.draftCreate(mimeMsg, this.view.threadId));
+            if (this.isLocalDraftId(this.view.draftId)) { // delete local draft if there is one
+              await storageLocalRemove([this.view.draftId]);
+            }
+          } catch (e) {
+            if (ApiErr.isNetErr(e)) {
+              draftId = await this.localDraftCreate(mimeMsg, this.view.threadId, msgData.recipients.to || [], msgData.subject);
+            } else {
+              throw e;
+            }
+          }
           this.view.S.cached('send_btn_note').text('Saved');
-          this.view.draftId = id;
-          await this.view.storageModule.draftMetaSet(id, this.view.threadId, msgData.recipients.to || [], String(this.view.S.cached('input_subject').val()));
+          this.view.draftId = draftId;
+          await this.view.storageModule.draftMetaSet(draftId, this.view.threadId, msgData.recipients.to || [], msgData.subject);
           // recursing one more time, because we need the draftId we get from this reply in the message itself
           // essentially everytime we save draft for the first time, we have to save it twice
           // currentlySavingDraft will remain true for now
-          await this.draftSave(true); // forceSave = true
+          if (!this.isLocalDraftId(this.view.draftId)) {
+            await this.draftSave(true); // forceSave = true
+          }
         } else {
-          await this.view.emailProvider.draftUpdate(this.view.draftId, mimeMsg);
+          try {
+            await this.view.emailProvider.draftUpdate(this.view.draftId, mimeMsg);
+          } catch (e) {
+            if (ApiErr.isNetErr(e)) {
+              this.view.draftId = await this.localDraftCreate(mimeMsg, this.view.threadId, msgData.recipients.to || [], msgData.subject);
+            } else {
+              throw e;
+            }
+          }
           this.view.S.cached('send_btn_note').text('Saved');
         }
       } catch (e) {
-        if (ApiErr.isNetErr(e)) {
-          this.view.S.cached('send_btn_note').text('Not saved (network)');
-        } else if (ApiErr.isAuthPopupNeeded(e)) {
+        if (ApiErr.isAuthPopupNeeded(e)) {
           BrowserMsg.send.notificationShowAuthPopupNeeded(this.view.parentTabId, { acctEmail: this.view.acctEmail });
           this.view.S.cached('send_btn_note').text('Not saved (reconnect)');
         } else if (e instanceof Error && e.message.indexOf('Could not find valid key packet for encryption in key') !== -1) {
@@ -148,6 +172,36 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
       }
       this.currentlySavingDraft = false;
     }
+  }
+
+  private isLocalDraftId = (draftId: string) => !!draftId.match(this.localDraftPrefix);
+
+  private localDraftCreate = async (mimeMsg: string, threadId: string, recipients: string[], subject: string) => {
+    const draftId = `${this.localDraftPrefix}${threadId}`;
+    const draftStorage = await AcctStore.get(this.view.acctEmail, ['drafts_reply', 'drafts_compose']);
+    if (threadId) { // it's a reply
+      const drafts = draftStorage.drafts_reply || {};
+      drafts[threadId] = draftId;
+      await AcctStore.set(this.view.acctEmail, { drafts_reply: drafts });
+    } else { // it's a new message
+      const drafts = draftStorage.drafts_compose || {};
+      drafts[draftId] = { recipients, subject, date: new Date().getTime() };
+      await AcctStore.set(this.view.acctEmail, { drafts_compose: drafts });
+    }
+    await storageLocalSet({ [draftId]: { message: { raw: Buf.fromUtfStr(mimeMsg).toBase64UrlStr(), threadId } } });
+    return draftId;
+  }
+
+  private localDraftGet = async (draftId: string) => {
+    const { [draftId]: localDraft } = await storageLocalGet([draftId]);
+    if (this.isValidLocalDraft(localDraft)) {
+      return localDraft;
+    }
+    return undefined;
+  }
+
+  private isValidLocalDraft = (localDraft: unknown): localDraft is GmailRes.GmailDraftGet => {
+    return localDraft && typeof (localDraft as GmailRes.GmailDraftGet).message === 'object';
   }
 
   private deleteDraftClickHandler = async () => {

--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -550,7 +550,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
       if (ApiErr.isAuthPopupNeeded(e)) {
         BrowserMsg.send.notificationShowAuthPopupNeeded(this.view.parentTabId, { acctEmail: this.view.acctEmail });
       } else if (ApiErr.isNetErr(e)) {
-        Ui.toast(`Network erroc - cannot search contacts`).catch(Catch.reportErr);
+        Ui.toast(`Network error - cannot search contacts`).catch(Catch.reportErr);
       } else if (ApiErr.isMailOrAcctDisabledOrPolicy(e)) {
         Ui.toast(`Cannot search contacts - account disabled or forbidden by admin policy`).catch(Catch.reportErr);
       } else {

--- a/extension/chrome/elements/compose-modules/compose-render-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-render-module.ts
@@ -118,8 +118,10 @@ export class ComposeRenderModule extends ViewModule<ComposeView> {
   public initComposeBox = async () => {
     this.initComposeBoxStyles();
     if (this.view.draftId) {
-      this.view.S.cached('triple_dot').remove(); // if it's draft, footer and quote should already be included in the draft
-      await this.view.draftModule.initialDraftLoad(this.view.draftId);
+      const draftLoaded = await this.view.draftModule.initialDraftLoad(this.view.draftId);
+      if (draftLoaded) {
+        this.view.S.cached('triple_dot').remove(); // if it's draft, footer and quote should already be included in the draft
+      }
       if (this.view.isReplyBox) {
         await this.view.renderModule.renderReplyMsgComposeTable();
       }

--- a/extension/chrome/elements/compose.ts
+++ b/extension/chrome/elements/compose.ts
@@ -167,8 +167,12 @@ export class ComposeView extends View {
     if (this.replyMsgId) {
       await this.renderModule.fetchReplyMeta(Object.keys(storage.sendAs!));
     }
-    if (this.isReplyBox && this.threadId && !this.ignoreDraft && storage.drafts_reply && storage.drafts_reply[this.threadId]) {
-      this.draftId = storage.drafts_reply[this.threadId]; // there may be a draft we want to load
+    if (this.isReplyBox) {
+      if (this.threadId && !this.ignoreDraft && storage.drafts_reply && storage.drafts_reply[this.threadId]) {
+        this.draftId = storage.drafts_reply[this.threadId]; // there may be a draft we want to load
+      }
+    } else {
+      this.draftId = this.draftModule.localDraftPrefix;
     }
     BrowserMsg.listen(this.tabId!);
     await this.renderModule.initComposeBox();

--- a/extension/chrome/elements/compose.ts
+++ b/extension/chrome/elements/compose.ts
@@ -167,12 +167,14 @@ export class ComposeView extends View {
     if (this.replyMsgId) {
       await this.renderModule.fetchReplyMeta(Object.keys(storage.sendAs!));
     }
-    if (this.isReplyBox) {
+    if (this.isReplyBox) { // reply
       if (this.threadId && !this.ignoreDraft && storage.drafts_reply && storage.drafts_reply[this.threadId]) {
         this.draftId = storage.drafts_reply[this.threadId]; // there may be a draft we want to load
       }
-    } else {
-      this.draftId = this.draftModule.localDraftPrefix;
+    } else { // compose
+      if (!this.draftId) {
+        this.draftId = this.draftModule.localDraftPrefix;
+      }
     }
     BrowserMsg.listen(this.tabId!);
     await this.renderModule.initComposeBox();

--- a/extension/chrome/elements/compose.ts
+++ b/extension/chrome/elements/compose.ts
@@ -173,7 +173,7 @@ export class ComposeView extends View {
       }
     } else { // compose
       if (!this.draftId) {
-        this.draftId = this.draftModule.localDraftPrefix;
+        this.draftId = this.draftModule.localNewMessageDraftId;
       }
     }
     BrowserMsg.listen(this.tabId!);

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -2148,6 +2148,11 @@ body#new_message.popup table#compose tr td {
 
 body#new_message { overflow-y: hidden; }
 
+body#new_message #loader {
+  display: flex;
+  align-items: center;
+}
+
 body#new_message.full_window {
   background-color: rgba(0, 0, 0, 0.5);
   padding: 20px 150px;

--- a/test/source/tests/page-recipe/compose-page-recipe.ts
+++ b/test/source/tests/page-recipe/compose-page-recipe.ts
@@ -108,6 +108,10 @@ export class ComposePageRecipe extends PageRecipe {
     await composePageOrFrame.verifyContentIsPresentContinuously('@send-btn-note', 'Saved');
   }
 
+  public static waitWhenDraftIsSavedLocally = async (composePageOrFrame: Controllable) => {
+    await composePageOrFrame.verifyContentIsPresentContinuously('@send-btn-note', 'Draft saved locally (offline)');
+  }
+
   public static sendAndClose = async (
     composePage: ControllablePage,
     { password, timeout, expectProgress }: { password?: string, timeout?: number, expectProgress?: boolean } = { timeout: 60 }

--- a/test/source/tests/tests/compose.ts
+++ b/test/source/tests/tests/compose.ts
@@ -1,6 +1,7 @@
 /* ©️ 2016 - present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com */
 
 import * as ava from 'ava';
+import { Page } from 'puppeteer';
 
 import { BrowserHandle, Controllable, ControllablePage, ControllableFrame } from '../../browser';
 import { Config, Util } from '../../util';
@@ -539,6 +540,18 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       const body = await composePage.waitAny('@input-body');
       await composePage.waitAll('#input_text img');
       expect(await body.$eval('#input_text img', el => el.getAttribute('src'))).to.eq(imgBase64);
+    }));
+
+    ava.default('compose - saving and rendering a draft when offline', testWithBrowser('compatibility', async (t, browser) => {
+      let composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
+      await (composePage.target as Page).setOfflineMode(true); // go offline mode
+      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'offline test', {});
+      await composePage.type('@input-body', `This is a test of saving a draft when offline`);
+      await ComposePageRecipe.waitWhenDraftIsSaved(composePage);
+      await composePage.close();
+      composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
+      await composePage.waitForContent('@input-subject', 'offline test');
+      await composePage.waitForContent('@input-body', 'This is a test of saving a draft when offline');
     }));
 
     ava.default('compose - RTL subject', testWithBrowser('compatibility', async (t, browser) => {

--- a/test/source/tests/tests/compose.ts
+++ b/test/source/tests/tests/compose.ts
@@ -548,7 +548,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'offline test', {});
       expect(await composePage.read('@action-send')).to.eq('Re-enter recipient..'); // ensure offline mode
       await composePage.type('@input-body', `This is a test of saving a draft when offline`);
-      await ComposePageRecipe.waitWhenDraftIsSaved(composePage);
+      await ComposePageRecipe.waitWhenDraftIsSavedLocally(composePage);
       await composePage.close();
       composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
       expect(await composePage.value('@input-subject')).to.match(/offline test/);

--- a/test/source/tests/tests/compose.ts
+++ b/test/source/tests/tests/compose.ts
@@ -546,11 +546,12 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       let composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
       await (composePage.target as Page).setOfflineMode(true); // go offline mode
       await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'offline test', {});
+      expect(await composePage.read('@action-send')).to.eq('Re-enter recipient..'); // ensure offline mode
       await composePage.type('@input-body', `This is a test of saving a draft when offline`);
       await ComposePageRecipe.waitWhenDraftIsSaved(composePage);
       await composePage.close();
       composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
-      await composePage.waitForContent('@input-subject', 'offline test');
+      expect(await composePage.value('@input-subject')).to.match(/offline test/);
       await composePage.waitForContent('@input-body', 'This is a test of saving a draft when offline');
     }));
 


### PR DESCRIPTION
Closes #2636

Hopefully the code is good now, I tried to make local drafts as close as possible to Gmail drafts so the saving/restoring/deleting processes would be the same.

Added the ability to save drafts when offline for both compose and reply use-cases.

![7U19rxmNYf](https://user-images.githubusercontent.com/6059356/88743442-65461480-d14d-11ea-8550-1bec9a8c9450.gif)

---

Also fixed the centering of reply loader:

before | after
-|-
![image](https://user-images.githubusercontent.com/6059356/88742986-46934e00-d14c-11ea-8963-a227e9c427aa.png) | ![image](https://user-images.githubusercontent.com/6059356/88742993-4abf6b80-d14c-11ea-8a13-5b227e457f7c.png)

And also this typo:

![image](https://user-images.githubusercontent.com/6059356/88743062-70e50b80-d14c-11ea-8cdd-5215e2f18ce5.png)