### PR TITLE
Keep the cursor of the reply box in the viewport

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-input-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-input-module.ts
@@ -5,6 +5,7 @@
 import { NewMsgData, RecipientElement } from './compose-types.js';
 import { SquireEditor, WillPasteEvent } from '../../../types/squire.js';
 
+import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
 import { Catch } from '../../../js/common/platform/catch.js';
 import { Recipients } from '../../../js/common/api/email-provider/email-provider-api.js';
 import { Str } from '../../../js/common/core/common.js';
@@ -191,6 +192,14 @@ export class ComposeInputModule extends ViewModule<ComposeView> {
   private scrollIntoView = () => {
     this.squire.addEventListener('cursor', () => {
       try {
+        // keep the cursor of the reply box in the vieport, #3403
+        if (this.view.isReplyBox) {
+          BrowserMsg.send.scrollToReplyBox(this.view.parentTabId, {
+            replyMsgId: `#${this.view.frameId}`,
+            cursor: this.squire.getCursorPosition()
+          });
+        }
+        // keep the cursor of the compose/reply box visible in #input_text, #3403
         const inputText = this.view.S.cached('input_text').get(0);
         const offsetBottom = this.squire.getCursorPosition().bottom - inputText.getBoundingClientRect().top;
         const editorRootHeight = this.view.S.cached('input_text').height() || 0;

--- a/extension/chrome/elements/compose-modules/compose-size-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-size-module.ts
@@ -49,16 +49,22 @@ export class ComposeSizeModule extends ViewModule<ComposeView> {
       let minHeight = 0;
       let currentHeight = 0;
       if (this.view.S.cached('compose_table').is(':visible')) {
-        currentHeight = this.view.S.cached('compose_table').outerHeight() || 0;
+        currentHeight =
+          this.view.S.cached('recipients_placeholder').outerHeight()! +
+          this.view.S.cached('intro_container').get(0).clientHeight +
+          this.view.S.cached('add_intro').get(0).clientHeight +
+          this.view.S.cached('input_text').get(0).scrollHeight +
+          this.view.S.cached('password_or_pubkey').get(0).clientHeight +
+          this.view.S.cached('footer').outerHeight()!;
         minHeight = 260;
       } else if (this.view.S.cached('reply_msg_successful').is(':visible')) {
         currentHeight = this.view.S.cached('reply_msg_successful').outerHeight() || 0;
       } else {
         currentHeight = this.view.S.cached('prompt').outerHeight() || 0;
       }
-      if (currentHeight !== this.lastReplyBoxTableHeight && Math.abs(currentHeight - this.lastReplyBoxTableHeight) > 2) { // more then two pixel difference compared to last time
+      if (currentHeight !== this.lastReplyBoxTableHeight && Math.abs(currentHeight - this.lastReplyBoxTableHeight) > 2) { // more than two pixels difference compared to last time
         this.lastReplyBoxTableHeight = currentHeight;
-        BrowserMsg.send.setCss(this.view.parentTabId, { selector: `iframe#${this.view.frameId}`, css: { height: `${(Math.max(minHeight, currentHeight) + addExtra)}px` } });
+        BrowserMsg.send.setReplyBoxHeight(this.view.parentTabId, { replyMsgId: `#${this.view.frameId}`, height: Math.max(minHeight, currentHeight) + addExtra });
       }
     } else {
       this.view.S.cached('input_text').css('max-width', '');

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -1695,6 +1695,10 @@ table#compose td.input.show_send_from select#input_from:focus {
 
 .reply_box table#compose td.input.show_send_from select#input_from { margin-right: 4px; }
 
+.reply_box table#compose .text_container {
+  max-height: calc(100vh - 92px);
+}
+
 table#compose td.input.show_send_from #input_from_settings {
   position: absolute;
   right: 10px;

--- a/extension/js/common/browser/browser-msg.ts
+++ b/extension/js/common/browser/browser-msg.ts
@@ -32,7 +32,8 @@ export namespace Bm {
   export type AddOrRemoveClass = { class: string, selector: string; };
   export type Settings = { path?: string, page?: string, acctEmail?: string, pageUrlParams?: UrlParams, addNewAcct?: boolean };
   export type PassphraseDialog = { type: PassphraseDialogType, longids: string[] };
-  export type ScrollToReplyBox = { replyMsgId: string };
+  export type SetReplyBoxHeight = { replyMsgId: string, height: number };
+  export type ScrollToReplyBox = { replyMsgId: string, cursor?: DOMRect };
   export type NotificationShow = { notification: string, callbacks?: Dict<() => void> };
   export type NotificationShowAuthPopupNeeded = { acctEmail: string };
   export type RenderPublicKeys = { afterFrameId: string, publicKeys: string[], traverseUp?: number };
@@ -162,6 +163,7 @@ export class BrowserMsg {
     focusFrame: (dest: Bm.Dest, bm: Bm.FocusFrame) => BrowserMsg.sendCatch(dest, 'focus_frame', bm),
     closeReplyMessage: (dest: Bm.Dest, bm: Bm.CloseReplyMessage) => BrowserMsg.sendCatch(dest, 'close_reply_message', bm),
     openNewMessage: (dest: Bm.Dest) => BrowserMsg.sendCatch(dest, 'open_new_message', {}),
+    setReplyBoxHeight: (dest: Bm.Dest, bm: Bm.SetReplyBoxHeight) => BrowserMsg.sendCatch(dest, 'set_reply_box_height', bm),
     scrollToReplyBox: (dest: Bm.Dest, bm: Bm.ScrollToReplyBox) => BrowserMsg.sendCatch(dest, 'scroll_to_reply_box', bm),
     reinsertReplyBox: (dest: Bm.Dest, bm: Bm.ReinsertReplyBox) => BrowserMsg.sendCatch(dest, 'reinsert_reply_box', bm),
     passphraseDialog: (dest: Bm.Dest, bm: Bm.PassphraseDialog) => BrowserMsg.sendCatch(dest, 'passphrase_dialog', bm),

--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -99,22 +99,29 @@ export class GmailElementReplacer implements WebmailElementReplacer {
     $('.reply_message_iframe_container:visible').last().append(this.factory.embeddedReply(params, false, true)); // xss-safe-value
   }
 
-  public scrollToReplyBox = (selector: string) => {
+  public scrollToReplyBox = (selector: string, cursor?: DOMRect) => {
     const convoRootScrollable = $(this.sel.convoRootScrollable).get(0);
     if (convoRootScrollable) {
-      const element = $(selector);
-      if (element) {
+      const replyBox = $(selector);
+      if (replyBox) {
         $(this.sel.convoRootScrollable).css('scroll-behavior', 'smooth');
         const gmailHeaderHeight = 120;
         const topGap = 80; // so the bottom of the prev message will be visible
-        // scroll to the bottom of the element,
-        // or to the top of the element if the element's height is bigger than the convoRoot
+        if (cursor) { // `cursor` is only provided for reply box, perform scrolling only if the cursor went outside of viewport (e.g. by pressing arrows)
+          // TODO
+          // console.log(`replyBox.position()!.top`, replyBox.position()!.top);
+          // console.log(`cursor.top`, cursor.top);
+          // console.log(`replyBox.position()!.top + cursor.top`, replyBox.position()!.top + cursor.top);
+          // console.log(`$(window).height()`, $(window).height());
+        }
+        // scroll to the bottom of the replyBox,
+        // or to the top of the replyBox if the element's height is bigger than the convoRoot
         convoRootScrollable.scrollTop =
-          element.position()!.top + $(element).height()! -
-          Math.max(0, $(element).height()! - $(this.sel.convoRootScrollable).height()! + gmailHeaderHeight + topGap);
+          replyBox.position()!.top + $(replyBox).height()! -
+          Math.max(0, $(replyBox).height()! - $(this.sel.convoRootScrollable).height()! + gmailHeaderHeight + topGap);
       }
     } else if (window.location.hash.match(/^#inbox\/[a-zA-Z]+$/)) { // is a conversation view, but no scrollable conversation element
-      Catch.report(`Cannot find Gmail scrollable element: ${this.sel.convoRootScrollable}`);
+      Catch.report(`Cannot find replyBox: ${this.sel.convoRootScrollable}`);
     }
   }
 

--- a/extension/js/content_scripts/webmail/setup-webmail-content-script.ts
+++ b/extension/js/content_scripts/webmail/setup-webmail-content-script.ts
@@ -30,7 +30,7 @@ export interface WebmailElementReplacer {
   getIntervalFunctions: () => Array<IntervalFunction>;
   setReplyBoxEditable: () => Promise<void>;
   reinsertReplyBox: (replyMsgId: string) => void;
-  scrollToReplyBox: (replyMsgId: string) => void;
+  scrollToReplyBox: (replyMsgId: string, cursor?: DOMRect) => void;
 }
 
 const win = window as unknown as ContentScriptWindow;
@@ -142,8 +142,11 @@ export const contentScriptSetupIfVacant = async (webmailSpecific: WebmailSpecifi
     BrowserMsg.addListener('close_swal', async () => {
       Swal.close();
     });
-    BrowserMsg.addListener('scroll_to_reply_box', async ({ replyMsgId }: Bm.ScrollToReplyBox) => {
-      webmailSpecific.getReplacer().scrollToReplyBox(replyMsgId);
+    BrowserMsg.addListener('set_reply_box_height', async ({ replyMsgId, height }: Bm.SetReplyBoxHeight) => {
+      $(replyMsgId).css('height', Math.min(height, $(window).height()! - 270));
+    });
+    BrowserMsg.addListener('scroll_to_reply_box', async ({ replyMsgId, cursor }: Bm.ScrollToReplyBox) => {
+      webmailSpecific.getReplacer().scrollToReplyBox(replyMsgId, cursor);
     });
     BrowserMsg.addListener('passphrase_dialog', async ({ longids, type }: Bm.PassphraseDialog) => {
       if (!$('#cryptup_dialog').length) {


### PR DESCRIPTION
This PR keeps the cursor of the reply box in the viewport so users always know where they are.

close #3403