### PR TITLE
Add additional directives to CSP

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -92,5 +92,5 @@
     "/chrome/elements/shared/footer.htm"
   ],
   "minimum_chrome_version": "61",
-  "content_security_policy": "upgrade-insecure-requests; script-src 'self'; frame-ancestors https://mail.google.com 'self';"
+  "content_security_policy": "upgrade-insecure-requests; script-src 'self'; frame-ancestors https://mail.google.com 'self'; form-action 'none'; media-src 'none'; font-src 'none'; manifest-src 'none'; worker-src 'none';"
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -92,5 +92,5 @@
     "/chrome/elements/shared/footer.htm"
   ],
   "minimum_chrome_version": "61",
-  "content_security_policy": "upgrade-insecure-requests; script-src 'self'; frame-ancestors https://mail.google.com 'self'; form-action 'none'; media-src 'none'; font-src 'none'; manifest-src 'none'; worker-src 'self';"
+  "content_security_policy": "upgrade-insecure-requests; script-src 'self'; frame-ancestors https://mail.google.com 'self'; form-action 'none'; media-src 'none'; font-src 'none'; manifest-src 'none'; worker-src 'self'; object-src 'self';"
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -92,5 +92,5 @@
     "/chrome/elements/shared/footer.htm"
   ],
   "minimum_chrome_version": "61",
-  "content_security_policy": "upgrade-insecure-requests; script-src 'self'; frame-ancestors https://mail.google.com 'self'; form-action 'none'; media-src 'none'; font-src 'none'; manifest-src 'none'; worker-src 'none';"
+  "content_security_policy": "upgrade-insecure-requests; script-src 'self'; frame-ancestors https://mail.google.com 'self'; form-action 'none'; media-src 'none'; font-src 'none'; manifest-src 'none'; worker-src 'self';"
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -92,5 +92,5 @@
     "/chrome/elements/shared/footer.htm"
   ],
   "minimum_chrome_version": "61",
-  "content_security_policy": "upgrade-insecure-requests; script-src 'self'; frame-ancestors https://mail.google.com 'self'; form-action 'none'; media-src 'none'; font-src 'none'; manifest-src 'none'; worker-src 'self'; object-src 'self';"
+  "content_security_policy": "upgrade-insecure-requests; script-src 'self'; frame-ancestors https://mail.google.com 'self'; form-action 'none'; media-src 'none'; font-src 'none'; manifest-src 'none'; object-src 'none';"
 }


### PR DESCRIPTION
Adds the following directives:

    font-src (none)
    manifest-src (none/self)
    media-src (none)
    worker-src (self)
    form-action (none)

I left out `style-src` because we have a bunch of inline styles. Ideally, we should move that code to .css files and then add `style-src 'self'`. But for now I just wanted to include directives that don't break anything.