### PR TITLE
Improve #input_from styles, add custom outline to it and #cc/#bcc buttons

### DIFF
--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -1560,7 +1560,7 @@ table#compose td.recipients-inputs > div#input_addresses_container div .recipien
 table#compose td.recipients-inputs > div#input_addresses_container div span.container-cc-bcc-buttons {
   position: absolute;
   right: 8px;
-  bottom: 8px;
+  bottom: 6px;
   white-space: nowrap;
   color: #636c72;
 }
@@ -1571,6 +1571,13 @@ table#compose td.recipients-inputs > div#input_addresses_container div span.cont
   background: none;
   cursor: pointer;
   border: 0;
+  height: 24px;
+  outline: none;
+  box-shadow: 0 0 0 3px transparent;
+}
+
+table#compose td.recipients-inputs > div#input_addresses_container div span.container-cc-bcc-buttons button:focus {
+  box-shadow: 0 0 0 3px rgba(49, 162, 23, 0.4);
 }
 
 table#compose td.recipients-inputs > div#input_addresses_container div span.container-cc-bcc-buttons img {
@@ -1654,13 +1661,22 @@ table#compose td input {
 table#compose td.input.show_send_from select#input_from {
   border: none;
   background: none;
-  margin: -3px 4px 9px 4px;
+  height: 24px;
+  margin: 0 3px 3px;
+  padding: 0 3px;
   font-size: 1em;
   cursor: pointer;
   width: -moz-available;
   width: -webkit-fill-available;
   -moz-appearance: none;
+  outline: none;
+  box-shadow: 0 0 0 3px transparent;
 }
+
+table#compose td.input.show_send_from select#input_from:focus {
+  box-shadow: 0 0 0 3px rgba(49, 162, 23, 0.4);
+}
+
 .reply_box table#compose td.input.show_send_from select#input_from { margin-right: 4px; }
 
 table#compose td.input.show_send_from #input_from_settings {


### PR DESCRIPTION
Fixes #3037

Also, added custom outlines as native outline were missing in Firefox for some reason:

![0fix5BmFFA](https://user-images.githubusercontent.com/6059356/98161631-bbfb8100-1ee8-11eb-8d3f-efc52bc4c264.gif)

Also, increased the height of `#cc` and `#bcc` buttons to `24px` so it won't be too small (prev height was `17px`)