### PR TITLE
Set max-width: 100% for inline images in rich-text messages

### DIFF
--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -1873,6 +1873,10 @@ table#compose td.text div#input_text {
   min-height: 140px;
 }
 
+table#compose td.text div#input_text img {
+  max-width: 100%;
+}
+
 table#compose td.text div.text_container {
   display: flex;
   flex-direction: column;

--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -282,14 +282,13 @@ div.reply_message_iframe_container.inserted {
 body.cryptup_gmail div.recipients_use_encryption {
   min-height: 0;
   background-color: #f5f5f5;
-  padding-left: 10px;
-  padding-top: 4px;
-  padding-bottom: 4px;
+  margin: 0 -20px;
+  padding: 4px 20px;
 }
 
 body.cryptup_gmail div.recipients_use_encryption a {
   position: absolute;
-  right: 8px;
+  right: 20px;
 }
 
 /* cryptup dialog */


### PR DESCRIPTION
Fixes #3267

---

Also, improved styles for `div.recipients_use_encryption`, it looked a bit broken for narrow (<1200px) screens:

Before:

![image](https://user-images.githubusercontent.com/6059356/102933520-0d68cb00-44ab-11eb-8364-38f6bd73f331.png)

After: 

![image](https://user-images.githubusercontent.com/6059356/102933452-f033fc80-44aa-11eb-90aa-eb6b36b67e3c.png)
