### PR TITLE
quick fix for signed unencrypted attachments bug

### DIFF
--- a/extension/chrome/elements/attachment_preview.ts
+++ b/extension/chrome/elements/attachment_preview.ts
@@ -27,7 +27,7 @@ View.run(class AttachmentPreviewView extends AttachmentDownloadView {
       Xss.sanitizeRender(this.attachmentPreviewContainer, `${Ui.spinner('green', 'large_spinner')}<span class="download_progress"></span>`);
       this.att = new Att({ name: this.origNameBasedOnFilename, type: this.type, msgId: this.msgId, id: this.id, url: this.url });
       await this.downloadDataIfNeeded();
-      const result = this.isEncrypted ? await this.decrypt() : this.att.getData();
+      const result = (this.isEncrypted && this.type === "application/octet-stream")? await this.decrypt() : this.att.getData();
       if (result) {
         const blob = new Blob([result], { type: this.type });
         const url = window.URL.createObjectURL(blob);


### PR DESCRIPTION
This is a quick fix for https://github.com/FlowCrypt/flowcrypt-browser/issues/2834.

The first time you open an email with a signed, unencrypted attachment the extension thinks it is encrypted. I tested this with a quick console log, and the property `this.isEncrypted` is true in attachment_preview.ts, even though the attachment is *not* encrypted. However, if you refresh the page or return to the email after already having opened it, everything works fine. The email preview works normally. Firefox does not have this problem, only Chrome.

In this PR I've added a quick fix using the attachment's media type, because encrypted attachments always have a media type of `application/octet-stream`. This fixes the vast majority of cases, but the original bug would resurface were a user to send an attachment that actually does have a media type of `application/octet-stream`. 

While this fix is imperfect and the original source of the bug is still unknown to me, this fix should cover most practical cases in the meantime.