### PR TITLE
Include DOMPurify JS map for better error output

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,6 +47,7 @@ fi
 mkdir -p $OUTDIR/lib/
 mkdir -p $OUTDIR/css/
 cp node_modules/dompurify/dist/purify.js $OUTDIR/lib/purify.js
+cp node_modules/dompurify/dist/purify.js.map $OUTDIR/lib/purify.js.map
 cp node_modules/jquery/dist/jquery.min.js $OUTDIR/lib/jquery.min.js
 cp node_modules/openpgp/dist/openpgp.js $OUTDIR/lib/openpgp.js
 cp node_modules/openpgp/dist/openpgp.worker.js $OUTDIR/lib/openpgp.worker.js


### PR DESCRIPTION
Currently, when purify.js throws an error we get this:

>DevTools failed to load SourceMap: Could not load content for chrome-extension://bnjglocicdkmhmoohhfkfkbbkejdhdgc/lib/purify.js.map: HTTP error: status code 404, net::ERR_UNKNOWN_URL_SCHEME

This PR adds the map so we get better errors from this.