### PR TITLE
Remove url email reflection that causes html injection vulnerability

### DIFF
--- a/extension/js/common/org-rules.ts
+++ b/extension/js/common/org-rules.ts
@@ -30,7 +30,7 @@ export class OrgRules {
   public static newInstance = async (acctEmail: string): Promise<OrgRules> => {
     const email = Str.parseEmail(acctEmail).email;
     if (!email) {
-      throw new Error(`Not a valid email:${acctEmail}`);
+      throw new Error(`Not a valid email`);
     }
     const storage = await AcctStore.get(email, ['rules']);
     return new OrgRules(storage.rules || OrgRules.default, acctEmail.split('@')[1]);


### PR DESCRIPTION
Just removes the reflected input entirely (simple solution). I tested this on Chrome, here's what it looks like:

![Screenshot from 2020-10-24 01-16-41](https://user-images.githubusercontent.com/44826516/97070614-f97e1700-1596-11eb-904e-a4d4958ab557.png)

Fixes https://github.com/FlowCrypt/flowcrypt-security/issues/63