### PR TITLE
Adjust OAuth popup size

### DIFF
--- a/extension/js/common/api/email-provider/gmail/google-auth.ts
+++ b/extension/js/common/api/email-provider/gmail/google-auth.ts
@@ -121,7 +121,7 @@ export class GoogleAuth {
     }
     const authRequest: AuthReq = { acctEmail, scopes, csrfToken: `csrf-${Api.randomFortyHexChars()}` };
     const url = GoogleAuth.apiGoogleAuthCodeUrl(authRequest);
-    const oauthWin = await windowsCreate({ url, left: 100, top: 50, height: 700, width: 600, type: 'popup' });
+    const oauthWin = await windowsCreate({ url, left: 100, top: 50, height: 780, width: 500, type: 'popup' });
     if (!oauthWin || !oauthWin.tabs || !oauthWin.tabs.length) {
       return { result: 'Error', error: 'No oauth window renturned after initiating it', acctEmail, id_token: undefined };
     }


### PR DESCRIPTION
This PR increases the OAuth popup height so users won't have to scroll to the action button.

close #3373

![image](https://user-images.githubusercontent.com/6059356/107070564-31c6ff80-67ec-11eb-96af-b354cdbac58e.png)

Also, I decreased the popup width because that seems to be the cause of that padding from your screenshot (was not happening in my environment):

![image](https://user-images.githubusercontent.com/6059356/107070803-73f04100-67ec-11eb-8908-7498548f9d22.png)
