### PR TITLE
fix ⌘ + Enter shortcut for sending

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-send-btn-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-send-btn-module.ts
@@ -38,7 +38,7 @@ export class ComposeSendBtnModule extends ViewModule<ComposeView> {
 
   public setHandlers = (): void => {
     const ctrlEnterHandler = Ui.ctrlEnter(() => !this.view.sizeModule.composeWindowIsMinimized && this.extractProcessSendMsg());
-    this.view.S.cached('subject').add(this.view.S.cached('compose')).keypress(ctrlEnterHandler);
+    this.view.S.cached('subject').add(this.view.S.cached('compose')).keydown(ctrlEnterHandler);
     this.view.S.cached('send_btn').click(this.view.setHandlerPrevent('double', () => this.extractProcessSendMsg()));
     this.popover.setHandlers();
   }

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -184,7 +184,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
     ava.default('compose - keyboard - Ctrl+Enter sends message', testWithBrowser('ci.tests.gmail', async (t, browser) => {
       const inboxPage = await browser.newPage(t, TestUrls.extensionInbox('ci.tests.gmail@flowcrypt.dev'));
       const composeFrame = await InboxPageRecipe.openAndGetComposeFrame(inboxPage);
-      await composeFrame.target.evaluateHandle(() => (document.querySelector('#section_compose') as HTMLElement).dispatchEvent(new KeyboardEvent('keypress', { key: 'Enter', ctrlKey: true })));
+      await composeFrame.target.evaluateHandle(() => (document.querySelector('#section_compose') as HTMLElement).dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', ctrlKey: true })));
       await composeFrame.waitAndRespondToModal('error', 'confirm', 'Please add a recipient first');
     }));
 


### PR DESCRIPTION
This PR allows macOS users to send message with the expected `⌘ + Enter` shortcut

close #3355