### PR TITLE
Keep the cursor of the reply box always in viewport

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-input-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-input-module.ts
@@ -3,7 +3,7 @@
 'use strict';
 
 import { NewMsgData, RecipientElement } from './compose-types.js';
-import { SquireEditor, WillPasteEvent } from '../../../types/squire.js';
+import { CursorEvent, SquireEditor, WillPasteEvent } from '../../../types/squire.js';
 
 import { Catch } from '../../../js/common/platform/catch.js';
 import { Recipients } from '../../../js/common/api/email-provider/email-provider-api.js';
@@ -180,9 +180,10 @@ export class ComposeInputModule extends ViewModule<ComposeView> {
   }
 
   private resizeReplyBox = () => {
-    this.squire.addEventListener('cursor', (e: any) => {
+    this.squire.addEventListener('cursor', (e: CursorEvent) => {
       if (this.view.isReplyBox) {
-        this.view.sizeModule.resizeComposeBox(0, e?.range?.commonAncestorContainer?.offsetTop);
+        const cursorContainer = e.range.commonAncestorContainer as HTMLElement;
+        this.view.sizeModule.resizeComposeBox(0, cursorContainer?.offsetTop);
       }
     });
   }

--- a/extension/chrome/elements/compose-modules/compose-input-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-input-module.ts
@@ -180,9 +180,9 @@ export class ComposeInputModule extends ViewModule<ComposeView> {
   }
 
   private resizeReplyBox = () => {
-    this.squire.addEventListener('cursor', () => {
+    this.squire.addEventListener('cursor', (e: any) => {
       if (this.view.isReplyBox) {
-        this.view.sizeModule.resizeComposeBox();
+        this.view.sizeModule.resizeComposeBox(0, e?.range?.commonAncestorContainer?.offsetTop);
       }
     });
   }

--- a/extension/chrome/elements/compose-modules/compose-size-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-size-module.ts
@@ -64,10 +64,7 @@ export class ComposeSizeModule extends ViewModule<ComposeView> {
         });
       }
       if (cursorOffsetTop) {
-        BrowserMsg.send.scrollToCursorInReplyBox(this.view.parentTabId, {
-          replyMsgId: `#${this.view.frameId}`,
-          cursorOffsetTop
-        });
+        BrowserMsg.send.scrollToCursorInReplyBox(this.view.parentTabId, { replyMsgId: `#${this.view.frameId}`, cursorOffsetTop });
       }
     } else {
       this.view.S.cached('input_text').css('max-width', '');

--- a/extension/chrome/elements/compose-modules/compose-size-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-size-module.ts
@@ -43,7 +43,7 @@ export class ComposeSizeModule extends ViewModule<ComposeView> {
     }, 1000);
   }
 
-  public resizeComposeBox = (addExtra: number = 0) => {
+  public resizeComposeBox = (addExtra: number = 0, cursorOffsetTop?: number) => {
     if (this.view.isReplyBox) {
       this.view.S.cached('input_text').css('max-width', (this.view.S.cached('body').width()! - 20) + 'px'); // body should always be present
       let minHeight = 0;
@@ -58,7 +58,16 @@ export class ComposeSizeModule extends ViewModule<ComposeView> {
       }
       if (currentHeight !== this.lastReplyBoxTableHeight && Math.abs(currentHeight - this.lastReplyBoxTableHeight) > 2) { // more then two pixel difference compared to last time
         this.lastReplyBoxTableHeight = currentHeight;
-        BrowserMsg.send.setCss(this.view.parentTabId, { selector: `iframe#${this.view.frameId}`, css: { height: `${(Math.max(minHeight, currentHeight) + addExtra)}px` } });
+        BrowserMsg.send.setCss(this.view.parentTabId, {
+          selector: `iframe#${this.view.frameId}`,
+          css: { height: `${(Math.max(minHeight, currentHeight) + addExtra)}px` }
+        });
+      }
+      if (cursorOffsetTop) {
+        BrowserMsg.send.scrollToCursorInReplyBox(this.view.parentTabId, {
+          replyMsgId: `#${this.view.frameId}`,
+          cursorOffsetTop
+        });
       }
     } else {
       this.view.S.cached('input_text').css('max-width', '');

--- a/extension/js/common/browser/browser-msg.ts
+++ b/extension/js/common/browser/browser-msg.ts
@@ -33,6 +33,7 @@ export namespace Bm {
   export type Settings = { path?: string, page?: string, acctEmail?: string, pageUrlParams?: UrlParams, addNewAcct?: boolean };
   export type PassphraseDialog = { type: PassphraseDialogType, longids: string[] };
   export type ScrollToReplyBox = { replyMsgId: string };
+  export type ScrollToCursorInReplyBox = { replyMsgId: string, cursorOffsetTop: number };
   export type NotificationShow = { notification: string, callbacks?: Dict<() => void> };
   export type NotificationShowAuthPopupNeeded = { acctEmail: string };
   export type RenderPublicKeys = { afterFrameId: string, publicKeys: string[], traverseUp?: number };
@@ -93,7 +94,8 @@ export namespace Bm {
   }
 
   export type AnyRequest = PassphraseEntry | StripeResult | OpenPage | OpenGoogleAuthDialog | Redirect | Reload |
-    AddPubkeyDialog | ReinsertReplyBox | CloseReplyMessage | ScrollToReplyBox | SubscribeDialog | RenderPublicKeys | NotificationShowAuthPopupNeeded |
+    AddPubkeyDialog | ReinsertReplyBox | CloseReplyMessage | ScrollToReplyBox | ScrollToCursorInReplyBox | SubscribeDialog |
+    RenderPublicKeys | NotificationShowAuthPopupNeeded |
     NotificationShow | PassphraseDialog | PassphraseDialog | Settings | SetCss | AddOrRemoveClass | ReconnectAcctAuthPopup |
     Db | StoreSessionSet | StoreSessionGet | StoreGlobalGet | StoreGlobalSet | StoreAcctGet | StoreAcctSet | KeyParse |
     PgpMsgDecrypt | PgpMsgDiagnoseMsgPubkeys | PgpMsgVerifyDetached | PgpHashChallengeAnswer | PgpMsgType | Ajax | FocusFrame |
@@ -163,6 +165,7 @@ export class BrowserMsg {
     closeReplyMessage: (dest: Bm.Dest, bm: Bm.CloseReplyMessage) => BrowserMsg.sendCatch(dest, 'close_reply_message', bm),
     openNewMessage: (dest: Bm.Dest) => BrowserMsg.sendCatch(dest, 'open_new_message', {}),
     scrollToReplyBox: (dest: Bm.Dest, bm: Bm.ScrollToReplyBox) => BrowserMsg.sendCatch(dest, 'scroll_to_reply_box', bm),
+    scrollToCursorInReplyBox: (dest: Bm.Dest, bm: Bm.ScrollToCursorInReplyBox) => BrowserMsg.sendCatch(dest, 'scroll_to_cursor_in_reply_box', bm),
     reinsertReplyBox: (dest: Bm.Dest, bm: Bm.ReinsertReplyBox) => BrowserMsg.sendCatch(dest, 'reinsert_reply_box', bm),
     passphraseDialog: (dest: Bm.Dest, bm: Bm.PassphraseDialog) => BrowserMsg.sendCatch(dest, 'passphrase_dialog', bm),
     notificationShow: (dest: Bm.Dest, bm: Bm.NotificationShow) => BrowserMsg.sendCatch(dest, 'notification_show', bm),

--- a/extension/js/content_scripts/webmail/setup-webmail-content-script.ts
+++ b/extension/js/content_scripts/webmail/setup-webmail-content-script.ts
@@ -31,6 +31,7 @@ export interface WebmailElementReplacer {
   setReplyBoxEditable: () => Promise<void>;
   reinsertReplyBox: (replyMsgId: string) => void;
   scrollToReplyBox: (replyMsgId: string) => void;
+  scrollToCursorInReplyBox: (replyMsgId: string, cursorOffsetTop: number) => void;
 }
 
 const win = window as unknown as ContentScriptWindow;
@@ -144,6 +145,9 @@ export const contentScriptSetupIfVacant = async (webmailSpecific: WebmailSpecifi
     });
     BrowserMsg.addListener('scroll_to_reply_box', async ({ replyMsgId }: Bm.ScrollToReplyBox) => {
       webmailSpecific.getReplacer().scrollToReplyBox(replyMsgId);
+    });
+    BrowserMsg.addListener('scroll_to_cursor_in_reply_box', async ({ replyMsgId, cursorOffsetTop }: Bm.ScrollToCursorInReplyBox) => {
+      webmailSpecific.getReplacer().scrollToCursorInReplyBox(replyMsgId, cursorOffsetTop);
     });
     BrowserMsg.addListener('passphrase_dialog', async ({ longids, type }: Bm.PassphraseDialog) => {
       if (!$('#cryptup_dialog').length) {

--- a/extension/types/squire.d.ts
+++ b/extension/types/squire.d.ts
@@ -77,3 +77,6 @@ export declare class WillPasteEvent extends ClipboardEvent {
   fragment: DocumentFragment;
   text: string;
 }
+export declare class CursorEvent {
+  range: Range;
+}


### PR DESCRIPTION
This PR keeps the cursor of the reply box in the viewport so users always know where they are.

close #3403

@tomholub this small issue kept me busy, and I'm still unable to come up with the perfect solution, but this one looks good enough for me. There's one visual imperfection which I'm unable to fix - the visible vertical jumpiness of the Send button when adjusting `scrollTop` of `convoRootScrollable`:

https://user-images.githubusercontent.com/6059356/109157005-3131e100-777a-11eb-8212-4c26d1e3020b.mp4

I'm not even sure if there is a solution to keep the button stable, but if there is one it would probably be complex.