### PR TITLE
Fix rendering rich-text encrypted message right after sending it

### DIFF
--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -334,7 +334,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
                 nRenderedAtts++;
               }
             } else {
-              msgEl = this.updateMsgBodyEl_DANGEROUSLY(msgEl, 'append', this.factory.embeddedMsg('encryptedMsg', '', msgId, false, senderEmail)); // xss-safe-factory
+              msgEl = this.updateMsgBodyEl_DANGEROUSLY(msgEl, 'set', this.factory.embeddedMsg('encryptedMsg', '', msgId, false, senderEmail)); // xss-safe-factory
             }
           } else if (treatAs === 'publicKey') { // todo - pubkey should be fetched in pgp_pubkey.js
             nRenderedAtts = await this.renderPublicKeyFromFile(a, attsContainerInner, msgEl, isOutgoing, attSel, nRenderedAtts);

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -121,14 +121,14 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
     ava.default('mail.google.com - send rich-text encrypted message', testWithBrowser('ci.tests.gmail', async (t, browser) => {
       const gmailPage = await BrowserRecipe.openGmailPageAndVerifyComposeBtnPresent(t, browser);
       const composePage = await GmailPageRecipe.openSecureCompose(t, gmailPage, browser);
-      await ComposePageRecipe.fillMsg(composePage, { to: 'ci.tests.gmail@flowcrypt.dev' }, 'New Rich Text Message', { richtext: true });
+      const subject = `New Rich Text Message ${Util.lousyRandom()}`;
+      await ComposePageRecipe.fillMsg(composePage, { to: 'ci.tests.gmail@flowcrypt.dev' }, subject, { richtext: true });
       await ComposePageRecipe.sendAndClose(composePage);
       await gmailPage.waitAndClick('[aria-label^="Inbox"]');
       await gmailPage.waitAndClick('[role="row"]'); // click the first message
-      const emailWrapper = await gmailPage.waitAny('.nH.if');
-      expect(await emailWrapper.$eval('h2', el => el.innerHTML)).to.eq('Automated puppeteer test: New Rich Text Message');
+      await gmailPage.waitForContent('.nH.if h2', `Automated puppeteer test: ${subject}`);
       const urls = await gmailPage.getFramesUrls(['/chrome/elements/pgp_block.htm'], { sleep: 1 });
-      // await gmailPage.waitAndClick('[aria-label^="Delete"]');
+      await GmailPageRecipe.deleteMessage(gmailPage);
       expect(urls.length).to.eq(1);
     }));
 

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -118,7 +118,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       await gmailPage.notPresent(['@webmail-notification', '@notification-setup-action-open-settings', '@notification-setup-action-dismiss', '@notification-setup-action-close']);
     }));
 
-    ava.default.only('mail.google.com - send rich-text encrypted message', testWithBrowser('ci.tests.gmail', async (t, browser) => {
+    ava.default('mail.google.com - send rich-text encrypted message', testWithBrowser('ci.tests.gmail', async (t, browser) => {
       const gmailPage = await BrowserRecipe.openGmailPageAndVerifyComposeBtnPresent(t, browser);
       const composePage = await GmailPageRecipe.openSecureCompose(t, gmailPage, browser);
       await ComposePageRecipe.fillMsg(composePage, { to: 'ci.tests.gmail@flowcrypt.dev' }, 'New Rich Text Message', { richtext: true });

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -128,8 +128,8 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       const emailWrapper = await gmailPage.waitAny('.nH.if');
       expect(await emailWrapper.$eval('h2', el => el.innerHTML)).to.eq('Automated puppeteer test: New Rich Text Message');
       const urls = await gmailPage.getFramesUrls(['/chrome/elements/pgp_block.htm'], { sleep: 1 });
+      await gmailPage.waitAndClick('[aria-label^="Delete"]');
       expect(urls.length).to.eq(1);
-      await gmailPage.waitAndClick('[aria-label="Delete"]');
     }));
 
     ava.default('mail.google.com - decrypt message in offline mode', testWithBrowser('ci.tests.gmail', async (t, browser) => {

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -128,7 +128,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       const emailWrapper = await gmailPage.waitAny('.nH.if');
       expect(await emailWrapper.$eval('h2', el => el.innerHTML)).to.eq('Automated puppeteer test: New Rich Text Message');
       const urls = await gmailPage.getFramesUrls(['/chrome/elements/pgp_block.htm'], { sleep: 1 });
-      await gmailPage.waitAndClick('[aria-label^="Delete"]');
+      // await gmailPage.waitAndClick('[aria-label^="Delete"]');
       expect(urls.length).to.eq(1);
     }));
 

--- a/test/source/tests/page-recipe/gmail-page-recipe.ts
+++ b/test/source/tests/page-recipe/gmail-page-recipe.ts
@@ -13,7 +13,7 @@ export class GmailPageRecipe extends PageRecipe {
     await gmailPage.waitAll('@container-new-message');
     const urls = await gmailPage.getFramesUrls(['/chrome/elements/compose.htm'], { sleep: 1 });
     expect(urls.length).to.equal(1);
-    return await browser.newPage(t, urls[0]);
+    return await browser.newPage(t, `${urls[0]}&debug=___cu_true___`);
   }
 
   public static getSubscribeDialog = async (t: AvaContext, gmailPage: ControllablePage, browser: BrowserHandle): Promise<ControllablePage> => {

--- a/test/source/tests/page-recipe/gmail-page-recipe.ts
+++ b/test/source/tests/page-recipe/gmail-page-recipe.ts
@@ -27,4 +27,14 @@ export class GmailPageRecipe extends PageRecipe {
     await gmailPage.waitAndClick('@notification-successfully-setup-action-close');
   }
 
+  public static deleteMessage = async (gmailPage: ControllablePage) => {
+    // the toolbar needs to be focused in order for Delete button to work
+    gmailPage.page.keyboard.down('Shift');
+    for (let i = 0; i < 5; i++) {
+      gmailPage.press('Tab');
+    }
+    gmailPage.page.keyboard.up('Shift');
+    await gmailPage.waitAndClick('[aria-label="Delete"]');
+  }
+
 }

--- a/test/source/tests/page-recipe/gmail-page-recipe.ts
+++ b/test/source/tests/page-recipe/gmail-page-recipe.ts
@@ -29,11 +29,11 @@ export class GmailPageRecipe extends PageRecipe {
 
   public static deleteMessage = async (gmailPage: ControllablePage) => {
     // the toolbar needs to be focused in order for Delete button to work
-    gmailPage.page.keyboard.down('Shift');
+    await gmailPage.page.keyboard.down('Shift');
     for (let i = 0; i < 5; i++) {
-      gmailPage.press('Tab');
+      await gmailPage.press('Tab');
     }
-    gmailPage.page.keyboard.up('Shift');
+    await gmailPage.page.keyboard.up('Shift');
     await gmailPage.waitAndClick('[aria-label="Delete"]');
   }
 


### PR DESCRIPTION
Fixes #3180 

For some reason Gmail removes `msgBody` from [here](https://github.com/FlowCrypt/flowcrypt-browser/blob/88300b146314c791f610d7d84b4d4798eca3c2d2/extension/js/content_scripts/webmail/gmail-element-replacer.ts#L486) right after we render secured message. By using `updateMsgBodyEl_DANGEROUSLY(el, 'set')`, `msgBody` is being replaced and therefore Gmail won't remove it.