### PR TITLE
Update openpgp-key.ts due to typo

### DIFF
--- a/extension/js/common/core/crypto/pgp/openpgp-key.ts
+++ b/extension/js/common/core/crypto/pgp/openpgp-key.ts
@@ -455,7 +455,7 @@ export class OpenPGPKey {
     const output: string[] = [];
     try {
       if (!key.isFullyDecrypted()) {
-        return 'skiped, not fully decrypted';
+        return 'skipped, not fully decrypted';
       }
       const signedMessage = await opgp.message.fromText(OpenPGPKey.encryptionText).sign([key]);
       output.push('sign msg ok');


### PR DESCRIPTION
Typo!

'skiped' should be 'skipped'

This is done because otherwise, the form vowel + consonant + e causes the vowel to take the long form (eg the words Skype, hope, or dine). Consider the word hop. To prevent it's past simple from being 'hoped' (which would be pronounced with the long o and means something else), it becomes hopped.

Interesting to me how these things kind of have rules, but also kind of don't!