### PR TITLE
Report issues with parsing inline images

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-err-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-err-module.ts
@@ -17,7 +17,7 @@ import { ViewModule } from '../../../js/common/view-module.js';
 import { ComposeView } from '../compose.js';
 import { AjaxErrMsgs } from '../../../js/common/api/shared/api-error.js';
 
-class ComposerUserError extends Error { }
+export class ComposerUserError extends Error { }
 class ComposerNotReadyError extends ComposerUserError { }
 export class ComposerResetBtnTrigger extends Error { }
 
@@ -83,7 +83,7 @@ export class ComposeErrModule extends ViewModule<ComposeView> {
         }
       }
     } else if (e instanceof ComposerUserError) {
-      await Ui.modal.error(e.message);
+      await Ui.modal.error(e.message, true);
     } else {
       if (!(e instanceof ComposerResetBtnTrigger || e instanceof ComposerNotReadyError)) {
         Catch.reportErr(e);

--- a/extension/chrome/elements/compose-modules/compose-send-btn-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-send-btn-module.ts
@@ -178,8 +178,8 @@ export class ComposeSendBtnModule extends ViewModule<ComposeView> {
         } else {
           throw new ComposerUserError(`
             Unable to parse an inline image <details>
-              <summary>with src="..."</summary>
-              ${src}
+              <summary>See error details</summary>
+              src="${src}"
             </details>
           `);
         }

--- a/extension/chrome/elements/compose-modules/compose-send-btn-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-send-btn-module.ts
@@ -164,15 +164,19 @@ export class ComposeSendBtnModule extends ViewModule<ComposeView> {
         const img: Element = node;
         const src = img.getAttribute('src') as string;
         const { mimeType, data } = this.parseInlineImageSrc(src);
-        const imgAttachment = new Attachment({
-          cid: Attachment.attachmentId(),
-          name: img.getAttribute('name') || '',
-          type: mimeType,
-          data: Buf.fromBase64Str(data),
-          inline: true
-        });
-        img.setAttribute('src', `cid:${imgAttachment.cid}`);
-        imgAttachments.push(imgAttachment);
+        if (mimeType && data) {
+          const imgAttachment = new Attachment({
+            cid: Attachment.attachmentId(),
+            name: img.getAttribute('name') || '',
+            type: mimeType,
+            data: Buf.fromBase64Str(data),
+            inline: true
+          });
+          img.setAttribute('src', `cid:${imgAttachment.cid}`);
+          imgAttachments.push(imgAttachment);
+        } else {
+          Catch.report(`Unable to parse an inline image with src="${src}"`);
+        }
       }
     });
     const htmlWithCidImages = DOMPurify.sanitize(html);

--- a/extension/chrome/elements/compose-modules/compose-send-btn-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-send-btn-module.ts
@@ -179,7 +179,7 @@ export class ComposeSendBtnModule extends ViewModule<ComposeView> {
           throw new ComposerUserError(`
             Unable to parse an inline image <details>
               <summary>See error details</summary>
-              src="${src}"
+              src="${Xss.escape(src)}"
             </details>
           `);
         }

--- a/extension/chrome/elements/compose-modules/compose-send-btn-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-send-btn-module.ts
@@ -9,6 +9,7 @@ import { Attachment } from '../../../js/common/core/attachment.js';
 import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
 import { Buf } from '../../../js/common/core/buf.js';
 import { Catch } from '../../../js/common/platform/catch.js';
+import { ComposerUserError } from './compose-err-module.js';
 import { ComposeSendBtnPopoverModule } from './compose-send-btn-popover-module.js';
 import { GeneralMailFormatter } from './formatters/general-mail-formatter.js';
 import { GmailRes } from '../../../js/common/api/email-provider/gmail/gmail-parser.js';
@@ -175,7 +176,12 @@ export class ComposeSendBtnModule extends ViewModule<ComposeView> {
           img.setAttribute('src', `cid:${imgAttachment.cid}`);
           imgAttachments.push(imgAttachment);
         } else {
-          Catch.report(`Unable to parse an inline image with src="${src}"`);
+          throw new ComposerUserError(`
+            Unable to parse an inline image <details>
+              <summary>with src="..."</summary>
+              ${src}
+            </details>
+          `);
         }
       }
     });


### PR DESCRIPTION
This PR reports issues with parsing inline images to track issues with unexpected `src` values of inline images (https://github.com/FlowCrypt/flowcrypt-browser/issues/3301#issuecomment-757591686)

close #3301
