### PR TITLE
Issue 3436 contacts popup in reply box

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -349,6 +349,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
       return;
     }
     this.view.errModule.debug(`input_to.blur -> parseRenderRecipients start causedBy(${e.relatedTarget ? e.relatedTarget.outerHTML : undefined})`);
+    this.hideContacts();
     await this.parseRenderRecipients($(target));
     // If thereis no related target or related target isn't in recipients functionality
     // then we need to collapse inputs

--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -657,10 +657,13 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
       } else {
         leftOffset = offset.left + inputToPadding;
       }
+      const offsetTop = $('#recipients_row').height()! + offset.top; // both are in the template
+      const bottomGap = 10;
       this.view.S.cached('contacts').css({
         display: 'block',
         left: leftOffset,
-        top: `${$('#compose > tbody > tr:first').height()! + offset.top}px`, // both are in the template
+        top: offsetTop,
+        maxHeight: `calc(100% - ${offsetTop + bottomGap}px)`,
       });
     }
   }

--- a/extension/chrome/elements/compose.htm
+++ b/extension/chrome/elements/compose.htm
@@ -57,7 +57,7 @@
           </div>
         </th>
       </tr>
-      <tr>
+      <tr id="recipients_row">
         <td class="input recipients-inputs">
           <div id="input_addresses_container" class="invisible">
             <!-- to -->

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -2060,6 +2060,7 @@ div#contacts {
   display: none;
   position: absolute;
   background: white;
+  overflow-y: auto;
   top: 74px;
   border: 1px solid rgba(0, 0, 0, 0.2);
   left: 10px;


### PR DESCRIPTION
This PR adds scrolling to the contacts popup if it's higher than the iframe (e.g. reply box), so users will always be able to see and click contacts which were previously just inaccessible.

Also, fixed this small UI inconvenience when the contacts popup was staying visible after the focus was moved to `#input_text`:


https://user-images.githubusercontent.com/6059356/109433961-a1ab5d00-7a1b-11eb-9d8f-204760420465.mp4



close #3436