### PR TITLE
Dumping contents of 'debug' IndexedDB in browser tests #3482

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ $ npm run-script build
 
 Now you can find your built project in `build/chrome-consumer` and `build/firefox-consumer`
 
+Printing debug data to test logs can be done using special `Debug` class:
+https://github.com/FlowCrypt/flowcrypt-browser/tree/master/extension/js/common/platform/debug.ts#L7
+
 ### Note for Mac OS users
 
 In order for `npm run-script build` to work you have to:

--- a/extension/chrome/dev/ci_unit_test.ts
+++ b/extension/chrome/dev/ci_unit_test.ts
@@ -14,6 +14,7 @@ import { MsgUtil } from '../../js/common/core/crypto/pgp/msg-util.js';
 import { Sks } from '../../js/common/api/key-server/sks.js';
 import { Ui } from '../../js/common/browser/ui.js';
 import { ContactStore } from '../../js/common/platform/store/contact-store.js';
+import { Debug } from '../../js/common/platform/debug.js';
 
 /**
  * importing all libs that are tested in ci tests
@@ -31,7 +32,8 @@ const libs: any[] = [
   Sks,
   MsgUtil,
   Ui,
-  ContactStore
+  ContactStore,
+  Debug
 ];
 
 // add them to global scope so ci can use them

--- a/extension/js/common/platform/debug.ts
+++ b/extension/js/common/platform/debug.ts
@@ -1,0 +1,51 @@
+/* ©️ 2016 - present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com */
+
+'use strict';
+
+import { AbstractStore } from './store/abstract-store.js';
+
+export class Debug {
+  public static readDatabase = async (): Promise<any[] | undefined> => {
+    const db = await Debug.openDatabase();
+    const records: any[] = [];
+    const tx = db.transaction(['messages'], 'readwrite');
+    await new Promise((resolve, reject) => {
+      tx.oncomplete = () => resolve(undefined);
+      tx.onerror = () => reject(AbstractStore.errCategorize(tx.error));
+      const messages = tx.objectStore('messages');
+      const search = messages.getAll(undefined);
+      search.onsuccess = () => {
+        records.push(...search.result);
+        messages.clear();
+      }
+    });
+    return records;
+  }
+
+  public static addMessage = async (message: any): Promise<void> => {
+    const db = await Debug.openDatabase();
+    const tx = db.transaction(['messages'], 'readwrite');
+    await new Promise((resolve, reject) => {
+      tx.oncomplete = () => resolve(undefined);
+      tx.onerror = () => reject(AbstractStore.errCategorize(tx.error));
+      const messages = tx.objectStore('messages');
+      messages.add(message);
+    });
+  }
+
+  private static openDatabase = async (): Promise<IDBDatabase> => {
+    const db = await new Promise((resolve, reject) => {
+      const openDbReq = indexedDB.open('debug', 1);
+      openDbReq.onupgradeneeded = (event) => {
+        const db = openDbReq.result;
+        if (event.oldVersion < 1) {
+          db.createObjectStore('messages', { autoIncrement: true });
+        }
+      };
+      openDbReq.onsuccess = () => resolve(openDbReq.result as IDBDatabase);
+      openDbReq.onblocked = () => reject(AbstractStore.errCategorize(openDbReq.error));
+      openDbReq.onerror = () => reject(AbstractStore.errCategorize(openDbReq.error));
+    });
+    return db as IDBDatabase;
+  }
+}

--- a/extension/js/common/platform/debug.ts
+++ b/extension/js/common/platform/debug.ts
@@ -9,7 +9,7 @@ import { AbstractStore } from './store/abstract-store.js';
  * Db is initialized on demand in `addMessage` or `readDatabase` calls
  * Suggested usage is to log inputs and output of a method called from the browser by
  * substitution of the original method in a draft pull request with a replacement method:
- * 
+ *
  * fun someMethod(input1, input2) {
  *  const output = someMethodORIGINAL(input1, input2);
  *  Debug.addMessage({ input: {input1, input2}, output }).catch(Catch.reportErr);
@@ -18,8 +18,9 @@ import { AbstractStore } from './store/abstract-store.js';
  *
  * In async methods, the call can be arranged like this:
  * await Debug.addMessage({input, output});
- * 
- * Upon test completion, the data can be extracted by the test framework with  
+ *
+ * Upon test completion, the data can be extracted by the test framework with
+ * await page.target.evaluate(() => (window as any).Debug.readDatabase());
  */
 export class Debug {
   /**

--- a/extension/js/common/platform/debug.ts
+++ b/extension/js/common/platform/debug.ts
@@ -17,7 +17,7 @@ export class Debug {
       search.onsuccess = () => {
         records.push(...search.result);
         messages.clear();
-      }
+      };
     });
     return records;
   }

--- a/extension/js/common/platform/debug.ts
+++ b/extension/js/common/platform/debug.ts
@@ -4,8 +4,28 @@
 
 import { AbstractStore } from './store/abstract-store.js';
 
+/**
+ * This class stores debug messages in an IndexedDB
+ * Db is initialized on demand in `addMessage` or `readDatabase` calls
+ * Suggested usage is to log inputs and output of a method called from the browser by
+ * substitution of the original method in a draft pull request with a replacement method:
+ * 
+ * fun someMethod(input1, input2) {
+ *  const output = someMethodORIGINAL(input1, input2);
+ *  Debug.addMessage({ input: {input1, input2}, output }).catch(Catch.reportErr);
+ *  return output;
+ * }
+ *
+ * In async methods, the call can be arranged like this:
+ * await Debug.addMessage({input, output});
+ * 
+ * Upon test completion, the data can be extracted by the test framework with  
+ */
 export class Debug {
-  public static readDatabase = async (): Promise<any[] | undefined> => {
+  /**
+   * Extracts all the stored messages from the `debug` database, also deleting them
+   */
+  public static readDatabase = async (): Promise<any[]> => {
     const db = await Debug.openDatabase();
     const records: any[] = [];
     const tx = db.transaction(['messages'], 'readwrite');
@@ -22,6 +42,9 @@ export class Debug {
     return records;
   }
 
+  /**
+  * Add an arbitrary message to `debug` database
+  */
   public static addMessage = async (message: any): Promise<void> => {
     const db = await Debug.openDatabase();
     const tx = db.transaction(['messages'], 'readwrite');

--- a/test/source/platform/debug.ts
+++ b/test/source/platform/debug.ts
@@ -1,0 +1,17 @@
+/* ©️ 2016 - present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com */
+
+'use strict';
+
+export class Debug {
+  private static DATA: any[] = [];
+
+  public static readDatabase = async (): Promise<any[] | undefined> => {
+    const old = Debug.DATA;
+    Debug.DATA = [];
+    return old;
+  }
+
+  public static addMessage = async (message: any): Promise<void> => {
+    Debug.DATA.push(message);
+  }
+}

--- a/test/source/platform/debug.ts
+++ b/test/source/platform/debug.ts
@@ -5,7 +5,7 @@
 export class Debug {
   private static DATA: any[] = [];
 
-  public static readDatabase = async (): Promise<any[] | undefined> => {
+  public static readDatabase = async (): Promise<any[]> => {
     const old = Debug.DATA;
     Debug.DATA = [];
     return old;

--- a/test/source/test.ts
+++ b/test/source/test.ts
@@ -60,12 +60,12 @@ ava.before('set config and mock api', async t => {
 const testWithBrowser = (acct: CommonAcct | undefined, cb: (t: AvaContext, browser: BrowserHandle) => Promise<void>, flag?: 'FAILING'): ava.Implementation<{}> => {
   return async (t: AvaContext) => {
     await browserPool.withNewBrowserTimeoutAndRetry(async (t, browser) => {
-      const page = await browser.newPage(t, TestUrls.extension('chrome/dev/ci_unit_test.htm'));
       if (acct) {
         await BrowserRecipe.setUpCommonAcct(t, browser, acct, !isMock);
       }
       await cb(t, browser);
       try {
+        const page = await browser.newPage(t, TestUrls.extension('chrome/dev/ci_unit_test.htm'));
         const items = await page.target.evaluate(() => (window as any).Debug.readDatabase());
         if (items.length > 0) {
           console.info('debug messages: ', JSON.stringify(items), '\n');


### PR DESCRIPTION
This PR dumps contents of `debug` IndexedDB entries.
These entries are supposed to be populated by `Debug.addMessage` calls in various test branches.
close #3482

@tomholub I tried adding this line
```
Debug.addMessage({ origText }).then(undefined, undefined);
```
inside `MsgBlockParser.detectBlocks` (as it is synchronous) and the input was successfully retrieved from the database upon test completion.
But is there a slight risk that we're trying to dump before completion of previous database transaction in this case?


