### PR TITLE
Call reject on exception in search.onsuccess

### DIFF
--- a/extension/js/common/platform/catch.ts
+++ b/extension/js/common/platform/catch.ts
@@ -91,7 +91,10 @@ export class Catch {
     return true;
   }
 
-  public static reportErr = (e: any) => {
+  public static reportErr = (e: any, reject?: (reason?: any) => void) => {
+    if (reject) {
+      reject(e);
+    }
     const { line, col } = Catch.getErrorLineAndCol(e);
     Catch.onErrorInternalHandler(e instanceof Error ? e.message : String(e), window.location.href, line, col, e, true);
   }
@@ -106,15 +109,15 @@ export class Catch {
       && typeof (v as Promise<any>).catch === 'function'; // tslint:disable-line:no-unbound-method - only testing if exists
   }
 
-  public static try = (code: () => void | Promise<void>) => {
+  public static try = (code: () => void | Promise<void>, reject?: (reason?: any) => void) => {
     return () => { // returns a function
       try {
         const r = code();
         if (Catch.isPromise(r)) {
-          r.catch(Catch.reportErr);
+          r.catch(codeErr => Catch.reportErr(codeErr, reject));
         }
       } catch (codeErr) {
-        Catch.reportErr(codeErr);
+        Catch.reportErr(codeErr, reject);
       }
     };
   }

--- a/extension/js/common/platform/catch.ts
+++ b/extension/js/common/platform/catch.ts
@@ -91,10 +91,7 @@ export class Catch {
     return true;
   }
 
-  public static reportErr = (e: any, reject?: (reason?: any) => void) => {
-    if (reject) {
-      reject(e);
-    }
+  public static reportErr = (e: any) => {
     const { line, col } = Catch.getErrorLineAndCol(e);
     Catch.onErrorInternalHandler(e instanceof Error ? e.message : String(e), window.location.href, line, col, e, true);
   }
@@ -109,15 +106,15 @@ export class Catch {
       && typeof (v as Promise<any>).catch === 'function'; // tslint:disable-line:no-unbound-method - only testing if exists
   }
 
-  public static try = (code: () => void | Promise<void>, reject?: (reason?: any) => void) => {
+  public static try = (code: () => void | Promise<void>) => {
     return () => { // returns a function
       try {
         const r = code();
         if (Catch.isPromise(r)) {
-          r.catch(codeErr => Catch.reportErr(codeErr, reject));
+          r.catch(Catch.reportErr);
         }
       } catch (codeErr) {
-        Catch.reportErr(codeErr, reject);
+        Catch.reportErr(codeErr);
       }
     };
   }

--- a/extension/js/common/platform/store/contact-store.ts
+++ b/extension/js/common/platform/store/contact-store.ts
@@ -158,7 +158,7 @@ export class ContactStore extends AbstractStore {
       const tx = db.transaction('contacts', 'readwrite');
       const contactsTable = tx.objectStore('contacts');
       contactsTable.put(prepared);
-      tx.oncomplete = Catch.try(resolve);
+      tx.oncomplete = () => resolve();
       tx.onabort = () => reject(ContactStore.errCategorize(tx.error));
     });
   }
@@ -210,7 +210,7 @@ export class ContactStore extends AbstractStore {
       const tx = db.transaction('contacts', 'readwrite');
       const contactsTable = tx.objectStore('contacts');
       contactsTable.put(updated);
-      tx.oncomplete = Catch.try(resolve);
+      tx.oncomplete = () => resolve();
       tx.onabort = () => reject(ContactStore.errCategorize(tx.error));
     });
   }
@@ -361,7 +361,14 @@ export class ContactStore extends AbstractStore {
       } else { // search primary longid
         tx = db.transaction('contacts', 'readonly').objectStore('contacts').index('index_longid').get(emailOrLongid);
       }
-      tx.onsuccess = Catch.try(() => resolve(ContactStore.toContact(tx.result)));
+      tx.onsuccess = () => {
+        try {
+          resolve(ContactStore.toContact(tx.result));
+        } catch (codeErr) {
+          reject(codeErr);
+          Catch.reportErr(codeErr);
+        }
+      };
       tx.onerror = () => reject(ContactStore.errCategorize(tx.error || new Error('Unknown db error')));
     });
   }

--- a/extension/js/common/platform/store/contact-store.ts
+++ b/extension/js/common/platform/store/contact-store.ts
@@ -285,19 +285,24 @@ export class ContactStore extends AbstractStore {
         }
       }
       const found: unknown[] = [];
-      search.onsuccess = Catch.try(() => {
-        const cursor = search.result as IDBCursorWithValue | undefined;
-        if (!cursor) {
-          resolve(found);
-        } else {
-          found.push(cursor.value);
-          if (query.limit && found.length >= query.limit) {
+      search.onsuccess = () => {
+        try {
+          const cursor = search.result as IDBCursorWithValue | undefined;
+          if (!cursor) {
             resolve(found);
           } else {
-            cursor.continue();
+            found.push(cursor.value);
+            if (query.limit && found.length >= query.limit) {
+              resolve(found);
+            } else {
+              cursor.continue();
+            }
           }
+        } catch (codeErr) {
+          reject(codeErr);
+          Catch.reportErr(codeErr);
         }
-      }, reject);
+      };
       search.onerror = () => reject(ContactStore.errCategorize(search!.error!)); // todo - added ! after ts3 upgrade - investigate
     });
     return raw;

--- a/extension/js/common/platform/store/contact-store.ts
+++ b/extension/js/common/platform/store/contact-store.ts
@@ -297,7 +297,7 @@ export class ContactStore extends AbstractStore {
             cursor.continue();
           }
         }
-      });
+      }, reject);
       search.onerror = () => reject(ContactStore.errCategorize(search!.error!)); // todo - added ! after ts3 upgrade - investigate
     });
     return raw;


### PR DESCRIPTION
Closes #2759 

Raising an exception inside 
```
       search.onsuccess = Catch.try(() => {
...
})
```
block resulted in unresolved Promise, so `const raw: unknown[] = await new Promise(...` hang.
