### PR TITLE
Fix webmailNamePattern regex

### DIFF
--- a/extension/js/common/core/att.ts
+++ b/extension/js/common/core/att.ts
@@ -15,7 +15,7 @@ export type FcAttLinkData = { name: string, type: string, size: number };
 
 export class Att {
 
-  public static readonly webmailNamePattern = /^(((cryptup|flowcrypt)-backup-[a-z0-9]+\.(key|asc))|(.+\.pgp)|(.+\.gpg)|(.+\.asc)|(noname)|(message)|(PGPMIME version identification)|())$/gm;
+  public static readonly webmailNamePattern = /^(((cryptup|flowcrypt)-backup-[a-z0-9]+\.(key|asc))|(.+\.pgp)|(.+\.gpg)|(.+\.asc)|(noname)|(message)|(PGPMIME version identification)|())$/m;
   public static readonly encryptedMsgNames = ['message', 'msg.asc', 'message.asc', 'encrypted.asc', 'encrypted.eml.pgp', 'Message.pgp', 'openpgp-encrypted-message.asc'];
 
   public length: number = NaN;


### PR DESCRIPTION
Fix #2928 

I guess this is the smallest PR in this repo :)

My knowledge of regexes wasn't enough and I asked for the help from the community: https://stackoverflow.com/q/63928569

Fortunately, the help was prompt and TIL that the `RegExp` object keeps track of the `lastIndex` where a match occurred, so on subsequent matches it will start from the last used index, instead of `0`: https://stackoverflow.com/a/1520853