### PR TITLE
Fix retry attachment download

### DIFF
--- a/extension/chrome/elements/attachment.ts
+++ b/extension/chrome/elements/attachment.ts
@@ -95,7 +95,7 @@ export class AttachmentDownloadView extends View {
       this.downloadButton.click(this.setHandlerPrevent('double', () => this.downloadButtonClickedHandler()));
       this.downloadButton.click((e) => e.stopPropagation());
       $('body').click(this.setHandlerPrevent('double', async () => {
-        if ($('body').attr('id') !== 'attachment-preview') {
+        if ($('body').attr('id') !== 'attachment-preview' && !$('body').hasClass('download-error')) {
           await this.previewAttachmentClickedHandler();
         }
       }));
@@ -185,6 +185,7 @@ export class AttachmentDownloadView extends View {
       Catch.reportErr(e);
       Xss.sanitizeRender('body.attachment', `Error downloading file - ${String(e)}. ${Ui.retryLink()}`);
     }
+    $('body.attachment').addClass('download-error').attr('title', '');
   }
 
   private processAsPublicKeyAndHideAttIfAppropriate = async () => {

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -2329,6 +2329,16 @@ body.attachment {
 }
 body.attachment:hover { border-color: #eaeaea; }
 
+body.attachment.download-error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  font-size: 14px;
+  padding: 10px;
+  box-sizing: border-box;
+}
+
 body.attachment #download {
   display: flex;
   opacity: 0;


### PR DESCRIPTION
Fixes #2989 

Also, improved styles a bit:

![image](https://user-images.githubusercontent.com/6059356/94988129-bb7f6b80-0573-11eb-8679-a91262785a2c.png)

@tomholub do we need a test for this fix? I was trying to add one, but for adding a test there should be some kind of going offline possibility in `GoogleData`. What do you think?