### PR TITLE
Attempt to fix key without identities (User IDs)

### DIFF
--- a/extension/js/common/core/crypto/key.ts
+++ b/extension/js/common/core/crypto/key.ts
@@ -94,6 +94,10 @@ export class KeyUtil {
     return await OpenPGPKey.isWithoutSelfCertifications(key);
   }
 
+  public static isWithoutIdentities = async (key: Key) => {
+    return key.identities.length === 0;
+  }
+
   /**
    * Read many keys, could be armored or binary, in single armor or separately, useful for importing keychains of various formats
    */

--- a/extension/js/common/ui/key-import-ui.ts
+++ b/extension/js/common/ui/key-import-ui.ts
@@ -136,6 +136,9 @@ export class KeyImportUi {
     await this.decryptAndEncryptAsNeeded(decrypted, encrypted, passphrase);
     await this.checkEncryptionPrvIfSelected(decrypted, encrypted);
     await this.checkSigningIfSelected(decrypted);
+    if (await KeyUtil.isWithoutIdentities(encrypted)) {
+      throw new KeyCanBeFixed(encrypted);
+    }
     return { normalized, passphrase, fingerprint: decrypted.id, decrypted, encrypted }; // will have fp if had longid
   }
 


### PR DESCRIPTION
This is a draft PR.

I've tested it and it works given that the check in OpenPGP.js is manually removed. It correctly fixes (reformats) the key.

I'll add the test case (disabled until OpenPGP.js v5) here and then mark it as ready for review.