### PR TITLE
issue 3508 keyinfo email missing

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-my-pubkey-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-my-pubkey-module.ts
@@ -33,7 +33,7 @@ export class ComposeMyPubkeyModule extends ViewModule<ComposeView> {
 
   public chooseMyPublicKeyBySenderEmail = async (keys: KeyInfo[], email: string) => {
     for (const key of keys) {
-      if (key.emails.includes(email.toLowerCase())) {
+      if (key.emails?.includes(email.toLowerCase())) {
         return key;
       }
     }

--- a/extension/js/common/core/crypto/key.ts
+++ b/extension/js/common/core/crypto/key.ts
@@ -70,7 +70,7 @@ export interface KeyInfo {
   public: string; // this cannot be Pubkey has it's being passed to localstorage
   longid: string;
   fingerprints: string[];
-  emails: string[];
+  emails?: string[]; // todo - used to be missing - but migration was supposed to add it? setting back to optional for now
 }
 
 export interface KeyInfoWithOptionalPp extends KeyInfo {


### PR DESCRIPTION
This PR makes KeyInfo.email optional to avoid unexpected NPE.

close #3508
