### PR TITLE
escape labelId parameter for HTML

### DIFF
--- a/extension/chrome/settings/inbox/inbox-modules/inbox-list-threads-module.ts
+++ b/extension/chrome/settings/inbox/inbox-modules/inbox-list-threads-module.ts
@@ -15,7 +15,7 @@ import { Xss } from '../../../../js/common/platform/xss.js';
 export class InboxListThreadsModule extends ViewModule<InboxView> {
 
   public render = async (labelId: string) => {
-    this.view.displayBlock('inbox', `Messages in ${Xss.htmlEscape(this.view.inboxMenuModule.getLabelName(labelId))}`);
+    this.view.displayBlock('inbox', `Messages in ${Xss.escape(this.view.inboxMenuModule.getLabelName(labelId))}`);
     try {
       const { threads } = await this.view.gmail.threadList(labelId);
       if (threads?.length) {

--- a/extension/chrome/settings/inbox/inbox-modules/inbox-list-threads-module.ts
+++ b/extension/chrome/settings/inbox/inbox-modules/inbox-list-threads-module.ts
@@ -15,7 +15,7 @@ import { Xss } from '../../../../js/common/platform/xss.js';
 export class InboxListThreadsModule extends ViewModule<InboxView> {
 
   public render = async (labelId: string) => {
-    this.view.displayBlock('inbox', `Messages in ${this.view.inboxMenuModule.getLabelName(labelId)}`);
+    this.view.displayBlock('inbox', `Messages in ${Xss.htmlEscape(this.view.inboxMenuModule.getLabelName(labelId))}`);
     try {
       const { threads } = await this.view.gmail.threadList(labelId);
       if (threads?.length) {

--- a/extension/js/common/platform/xss.ts
+++ b/extension/js/common/platform/xss.ts
@@ -37,6 +37,15 @@ export class Xss {
     return $(selector as any).replaceWith(Xss.htmlSanitize(dirtyHtml)); // xss-sanitized
   }
 
+  public static htmlEscape = (str: string) => {
+    return str.replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\//g, '&#x2F;');
+  }
+
   /**
    * Sanitize HTML to protect from nasty content from untrusted sources
    *

--- a/extension/js/common/platform/xss.ts
+++ b/extension/js/common/platform/xss.ts
@@ -37,15 +37,6 @@ export class Xss {
     return $(selector as any).replaceWith(Xss.htmlSanitize(dirtyHtml)); // xss-sanitized
   }
 
-  public static htmlEscape = (str: string) => {
-    return str.replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/\//g, '&#x2F;');
-  }
-
   /**
    * Sanitize HTML to protect from nasty content from untrusted sources
    *


### PR DESCRIPTION
Escapes HTML from the labelId parameter:

![Screenshot_2020-08-10_23-41-43](https://user-images.githubusercontent.com/44826516/89858311-f365c600-db63-11ea-86f5-083395a93e69.png)

I'll leave the issue open for similar problems (of which I suspect there might be a few).