### PR TITLE
Use non-numeric enum for RecipientStatus

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-pwd-or-pubkey-container-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-pwd-or-pubkey-container-module.ts
@@ -3,7 +3,7 @@
 'use strict';
 
 
-import { RecipientStatuses, SendBtnTexts } from './compose-types.js';
+import { RecipientStatus, SendBtnTexts } from './compose-types.js';
 import { KeyImportUi } from '../../../js/common/ui/key-import-ui.js';
 import { Catch } from '../../../js/common/platform/catch.js';
 import { Str } from '../../../js/common/core/common.js';
@@ -59,9 +59,9 @@ export class ComposePwdOrPubkeyContainerModule extends ViewModule<ComposeView> {
     if (!this.view.recipientsModule.getRecipients().length || !this.view.sendBtnModule.popover.choices.encrypt) {
       this.hideMsgPwdUi(); // Hide 'Add Pasword' prompt if there are no recipients or message is not encrypted
       this.view.sendBtnModule.enableBtn();
-    } else if (this.view.recipientsModule.getRecipients().find(r => r.status === RecipientStatuses.NO_PGP)) {
+    } else if (this.view.recipientsModule.getRecipients().find(r => r.status === RecipientStatus.NO_PGP)) {
       this.showMsgPwdUiAndColorBtn().catch(Catch.reportErr);
-    } else if (this.view.recipientsModule.getRecipients().find(r => [RecipientStatuses.FAILED, RecipientStatuses.WRONG].includes(r.status))) {
+    } else if (this.view.recipientsModule.getRecipients().find(r => [RecipientStatus.FAILED, RecipientStatus.WRONG].includes(r.status))) {
       this.view.S.now('send_btn_text').text(SendBtnTexts.BTN_WRONG_ENTRY);
       this.view.S.cached('send_btn').attr('title', 'Notice the recipients marked in red: please remove them and try to enter them egain.');
       this.view.sendBtnModule.disableBtn();

--- a/extension/chrome/elements/compose-modules/compose-types.ts
+++ b/extension/chrome/elements/compose-modules/compose-types.ts
@@ -6,15 +6,13 @@ import { RecipientType } from '../../../js/common/api/shared/api.js';
 import { Recipients } from '../../../js/common/api/email-provider/email-provider-api.js';
 import { PubkeyResult } from '../../../js/common/core/crypto/key.js';
 
-export type RecipientStatus = 0 | 1 | 2 | 3 | 4 | 5;
-
-export class RecipientStatuses {
-  public static EVALUATING: RecipientStatus = 0;
-  public static HAS_PGP: RecipientStatus = 1;
-  public static NO_PGP: RecipientStatus = 2;
-  public static EXPIRED: RecipientStatus = 3;
-  public static WRONG: RecipientStatus = 4;
-  public static FAILED: RecipientStatus = 5;
+export enum RecipientStatus {
+  EVALUATING,
+  HAS_PGP,
+  NO_PGP,
+  EXPIRED,
+  WRONG,
+  FAILED
 }
 
 export interface RecipientElement {

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -1451,6 +1451,12 @@ table#compose.not-encrypted td.input .collapsed .email_preview .email_address {
 }
 table#compose td.recipients-inputs { vertical-align: middle; }
 
+table#compose td.recipients-inputs .small_spinner,
+table#compose td.recipients-inputs .small_spinner img {
+  width: 16px;
+  height: 16px;
+}
+
 table#compose td.recipients-inputs > div#input_addresses_container.invisible {
   height: 0;
   overflow: hidden;


### PR DESCRIPTION
Closes #2785

Also, fixed the spinner size inside of `.recipients-inputs`, it was too big and produced jumpiness:

![Y6SgK1zvqh](https://user-images.githubusercontent.com/6059356/98593637-1c6d3280-22dc-11eb-8d08-29b389a27d06.gif)
