### PR TITLE
Adjust OAuth popup size for Windows

### DIFF
--- a/extension/js/common/api/email-provider/gmail/google-auth.ts
+++ b/extension/js/common/api/email-provider/gmail/google-auth.ts
@@ -121,7 +121,7 @@ export class GoogleAuth {
     }
     const authRequest: AuthReq = { acctEmail, scopes, csrfToken: `csrf-${Api.randomFortyHexChars()}` };
     const url = GoogleAuth.apiGoogleAuthCodeUrl(authRequest);
-    const oauthWin = await windowsCreate({ url, left: 100, top: 50, height: 780, width: 500, type: 'popup' });
+    const oauthWin = await windowsCreate({ url, left: 100, top: 50, height: 800, width: 550, type: 'popup' });
     if (!oauthWin || !oauthWin.tabs || !oauthWin.tabs.length) {
       return { result: 'Error', error: 'No oauth window renturned after initiating it', acctEmail, id_token: undefined };
     }


### PR DESCRIPTION
This PR increases the OAuth popup height so users won't have to scroll to the action button.

close #3373

@tomholub I assumed that the previous version would work in Windows as well, but after actual checking it wasn't good. Now the popup is good in both OS. Sorry about the hassle.

![image](https://user-images.githubusercontent.com/6059356/107099715-158e8700-681b-11eb-8598-1c41d241d203.png)
