### PR TITLE
Workaround the unavailability of chrome.windows in iframes on Firefox

### DIFF
--- a/extension/js/common/browser/browser.ts
+++ b/extension/js/common/browser/browser.ts
@@ -65,16 +65,16 @@ export class Browser {
     const basePath = chrome.runtime.getURL(`chrome/settings/${path}`);
     const pageUrlParams = rawPageUrlParams ? JSON.stringify(rawPageUrlParams) : undefined;
     if (acctEmail || path === 'fatal.htm') {
-      await Browser.openExtensionTab(Url.create(basePath, { acctEmail, page, pageUrlParams }));
+      Browser.openExtensionTab(Url.create(basePath, { acctEmail, page, pageUrlParams }));
     } else if (addNewAcct) {
-      await Browser.openExtensionTab(Url.create(basePath, { addNewAcct }));
+      Browser.openExtensionTab(Url.create(basePath, { addNewAcct }));
     } else {
       const acctEmails = await GlobalStore.acctEmailsGet();
-      await Browser.openExtensionTab(Url.create(basePath, { acctEmail: acctEmails[0], page, pageUrlParams }));
+      Browser.openExtensionTab(Url.create(basePath, { acctEmail: acctEmails[0], page, pageUrlParams }));
     }
   }
 
-  private static openExtensionTab = async (url: string) => {
+  public static openExtensionTab = (url: string) => {
     const tab = window.open(url, 'flowcrypt');
     if (tab) {
       tab.focus();

--- a/extension/js/common/settings.ts
+++ b/extension/js/common/settings.ts
@@ -6,6 +6,7 @@ import { Dict, Str, Url, UrlParams } from './core/common.js';
 import { Ui } from './browser/ui.js';
 import { Api } from './api/shared/api.js';
 import { ApiErr, AjaxErr } from './api/shared/api-error.js';
+import { Browser } from './browser/browser.js';
 import { Catch } from './platform/catch.js';
 import { Env } from './browser/env.js';
 import { Gmail } from './api/email-provider/gmail/gmail.js';
@@ -339,6 +340,11 @@ export class Settings {
   }
 
   public static loginWithPopupShowModalOnErr = async (acctEmail: string, then: (() => void) = () => undefined) => {
+    if (window !== window.top && !chrome.windows) { // Firefox, chrome.windows isn't available in iframes
+      Browser.openExtensionTab(Url.create(chrome.runtime.getURL(`chrome/settings/index.htm`), { acctEmail }));
+      await Ui.modal.info(`Reload after logging in.`);
+      return window.location.reload();
+    }
     const authRes = await GoogleAuth.newOpenidAuthPopup({ acctEmail });
     if (authRes.result === 'Success' && authRes.acctEmail && authRes.id_token) {
       then();


### PR DESCRIPTION
This PR workarounds the Firefox limitation when `chrome.windows` isn't available in iframes. The workaround opens the settings page where user can log in with the standard workflow. 

close #3368


https://user-images.githubusercontent.com/6059356/106969963-9767ad00-6754-11eb-8f19-1198e9b16cc5.mp4



