### PR TITLE
Change #header-row's margin to padding so body won't have margins

### DIFF
--- a/extension/css/settings.css
+++ b/extension/css/settings.css
@@ -8,7 +8,7 @@ html {
   width: auto;
 }
 
-#header-row { margin-top: 20px; }
+#header-row { padding-top: 20px; }
 
 #header-row .logo-row img.cryptup-logo {
   height: auto;


### PR DESCRIPTION
Fixes #2922 

The horizontal jumpiness caused by body with top margin was bothering my eye, so I pushed this one-liner bypassing the queue.