### PR TITLE
Fix ctrl+enter for chrome on windows

### DIFF
--- a/extension/js/common/browser/ui.ts
+++ b/extension/js/common/browser/ui.ts
@@ -385,7 +385,10 @@ export class Ui {
 
   public static ctrlEnter = (callback: () => void) => {
     return (e: JQuery.Event<HTMLElement, null>) => { // returns a function
-      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+      if (
+        (e.metaKey || e.ctrlKey) &&
+        (e.key === 'Enter' || e.keyCode === 10) // https://bugs.chromium.org/p/chromium/issues/detail?id=79407
+      ) {
         callback();
       }
     };


### PR DESCRIPTION
Fixes #3151 

https://bugs.chromium.org/p/chromium/issues/detail?id=79407

> the keyCode is 10 instead of 13. a normal enter reports 13, like other browsers, only ctrl+enter is broken, and **only on windows**.
