### PR TITLE
Escape subjects in extension inbox

### DIFF
--- a/extension/chrome/settings/inbox/inbox-modules/inbox-active-thread-module.ts
+++ b/extension/chrome/settings/inbox/inbox-modules/inbox-active-thread-module.ts
@@ -33,7 +33,7 @@ export class InboxActiveThreadModule extends ViewModule<InboxView> {
       thread = thread || await this.view.gmail.threadGet(threadId, 'metadata');
       const subject = GmailParser.findHeader(thread.messages[0], 'subject') || '(no subject)';
       this.updateUrlWithoutRedirecting(`${subject} - FlowCrypt Inbox`, { acctEmail: this.view.acctEmail, threadId });
-      this.view.displayBlock('thread', subject);
+      this.view.displayBlock('thread', Xss.escape(subject));
       for (const m of thread.messages) {
         await this.renderMsg(m);
       }


### PR DESCRIPTION
Currently XSS is mitigated like so:

https://github.com/FlowCrypt/flowcrypt-browser/blob/4e45cf6dfd80972e34ada1a7572c12e3a7276725/extension/chrome/settings/inbox/inbox.ts#L114-L118

But we don't account for HTML tags, which we don't want to render inside of subject lines.

Resolves https://github.com/FlowCrypt/flowcrypt-security/issues/100