### PR TITLE
Prevent HTML injection via Label ID

### DIFF
--- a/extension/chrome/settings/inbox/inbox-modules/inbox-list-threads-module.ts
+++ b/extension/chrome/settings/inbox/inbox-modules/inbox-list-threads-module.ts
@@ -21,7 +21,7 @@ export class InboxListThreadsModule extends ViewModule<InboxView> {
       if (threads?.length) {
         await Promise.all(threads.map(t => this.renderInboxItem(t.id)));
       } else {
-        Xss.sanitizeRender('.threads', `<p>No encrypted messages in ${labelId} yet. ${Ui.retryLink()}</p>`);
+        Xss.sanitizeRender('.threads', `<p>No encrypted messages in ${Xss.escape(labelId)} yet. ${Ui.retryLink()}</p>`);
       }
     } catch (e) {
       if (ApiErr.isNetErr(e)) {


### PR DESCRIPTION
This resolves https://github.com/FlowCrypt/flowcrypt-security/issues/106 by escaping the LabelID. Here's how this looks now when I try to inject HTML:

<img width="745" alt="Screen Shot 2021-02-17 at 16 31 48" src="https://user-images.githubusercontent.com/44826516/108282947-b5afae80-713f-11eb-89db-65f99964d5fb.png">

Let me know if I'm not accounting for anything!