### PR TITLE
Trigger resizeComposeBox() after showing/hiding password UI

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-pwd-or-pubkey-container-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-pwd-or-pubkey-container-module.ts
@@ -116,6 +116,7 @@ export class ComposePwdOrPubkeyContainerModule extends ViewModule<ComposeView> {
       const { removeValidationElements } = this.keyImportUI.renderPassPhraseStrengthValidationInput($("#input_password"), undefined, 'pwd');
       this.rmPwdStrengthValidationElements = removeValidationElements;
     }
+    this.view.sizeModule.resizeComposeBox();
   }
 
   private hideMsgPwdUi = () => {

--- a/extension/chrome/elements/compose-modules/compose-pwd-or-pubkey-container-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-pwd-or-pubkey-container-module.ts
@@ -40,14 +40,14 @@ export class ComposePwdOrPubkeyContainerModule extends ViewModule<ComposeView> {
     const footerHeight = this.view.S.cached('footer').outerHeight() || 0;
     this.view.S.cached('expiration_note').css({ bottom: (passwordContainerHeight + footerHeight) + 'px' });
     this.view.S.cached('expiration_note').fadeIn();
-    this.showHideContainerAndColorSendBtn();
+    this.showHideContainerAndColorSendBtn(); // tslint:disable-line:no-floating-promises
   }
 
   public inputPwdBlurHandler = () => {
     Catch.setHandledTimeout(() => { // timeout here is needed so <a> will be visible once clicked
       this.view.S.cached('expiration_note').fadeOut();
     }, 100);
-    this.showHideContainerAndColorSendBtn();
+    this.showHideContainerAndColorSendBtn(); // tslint:disable-line:no-floating-promises
   }
 
   public showHideContainerAndColorSendBtn = async () => {

--- a/extension/chrome/elements/compose-modules/compose-pwd-or-pubkey-container-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-pwd-or-pubkey-container-module.ts
@@ -50,7 +50,7 @@ export class ComposePwdOrPubkeyContainerModule extends ViewModule<ComposeView> {
     this.showHideContainerAndColorSendBtn();
   }
 
-  public showHideContainerAndColorSendBtn = () => {
+  public showHideContainerAndColorSendBtn = async () => {
     this.view.sendBtnModule.resetSendBtn();
     this.view.S.cached('send_btn_note').text('');
     this.view.S.cached('send_btn').removeAttr('title');
@@ -59,7 +59,7 @@ export class ComposePwdOrPubkeyContainerModule extends ViewModule<ComposeView> {
       this.hideMsgPwdUi(); // Hide 'Add Pasword' prompt if there are no recipients or message is not encrypted
       this.view.sendBtnModule.enableBtn();
     } else if (this.view.recipientsModule.getRecipients().find(r => r.status === RecipientStatus.NO_PGP)) {
-      this.showMsgPwdUiAndColorBtn().catch(Catch.reportErr);
+      await this.showMsgPwdUiAndColorBtn().catch(Catch.reportErr);
     } else if (this.view.recipientsModule.getRecipients().find(r => [RecipientStatus.FAILED, RecipientStatus.WRONG].includes(r.status))) {
       this.view.S.now('send_btn_text').text(SendBtnTexts.BTN_WRONG_ENTRY);
       this.view.S.cached('send_btn').attr('title', 'Notice the recipients marked in red: please remove them and try to enter them egain.');
@@ -116,7 +116,6 @@ export class ComposePwdOrPubkeyContainerModule extends ViewModule<ComposeView> {
       const { removeValidationElements } = this.keyImportUI.renderPassPhraseStrengthValidationInput($("#input_password"), undefined, 'pwd');
       this.rmPwdStrengthValidationElements = removeValidationElements;
     }
-    this.view.sizeModule.resizeComposeBox();
   }
 
   private hideMsgPwdUi = () => {

--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -848,7 +848,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
       Xss.sanitizePrepend(el, '<img class="lock-icon" src="/img/svgs/locked-icon.svg" />');
       $(el).attr('title', 'Could not verify their encryption setup. You can encrypt the message with a password below. Alternatively, add their pubkey.');
     }
-    this.view.pwdOrPubkeyContainerModule.showHideContainerAndColorSendBtn();
+    this.view.pwdOrPubkeyContainerModule.showHideContainerAndColorSendBtn(); // tslint:disable-line:no-floating-promises
     this.view.myPubkeyModule.reevaluateShouldAttachOrNot();
   }
 
@@ -862,7 +862,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
     }
     this.view.S.cached('input_addresses_container_outer').find(`#input-container-${this.addedRecipients[index].sendingType} input`).focus();
     this.addedRecipients.splice(index, 1);
-    this.view.pwdOrPubkeyContainerModule.showHideContainerAndColorSendBtn();
+    this.view.pwdOrPubkeyContainerModule.showHideContainerAndColorSendBtn(); // tslint:disable-line:no-floating-promises
     this.view.myPubkeyModule.reevaluateShouldAttachOrNot();
   }
 

--- a/extension/chrome/elements/compose-modules/compose-send-btn-popover-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-send-btn-popover-module.ts
@@ -72,7 +72,7 @@ export class ComposeSendBtnPopoverModule extends ViewModule<ComposeView> {
     }
     this.choices.richtext ? this.view.inputModule.addRichTextFormatting() : this.view.inputModule.removeRichTextFormatting();
     this.view.sendBtnModule.resetSendBtn();
-    this.view.pwdOrPubkeyContainerModule.showHideContainerAndColorSendBtn();
+    this.view.pwdOrPubkeyContainerModule.showHideContainerAndColorSendBtn(); // tslint:disable-line:no-floating-promises
     if (typeof machineForceStateTo === 'undefined' && popoverOpt === 'richtext') { // human-input choice of rich text
       this.richTextUserChoiceStore(newToggleTicked).catch(Catch.reportErr);
     }


### PR DESCRIPTION
This PR resizes reply box when showing/hiding password UI so the send btn is visible when the email address in recipients is marked grey

Addresses https://github.com/FlowCrypt/flowcrypt-browser/issues/3432#issuecomment-780109901