### PR TITLE
escape stacktraces in FlowCrypt error page

### DIFF
--- a/extension/chrome/settings/fatal.ts
+++ b/extension/chrome/settings/fatal.ts
@@ -44,5 +44,5 @@ if (reason === 'db_corrupted') {
 }
 
 if (stack) {
-  Xss.sanitizeAppend(details, `<br><pre>${stack}</pre>`);
+  Xss.sanitizeAppend(details, `<br><pre>${Xss.escape(stack)}</pre>`);
 }


### PR DESCRIPTION
Currently, in the page /chrome/settings/fatal.htm, you can pass a stacktrace parameter. The contents of that parameter are placed into a pre tag, but if the stacktrace itself contains a closing pre tag, then anything after that will be rendered as HTML.

For example, here is the result of going to /chrome/settings/fatal.htm?stacktrace=\</pre>\<marquee>I LOVE HYPERTEXT\</marquee>:

https://user-images.githubusercontent.com/44826516/108677326-c006db00-74a6-11eb-8666-7ba9a033e2d2.mov

To resolve this, I escape the contents of the stacktrace using Xss.escape. I tested this manually and it worked in blocking the attacks presented in the report.

Another possible complaint could be that we are reflecting output at all, as someone could just put a phishing message into the stack parameter. However, having that is useful for us for debugging purposes, so I left it.