### PR TITLE
Autofocus recover input

### DIFF
--- a/extension/chrome/settings/setup/setup-render.ts
+++ b/extension/chrome/settings/setup/setup-render.ts
@@ -87,6 +87,7 @@ export class SetupRenderModule {
       $('.back').css('visibility', ['step_2b_manual_enter', 'step_2a_manual_create'].includes(name) ? 'visible' : 'hidden');
       if (name === 'step_2_recovery') {
         $('.backups_count_words').text(this.view.fetchedKeyBackupsUniqueLongids.length > 1 ? `${this.view.fetchedKeyBackupsUniqueLongids.length} backups` : 'a backup');
+        $('#step_2_recovery input').focus();
       }
     }
   }

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -147,6 +147,7 @@ span.gray { color: #b7b7b7; }
 }
 
 .swal2-popup.ui-modal-iframe .swal2-close { color: #666; }
+.swal2-popup.ui-modal-iframe .swal2-content { padding: 0; }
 .swal2-popup.ui-modal-iframe iframe { max-width: 100%; }
 .swal2-container.ui-modal-page { background: rgba(0, 0, 0, 0.6) !important; }
 

--- a/extension/css/settings.css
+++ b/extension/css/settings.css
@@ -799,3 +799,8 @@ body#settings .settings-border .key_list {
 .input_private_key {
   font-family: monospace;
 }
+
+/* https://github.com/sweetalert2/sweetalert2/issues/834#issuecomment-359237178 */
+.swal2-popup {
+  font-size: 1.6rem !important;
+}


### PR DESCRIPTION
Fixes #2535 

Only autofocus was missing, `Enter` hit was working as expected.

Also fixed SweetAlert2's font-size for Bootstrap 3 because after upgrading deps #2105 was undone. #2105 was my mistake, the lesson to myself: never edit deps commited to the repo.

![image](https://user-images.githubusercontent.com/6059356/91105056-c5aa7200-e677-11ea-9038-c5e6ba9eef62.png)
