### PR TITLE
Add allow-downloads to attachment preview iframes

### DIFF
--- a/extension/chrome/elements/attachment_preview.htm
+++ b/extension/chrome/elements/attachment_preview.htm
@@ -12,7 +12,7 @@
 </head>
 
 <body id="attachment-preview">
-  <button id="attachment-preview-download" class="display_none">
+  <button id="attachment-preview-download" class="display_none" data-test="attachment-preview-download">
     <img src="/img/svgs/download-link-white.svg" alt="download attachment" width="28">
     DOWNLOAD
   </button>

--- a/extension/js/common/browser/ui.ts
+++ b/extension/js/common/browser/ui.ts
@@ -269,7 +269,7 @@ export class Ui {
           $(Swal.getContent()).attr('data-test', 'attachment-dialog');
           $(Swal.getCloseButton()).attr('data-test', 'dialog-close');
         },
-        html: `<iframe src="${Xss.escape(iframeUrl)}" style="border: 0" sandbox="allow-scripts allow-same-origin"></iframe>`,
+        html: `<iframe src="${Xss.escape(iframeUrl)}" style="border: 0" sandbox="allow-scripts allow-same-origin allow-downloads"></iframe>`,
         showConfirmButton: false,
         showCloseButton: true,
         grow: 'fullscreen',

--- a/test/source/tests/tests/settings.ts
+++ b/test/source/tests/tests/settings.ts
@@ -1,6 +1,8 @@
 /* ©️ 2016 - present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com */
 
+import * as fs from 'fs';
 import * as ava from 'ava';
+import { Page } from 'puppeteer';
 
 import { Config, Util } from '../../util';
 import { TestWithBrowser, internalTestState } from '../../test';
@@ -176,6 +178,11 @@ export let defineSettingsTests = (testVariant: TestVariant, testWithBrowser: Tes
       await pgpBlockFrame.waitAndClick('.preview-attachment');
       const attachmentPreviewImage = await inboxPage.getFrame(['attachment_preview.htm']);
       await attachmentPreviewImage.waitAll('#attachment-preview-container img.attachment-preview-img');
+      // @ts-ignore
+      await (inboxPage.target as Page)._client.send('Page.setDownloadBehavior', { behavior: 'allow', downloadPath: __dirname });
+      await attachmentPreviewImage.waitAndClick('@attachment-preview-download');
+      await Util.sleep(1);
+      expect(fs.existsSync(`${__dirname}/7 years.jpeg`)).to.be.true;
     }));
 
     ava.todo('settings - change passphrase - mismatch curent pp');

--- a/test/source/tests/tests/settings.ts
+++ b/test/source/tests/tests/settings.ts
@@ -170,6 +170,8 @@ export let defineSettingsTests = (testVariant: TestVariant, testWithBrowser: Tes
     }));
 
     ava.default('settings - pgp/mime preview and download attachment', testWithBrowser('compatibility', async (t, browser) => {
+      const downloadedAttachmentFilename = `${__dirname}/7 years.jpeg`;
+      fs.unlink(downloadedAttachmentFilename, () => { });
       const inboxPage = await browser.newPage(t, TestUrls.extension(`chrome/settings/inbox/inbox.htm?acctEmail=flowcrypt.compatibility@gmail.com&threadId=16e8b01f136c3d28`));
       const pgpBlockFrame = await inboxPage.getFrame(['pgp_block.htm']);
       // check if download is awailable
@@ -182,7 +184,8 @@ export let defineSettingsTests = (testVariant: TestVariant, testWithBrowser: Tes
       await (inboxPage.target as Page)._client.send('Page.setDownloadBehavior', { behavior: 'allow', downloadPath: __dirname });
       await attachmentPreviewImage.waitAndClick('@attachment-preview-download');
       await Util.sleep(1);
-      expect(fs.existsSync(`${__dirname}/7 years.jpeg`)).to.be.true; // tslint:disable-line:no-unused-expression
+      expect(fs.existsSync(downloadedAttachmentFilename)).to.be.true; // tslint:disable-line:no-unused-expression
+      fs.unlink(downloadedAttachmentFilename, () => { });
     }));
 
     ava.todo('settings - change passphrase - mismatch curent pp');

--- a/test/source/tests/tests/settings.ts
+++ b/test/source/tests/tests/settings.ts
@@ -182,7 +182,7 @@ export let defineSettingsTests = (testVariant: TestVariant, testWithBrowser: Tes
       await (inboxPage.target as Page)._client.send('Page.setDownloadBehavior', { behavior: 'allow', downloadPath: __dirname });
       await attachmentPreviewImage.waitAndClick('@attachment-preview-download');
       await Util.sleep(1);
-      expect(fs.existsSync(`${__dirname}/7 years.jpeg`)).to.be.true;
+      expect(fs.existsSync(`${__dirname}/7 years.jpeg`)).to.be.true; // tslint:disable-line:no-unused-expression
     }));
 
     ava.todo('settings - change passphrase - mismatch curent pp');

--- a/test/source/tests/tests/settings.ts
+++ b/test/source/tests/tests/settings.ts
@@ -171,7 +171,7 @@ export let defineSettingsTests = (testVariant: TestVariant, testWithBrowser: Tes
 
     ava.default('settings - pgp/mime preview and download attachment', testWithBrowser('compatibility', async (t, browser) => {
       const downloadedAttachmentFilename = `${__dirname}/7 years.jpeg`;
-      fs.unlink(downloadedAttachmentFilename, () => { });
+      Util.deleteFileIfExists(downloadedAttachmentFilename);
       const inboxPage = await browser.newPage(t, TestUrls.extension(`chrome/settings/inbox/inbox.htm?acctEmail=flowcrypt.compatibility@gmail.com&threadId=16e8b01f136c3d28`));
       const pgpBlockFrame = await inboxPage.getFrame(['pgp_block.htm']);
       // check if download is awailable
@@ -185,7 +185,7 @@ export let defineSettingsTests = (testVariant: TestVariant, testWithBrowser: Tes
       await attachmentPreviewImage.waitAndClick('@attachment-preview-download');
       await Util.sleep(1);
       expect(fs.existsSync(downloadedAttachmentFilename)).to.be.true; // tslint:disable-line:no-unused-expression
-      fs.unlink(downloadedAttachmentFilename, () => { });
+      Util.deleteFileIfExists(downloadedAttachmentFilename);
     }));
 
     ava.todo('settings - change passphrase - mismatch curent pp');

--- a/test/source/util/index.ts
+++ b/test/source/util/index.ts
@@ -99,7 +99,11 @@ export class Util {
   }
 
   public static deleteFileIfExists = (filename: string) => {
-    fs.unlinkSync(filename);
+    try {
+      fs.unlinkSync(filename);
+    } catch(e) {
+      // file didn't exist
+    }
   }
 
 }

--- a/test/source/util/index.ts
+++ b/test/source/util/index.ts
@@ -98,4 +98,8 @@ export class Util {
     return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\//g, '&#x2F;');
   }
 
+  public static deleteFileIfExists = (filename: string) => {
+    fs.unlink(filename, () => { }); // tslint:disable-line:no-empty-interface
+  }
+
 }

--- a/test/source/util/index.ts
+++ b/test/source/util/index.ts
@@ -99,7 +99,7 @@ export class Util {
   }
 
   public static deleteFileIfExists = (filename: string) => {
-    fs.unlink(filename, () => { }); // tslint:disable-line:no-empty-interface
+    fs.unlink(filename, () => { }); // tslint:disable-line:no-empty
   }
 
 }

--- a/test/source/util/index.ts
+++ b/test/source/util/index.ts
@@ -99,7 +99,7 @@ export class Util {
   }
 
   public static deleteFileIfExists = (filename: string) => {
-    fs.unlink(filename, () => { }); // tslint:disable-line:no-empty
+    fs.unlinkSync(filename);
   }
 
 }


### PR DESCRIPTION
Fixes #2950 

Google Chrome 83 began to disallow iframes from downloading unless the `allow-downloads` key is added to an iframe’s `sandbox` attributes: https://www.chromestatus.com/feature/5706745674465280