### PR TITLE
Replace deprecated sweetalert2 method onClose-> willClose

### DIFF
--- a/extension/js/common/browser/ui.ts
+++ b/extension/js/common/browser/ui.ts
@@ -246,7 +246,7 @@ export class Ui {
           $(Swal.getContent()!).attr('data-test', 'dialog');
           $(Swal.getCloseButton()!).attr('data-test', 'dialog-close').blur();
         },
-        onClose: () => {
+        willClose: () => {
           const urlWithoutPageParam = Url.removeParamsFromUrl(window.location.href, ['page']);
           window.history.pushState('', '', urlWithoutPageParam);
         },


### PR DESCRIPTION
Per the [SweetAlert2 documentation](https://sweetalert2.github.io/#handling-dismissals):

<img width="703" alt="Screen Shot 2021-02-04 at 17 09 02" src="https://user-images.githubusercontent.com/44826516/106971232-b9890d00-670b-11eb-9221-c19a067f582d.png">

