### PR TITLE
Escape HTML in password protected message intros

### DIFF
--- a/extension/chrome/elements/compose-modules/formatters/encrypted-mail-msg-formatter.ts
+++ b/extension/chrome/elements/compose-modules/formatters/encrypted-mail-msg-formatter.ts
@@ -197,7 +197,7 @@ export class EncryptedMsgMailFormatter extends BaseMailFormatter {
     const html = [];
     if (intro) {
       text.push(intro + '\n');
-      html.push(intro.replace(/\n/g, '<br>') + '<br><br>');
+      html.push(Xss.escape(intro).replace(/\n/g, '<br>') + '<br><br>');
     }
     text.push(Lang.compose.msgEncryptedText[lang] + msgUrl + '\n\n');
     html.push(`${Lang.compose.msgEncryptedHtml[lang] + a}<br/><br/>${Lang.compose.alternativelyCopyPaste[lang] + Xss.escape(msgUrl)}<br/><br/>`);


### PR DESCRIPTION
Currently, here is what happens if I include an `<i>` tag in a password protected message's unencrypted intro section:

<img width="282" alt="Screen Shot 2021-03-11 at 1 53 05" src="https://user-images.githubusercontent.com/44826516/110761155-a4246880-820c-11eb-8356-84bb3ef4b951.png">

As you can see, the tag is applied and the rest of the email is italicized. Here is what happens after this PR:

<img width="281" alt="Screen Shot 2021-03-11 at 1 52 51" src="https://user-images.githubusercontent.com/44826516/110761207-b43c4800-820c-11eb-9b85-3728a74956d7.png">