### PR TITLE
Add toast message for dropped pubkeys

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -163,7 +163,7 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
         } else {
           Catch.reportErr(e);
           this.view.S.cached('send_btn_note').text('Not saved (error)');
-          await Ui.toast(`Draft not saved: ${e}`, 5);
+          Ui.toast(`Draft not saved: ${e}`, 5);
         }
       }
       this.currentlySavingDraft = false;

--- a/extension/chrome/elements/compose-modules/compose-my-pubkey-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-my-pubkey-module.ts
@@ -23,7 +23,7 @@ export class ComposeMyPubkeyModule extends ViewModule<ComposeView> {
   public iconPubkeyClickHandler = (target: HTMLElement) => {
     this.toggledManually = true;
     const includePub = !$(target).is('.active'); // evaluating what the state of the icon was BEFORE clicking
-    Ui.toast(`${includePub ? 'Attaching' : 'Removing'} your Public Key`).catch(Catch.reportErr);
+    Ui.toast(`${includePub ? 'Attaching' : 'Removing'} your Public Key`);
     this.setAttachPreference(includePub);
   }
 

--- a/extension/chrome/elements/compose-modules/compose-my-pubkey-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-my-pubkey-module.ts
@@ -3,7 +3,6 @@
 'use strict';
 
 import { ApiErr } from '../../../js/common/api/shared/api-error.js';
-import { Catch } from '../../../js/common/platform/catch.js';
 import { KeyInfo } from '../../../js/common/core/crypto/key.js';
 import { Lang } from '../../../js/common/lang.js';
 import { Ui } from '../../../js/common/browser/ui.js';

--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -540,7 +540,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
         });
       }
     } catch (e) {
-      Ui.toast(`Error searching contacts: ${ApiErr.eli5(e)}`, 5).catch(Catch.reportErr);
+      Ui.toast(`Error searching contacts: ${ApiErr.eli5(e)}`, 5);
       throw e;
     } finally {
       this.view.errModule.debug('searchContacts 7 - finishing');
@@ -555,12 +555,12 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
       if (ApiErr.isAuthErr(e)) {
         BrowserMsg.send.notificationShowAuthPopupNeeded(this.view.parentTabId, { acctEmail: this.view.acctEmail });
       } else if (ApiErr.isNetErr(e)) {
-        Ui.toast(`Network error - cannot search contacts`).catch(Catch.reportErr);
+        Ui.toast(`Network error - cannot search contacts`);
       } else if (ApiErr.isMailOrAcctDisabledOrPolicy(e)) {
-        Ui.toast(`Cannot search contacts - account disabled or forbidden by admin policy`).catch(Catch.reportErr);
+        Ui.toast(`Cannot search contacts - account disabled or forbidden by admin policy`);
       } else {
         Catch.reportErr(e);
-        Ui.toast(`Error searching contacts: ${ApiErr.eli5(e)}`).catch(Catch.reportErr);
+        Ui.toast(`Error searching contacts: ${ApiErr.eli5(e)}`);
       }
     });
     this.view.errModule.debug('guessContactsFromSentEmails end');

--- a/extension/chrome/elements/compose-modules/compose-storage-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-storage-module.ts
@@ -16,8 +16,8 @@ import { AcctStore } from '../../../js/common/platform/store/acct-store.js';
 import { GlobalStore } from '../../../js/common/platform/store/global-store.js';
 import { ContactStore } from '../../../js/common/platform/store/contact-store.js';
 import { PassphraseStore } from '../../../js/common/platform/store/passphrase-store.js';
-
 import { Settings } from '../../../js/common/settings.js';
+import { Ui } from '../../../js/common/browser/ui.js';
 
 export class ComposeStorageModule extends ViewModule<ComposeView> {
 
@@ -124,6 +124,7 @@ export class ComposeStorageModule extends ViewModule<ComposeView> {
           const key = await KeyUtil.parse(lookupResult.pubkey);
           if (!key.usableForEncryption && !KeyUtil.expired(key)) { // Not to skip expired keys
             console.info('Dropping found+parsed key because getEncryptionKeyPacket===null', { for: email, fingerprint: key.id });
+            Ui.toast(`Public Key retrieved for email ${email} with id ${key.id} was ignored because it's not usable for encryption.`, 5);
             lookupResult.pubkey = null; // tslint:disable-line:no-null-keyword
           }
         }

--- a/extension/chrome/elements/compose-modules/compose-storage-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-storage-module.ts
@@ -124,6 +124,7 @@ export class ComposeStorageModule extends ViewModule<ComposeView> {
           const key = await KeyUtil.parse(lookupResult.pubkey);
           if (!key.usableForEncryption && !KeyUtil.expired(key)) { // Not to skip expired keys
             console.info('Dropping found+parsed key because getEncryptionKeyPacket===null', { for: email, fingerprint: key.id });
+            // tslint:disable-next-line:no-floating-promises
             Ui.toast(`Public Key retrieved for email ${email} with id ${key.id} was ignored because it's not usable for encryption.`, 5);
             lookupResult.pubkey = null; // tslint:disable-line:no-null-keyword
           }

--- a/extension/chrome/elements/compose-modules/compose-storage-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-storage-module.ts
@@ -124,7 +124,6 @@ export class ComposeStorageModule extends ViewModule<ComposeView> {
           const key = await KeyUtil.parse(lookupResult.pubkey);
           if (!key.usableForEncryption && !KeyUtil.expired(key)) { // Not to skip expired keys
             console.info('Dropping found+parsed key because getEncryptionKeyPacket===null', { for: email, fingerprint: key.id });
-            // tslint:disable-next-line:no-floating-promises
             Ui.toast(`Public Key retrieved for email ${email} with id ${key.id} was ignored because it's not usable for encryption.`, 5);
             lookupResult.pubkey = null; // tslint:disable-line:no-null-keyword
           }

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -143,7 +143,13 @@ span.gray { color: #b7b7b7; }
   background-color: #000;
   opacity: 0.8;
 }
-.swal2-title.ui-toast-title { color: #fff; }
+
+.swal2-popup.swal2-toast .swal2-title.ui-toast-title {
+  color: #fff;
+  margin: 0 0.6em 0.3em;
+}
+
+.swal2-popup.swal2-toast.ui-toast .swal2-timer-progress-bar { background: rgba(255, 255, 255, 0.5); }
 
 .swal2-popup.ui-modal-iframe {
   padding: 0;

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -134,6 +134,10 @@ span.gray { color: #b7b7b7; }
   color: white;
 }
 
+.swal2-container.ui-toast-container {
+  width: 77%;
+}
+
 .swal2-popup.swal2-toast.ui-toast {
   margin-bottom: 50px;
   background-color: #000;

--- a/extension/js/common/browser/ui.ts
+++ b/extension/js/common/browser/ui.ts
@@ -446,10 +446,15 @@ export class Ui {
       showConfirmButton: false,
       position: 'bottom',
       timer: seconds * 1000,
+      timerProgressBar: true,
       customClass: {
         container: 'ui-toast-container',
         popup: 'ui-toast',
         title: 'ui-toast-title'
+      },
+      didOpen: (toast) => {
+        toast.addEventListener('mouseenter', Swal.stopTimer);
+        toast.addEventListener('mouseleave', Swal.resumeTimer);
       }
     });
   }

--- a/extension/js/common/browser/ui.ts
+++ b/extension/js/common/browser/ui.ts
@@ -447,6 +447,7 @@ export class Ui {
       position: 'bottom',
       timer: seconds * 1000,
       customClass: {
+        container: 'ui-toast-container',
         popup: 'ui-toast',
         title: 'ui-toast-title'
       }

--- a/extension/js/common/browser/ui.ts
+++ b/extension/js/common/browser/ui.ts
@@ -439,8 +439,9 @@ export class Ui {
     return $(`<${name}/>`, attrs)[0].outerHTML; // xss-tested: jquery escapes attributes
   }
 
-  public static toast = async (msg: string, seconds = 2): Promise<void> => {
-    await Ui.swal().fire({
+  public static toast = (msg: string, seconds = 2) => {
+    // tslint:disable-next-line:no-floating-promises
+    Ui.swal().fire({
       toast: true,
       title: msg,
       showConfirmButton: false,


### PR DESCRIPTION
Closes #2763

Also, improved UX for toasts a bit to let users know when a toast will be closed and let them pause the timer (e.g. if they need more time to read and understand it) by hovering with a mouse.

![MGYudutmcC](https://user-images.githubusercontent.com/6059356/102940654-79523000-44b9-11eb-9486-d5a97d063162.gif)
