### PR TITLE
Issue 2732: fix S/MIME import on contacts screen

### DIFF
--- a/extension/chrome/elements/pgp_pubkey.htm
+++ b/extension/chrome/elements/pgp_pubkey.htm
@@ -29,6 +29,7 @@
   <script src="/lib/jquery.min.js"></script>
   <script src="/lib/sweetalert2.js"></script>
   <script src="/lib/openpgp.js"></script>
+  <script src="/lib/forge.js"></script>
   <script src="pgp_pubkey.js" type="module"></script>
 
 </body>

--- a/extension/chrome/settings/modules/contacts.htm
+++ b/extension/chrome/settings/modules/contacts.htm
@@ -82,6 +82,7 @@
   <script src="/lib/sweetalert2.js"></script>
   <script src="/lib/fine-uploader.js"></script>
   <script src="/lib/openpgp.js"></script>
+  <script src="/lib/forge.js"></script>
   <script src="contacts.js" type="module"></script>
 </body>
 

--- a/extension/chrome/settings/modules/contacts.ts
+++ b/extension/chrome/settings/modules/contacts.ts
@@ -212,7 +212,7 @@ View.run(class ContactsView extends View {
       } else { // Render Results
         const container = $('#bulk_import #processed');
         for (const block of blocks) {
-          if (block.type === 'publicKey') {
+          if (block.type === 'publicKey' || block.type === 'certificate') {
             const replacedHtmlSafe = XssSafeFactory.replaceRenderableMsgBlocks(this.factory!, block.content.toString(), '', '');
             if (replacedHtmlSafe && replacedHtmlSafe !== value) {
               container.append(replacedHtmlSafe); // xss-safe-factory

--- a/extension/js/common/xss-safe-factory.ts
+++ b/extension/js/common/xss-safe-factory.ts
@@ -63,6 +63,8 @@ export class XssSafeFactory {
       return factory.embeddedPubkey(PgpArmor.normalize(block.content.toString(), 'publicKey'), isOutgoing);
     } else if (block.type === 'privateKey') {
       return factory.embeddedBackup(PgpArmor.normalize(block.content.toString(), 'privateKey'));
+    } else if (block.type === 'certificate') {
+      return factory.embeddedPubkey(block.content.toString());
     } else if (['encryptedAtt', 'plainAtt'].includes(block.type)) {
       return block.attMeta ? factory.embeddedAtta(new Att(block.attMeta), block.type === 'encryptedAtt') : '[missing encrypted attachment details]';
     } else if (block.type === 'signedHtml') {

--- a/test/source/browser/controllable.ts
+++ b/test/source/browser/controllable.ts
@@ -265,18 +265,18 @@ abstract class ControllableBase {
     this.log(`wait_and_click:10:${selector}`);
   }
 
-  public waitForContent = async (selector: string, needle: string | RegExp, timeoutSec = 20, testLoopLengthMs = 100) => {
+  public waitForContent = async (selector: string, regExpNeedle: string | RegExp, timeoutSec = 20, testLoopLengthMs = 100) => {
     await this.waitAll(selector);
     const start = Date.now();
     let text = '';
     while (Date.now() - start < timeoutSec * 1000) {
       text = await this.read(selector, true);
-      if (text.match(needle)) {
+      if (text.match(regExpNeedle)) {
         return;
       }
       await Util.sleep(testLoopLengthMs / 1000);
     }
-    throw new Error(`Selector ${selector} was found but did not contain text "${needle}" whithin ${timeoutSec}s. Last content: "${text}"`);
+    throw new Error(`Selector ${selector} was found but did not match "${regExpNeedle}" within ${timeoutSec}s. Last content: "${text}"`);
   }
 
   public verifyContentIsPresentContinuously = async (selector: string, expectedText: string, expectPresentForMs: number = 3000, timeoutSec = 20) => {

--- a/test/source/tests/tests/compose.ts
+++ b/test/source/tests/tests/compose.ts
@@ -809,7 +809,6 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await contactsFrame.waitForContent('@container-pubkey-details', 'Expired: yes');
     }));
 
-
     ava.default('import S/MIME cert', testWithBrowser('compose', async (t, browser) => {
       const smimeCert = `-----BEGIN CERTIFICATE-----
 MIIE9DCCA9ygAwIBAgIQY/cCXnAPOUUwH7L7pWdPhDANBgkqhkiG9w0BAQsFADCB

--- a/test/source/tests/tests/compose.ts
+++ b/test/source/tests/tests/compose.ts
@@ -809,6 +809,63 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await contactsFrame.waitForContent('@container-pubkey-details', 'Expired: yes');
     }));
 
+
+    ava.default('import S/MIME cert', testWithBrowser('compose', async (t, browser) => {
+      const smimeCert = `-----BEGIN CERTIFICATE-----
+MIIE9DCCA9ygAwIBAgIQY/cCXnAPOUUwH7L7pWdPhDANBgkqhkiG9w0BAQsFADCB
+jTELMAkGA1UEBhMCSVQxEDAOBgNVBAgMB0JlcmdhbW8xGTAXBgNVBAcMEFBvbnRl
+IFNhbiBQaWV0cm8xIzAhBgNVBAoMGkFjdGFsaXMgUy5wLkEuLzAzMzU4NTIwOTY3
+MSwwKgYDVQQDDCNBY3RhbGlzIENsaWVudCBBdXRoZW50aWNhdGlvbiBDQSBHMjAe
+Fw0yMDAzMjMxMzU2NDZaFw0yMTAzMjMxMzU2NDZaMCIxIDAeBgNVBAMMF2FjdGFs
+aXNAbWV0YS4zM21haWwuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC
+AQEArVVpXBkzGvcqib8rDwqHCaKm2EiPslQ8I0G1ZDxrs6Ke2QXNm3yGVwOzkVvK
+eEnuzE5M4BBeh+GwcfvoyS/xI6m44WWnqj65cJoSLA1ypE4D4urv/pzG783y2Vdy
+Q96izBdFyevsil89Z2AxZxrFh1RC2XvgXad4yyD4yvVpHskfPexnhLliHl7cpXjw
+5D2n1hBGR8CSDbQAgO58PB7Y2ldrTi+rWBu2Akuk/YyWOOiGA8pdfLBIkOFJTeQc
+m7+vWP2JTN6Xp+JkGvXQBRaqwyGVg8fSc4e7uGCXZaH5/Na2FXY2OL+tYDDb27zS
+3cBrzEbGVjA6raYxcrFWV4PkdwIDAQABo4IBuDCCAbQwDAYDVR0TAQH/BAIwADAf
+BgNVHSMEGDAWgBRr8o2eaMElBB9RNFf2FlyU6k1pGjB+BggrBgEFBQcBAQRyMHAw
+OwYIKwYBBQUHMAKGL2h0dHA6Ly9jYWNlcnQuYWN0YWxpcy5pdC9jZXJ0cy9hY3Rh
+bGlzLWF1dGNsaWcyMDEGCCsGAQUFBzABhiVodHRwOi8vb2NzcDA5LmFjdGFsaXMu
+aXQvVkEvQVVUSENMLUcyMCIGA1UdEQQbMBmBF2FjdGFsaXNAbWV0YS4zM21haWwu
+Y29tMEcGA1UdIARAMD4wPAYGK4EfARgBMDIwMAYIKwYBBQUHAgEWJGh0dHBzOi8v
+d3d3LmFjdGFsaXMuaXQvYXJlYS1kb3dubG9hZDAdBgNVHSUEFjAUBggrBgEFBQcD
+AgYIKwYBBQUHAwQwSAYDVR0fBEEwPzA9oDugOYY3aHR0cDovL2NybDA5LmFjdGFs
+aXMuaXQvUmVwb3NpdG9yeS9BVVRIQ0wtRzIvZ2V0TGFzdENSTDAdBgNVHQ4EFgQU
+FrtAdAOjrcVeHg5K+T7sj7GHySMwDgYDVR0PAQH/BAQDAgWgMA0GCSqGSIb3DQEB
+CwUAA4IBAQAa9lXKDmV9874ojmIZEBL1S8mKaSNBWP+n0vp5FO0Yh5oL9lspYTPs
+8s6alWUSpVHV8if4uZ2EfcNpNkm9dAajj2n/F/Jyfkp8URu4uvBfm1QColl/zM/D
+x4B7FaD2dw0jTF/k5ulDmzUOc4k+j3LtZNbDOZMF/2g05hSKde/he1njlY3oKa9g
+VW8ftc2NwiSMthxyEIM+ALbNQVML2oN50gArBn5GeI22/aIBZxjtbEdmSTZIf82H
+sOwAnhJ+pD5iIPaF2oa0yN3PvI6IGxLpEv16tQO1N6e5bdP6ZDwqTQJyK+oNTNda
+yPLCqVTFJQWaCR5ZTekRQPTDZkjxjxbs
+-----END CERTIFICATE-----`;
+      const recipientEmail = 'actalis@meta.33mail.com';
+      // add S/MIME key manually
+      const settingsPage = await browser.newPage(t, TestUrls.extensionSettings('test.ci.compose@org.flowcrypt.com'));
+      await SettingsPageRecipe.toggleScreen(settingsPage, 'additional');
+      const contactsFrame = await SettingsPageRecipe.awaitNewPageFrame(settingsPage, '@action-open-contacts-page', ['contacts.htm', 'placement=settings']);
+      await contactsFrame.waitAll('@page-contacts');
+      await contactsFrame.waitAndClick('@action-show-import-public-keys-form', { confirmGone: true });
+      await contactsFrame.waitAndType('@input-bulk-public-keys', smimeCert);
+      await contactsFrame.waitAndClick('@action-show-parsed-public-keys', { confirmGone: true });
+      await contactsFrame.waitAll('iframe');
+      const pubkeyFrame = await contactsFrame.getFrame(['pgp_pubkey.htm']);
+      await pubkeyFrame.waitForContent('@action-add-contact', 'IMPORT KEY');
+      await pubkeyFrame.waitAndClick('@action-add-contact');
+      await pubkeyFrame.waitForContent('@container-pgp-pubkey', `${recipientEmail} added`);
+      await contactsFrame.waitAndClick('@action-back-to-contact-list', { confirmGone: true });
+      await contactsFrame.waitAndClick(`@action-show-pubkey-${recipientEmail.replace(/[^a-z0-9]+/g, '')}`, { confirmGone: true });
+      await contactsFrame.waitForContent('@container-pubkey-details', 'Type: x509');
+      await contactsFrame.waitForContent('@container-pubkey-details', 'Fingerprint: 63F7 025E 700F 3945 301F B2FB A567 4F84');
+      await contactsFrame.waitForContent('@container-pubkey-details', `Users: ${recipientEmail}`);
+      await contactsFrame.waitForContent('@container-pubkey-details', 'Created on: Mon Mar 23 2020 14:56:46');
+      await contactsFrame.waitForContent('@container-pubkey-details', 'Expiration: Tue Mar 23 2021 14:56:46');
+      await contactsFrame.waitForContent('@container-pubkey-details', 'Expired: no');
+      await contactsFrame.waitForContent('@container-pubkey-details', 'Usable for encryption: true');
+      await contactsFrame.waitForContent('@container-pubkey-details', 'Usable for signing: true');
+    }));
+
   }
 
 };

--- a/test/source/tests/tests/compose.ts
+++ b/test/source/tests/tests/compose.ts
@@ -858,8 +858,8 @@ yPLCqVTFJQWaCR5ZTekRQPTDZkjxjxbs
       await contactsFrame.waitForContent('@container-pubkey-details', 'Type: x509');
       await contactsFrame.waitForContent('@container-pubkey-details', 'Fingerprint: 63F7 025E 700F 3945 301F B2FB A567 4F84');
       await contactsFrame.waitForContent('@container-pubkey-details', `Users: ${recipientEmail}`);
-      await contactsFrame.waitForContent('@container-pubkey-details', 'Created on: Mon Mar 23 2020 14:56:46');
-      await contactsFrame.waitForContent('@container-pubkey-details', 'Expiration: Tue Mar 23 2021 14:56:46');
+      await contactsFrame.waitForContent('@container-pubkey-details', 'Created on: Mon Mar 23 2020');
+      await contactsFrame.waitForContent('@container-pubkey-details', 'Expiration: Tue Mar 23 2021');
       await contactsFrame.waitForContent('@container-pubkey-details', 'Expired: no');
       await contactsFrame.waitForContent('@container-pubkey-details', 'Usable for encryption: true');
       await contactsFrame.waitForContent('@container-pubkey-details', 'Usable for signing: true');


### PR DESCRIPTION
S/MIME certs couldn't be imported on contacts screen due to missing libraries and internal support to display the certs.

This change adds a test to catch this scenario, fixes the underlying code and adds missing libraries.

I've also improved the naming of `needle` as it took me some time to figure out why string was not found on the page when I see it's there :)

![2020-08-10T13:09:16,299609298+02:00](https://user-images.githubusercontent.com/1718963/89777345-cc7ba580-db0b-11ea-800e-6dd42ff86c9a.png)

As for #2732 this is now using `serialNumber` that is defined as:

```
hex encoded value of an ASN.1 INTEGER.
Conforming CAs should ensure serialNumber is:
  - no more than 20 octets
  - non-negative (prefix a '00' if your value starts with a '1' bit)
```

it looks like OpenPGP fingerprint and is displayed automatically in groups so I think this fixes #2732.