### PR TITLE
Limit the values the page url parameter can have

### DIFF
--- a/extension/chrome/settings/index.ts
+++ b/extension/chrome/settings/index.ts
@@ -50,6 +50,9 @@ View.run(class SettingsView extends View {
     const uncheckedUrlParams = Url.parse(['acctEmail', 'page', 'pageUrlParams', 'advanced', 'addNewAcct']);
     this.acctEmail = Assert.urlParamRequire.optionalString(uncheckedUrlParams, 'acctEmail');
     this.page = Assert.urlParamRequire.optionalString(uncheckedUrlParams, 'page');
+    if (!/^\/chrome|modules/.test!(this.page as string)) {
+      this.page = undefined;
+    }
     this.page = (this.page === 'undefined') ? undefined : this.page; // in case an "undefined" string slipped in
     this.pageUrlParams = (typeof uncheckedUrlParams.pageUrlParams === 'string') ? JSON.parse(uncheckedUrlParams.pageUrlParams) as UrlParams : undefined;
     this.addNewAcct = uncheckedUrlParams.addNewAcct === true;


### PR DESCRIPTION
I noticed that in the extension, the legitimate values passed to this parameter only ever start with either `/chrome` or `modules`. I 
tested it and everything worked fine.

I recognize this solution is pretty hacky and amatuerish - I'm very open to suggestions for better approaches.

Resolves https://github.com/FlowCrypt/flowcrypt-security/issues/98