### PR TITLE
Disallow clipboard copy of private key

### DIFF
--- a/extension/chrome/settings/modules/my_key.htm
+++ b/extension/chrome/settings/modules/my_key.htm
@@ -49,8 +49,6 @@
     </div>
     <div class="line"><span class="red_label">Never send this to anyone!</span></div>
     <div class="line">
-      <a href="#" class="action_copy_prv bad">Copy private key to clipboard</a>
-      &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
       <a href="#" class="action_download_prv bad">Save private key to a file</a>
     </div>
   </div>

--- a/extension/chrome/settings/modules/my_key.ts
+++ b/extension/chrome/settings/modules/my_key.ts
@@ -64,7 +64,7 @@ View.run(class MyKeyView extends View {
     $('.action_continue_download').click(this.setHandlerPrevent('double', () => this.downloadRevocationCert(String($('#input_passphrase').val()))));
     $('#input_passphrase').on('keydown', this.setEnterHandlerThatClicks('.action_continue_download'));
     $('.action_cancel_download_cert').click(this.setHandler(() => { $('.enter_pp').hide(); }));
-    const clipboardOpts = { text: (trigger: HTMLElement) =>  this.keyInfo.public };
+    const clipboardOpts = { text: () =>  this.keyInfo.public };
     new ClipboardJS('.action_copy_pubkey', clipboardOpts); // tslint:disable-line:no-unused-expression no-unsafe-any
   }
 

--- a/extension/chrome/settings/modules/my_key.ts
+++ b/extension/chrome/settings/modules/my_key.ts
@@ -64,8 +64,8 @@ View.run(class MyKeyView extends View {
     $('.action_continue_download').click(this.setHandlerPrevent('double', () => this.downloadRevocationCert(String($('#input_passphrase').val()))));
     $('#input_passphrase').on('keydown', this.setEnterHandlerThatClicks('.action_continue_download'));
     $('.action_cancel_download_cert').click(this.setHandler(() => { $('.enter_pp').hide(); }));
-    const clipboardOpts = { text: (trigger: HTMLElement) => trigger.className.includes('action_copy_pubkey') ? this.keyInfo.public : this.keyInfo.private };
-    new ClipboardJS('.action_copy_pubkey, .action_copy_prv', clipboardOpts); // tslint:disable-line:no-unused-expression no-unsafe-any
+    const clipboardOpts = { text: (trigger: HTMLElement) =>  this.keyInfo.public };
+    new ClipboardJS('.action_copy_pubkey', clipboardOpts); // tslint:disable-line:no-unused-expression no-unsafe-any
   }
 
   private renderPubkeyShareableLink = async () => {


### PR DESCRIPTION
Remove the option to copy private key to clipboard due to formatting inconveniences for users when eg pasting into word

Resolves https://github.com/FlowCrypt/flowcrypt-security/issues/115