### PR TITLE
refactored has_pgp, last_use and pubkey_last_check to camelCase

### DIFF
--- a/extension/chrome/elements/add_pubkey.ts
+++ b/extension/chrome/elements/add_pubkey.ts
@@ -37,7 +37,7 @@ View.run(class AddPubkeyView extends View {
     for (const missingPubkeyEmail of this.missingPubkeyEmails) {
       Xss.sanitizeAppend('select.email', `<option value="${Xss.escape(missingPubkeyEmail)}">${Xss.escape(missingPubkeyEmail)}</option>`);
     }
-    for (const contact of await ContactStore.search(undefined, { has_pgp: true })) {
+    for (const contact of await ContactStore.search(undefined, { hasPgp: true })) {
       Xss.sanitizeAppend('select.copy_from_email', `<option value="${Xss.escape(contact.email)}">${Xss.escape(contact.email)}</option>`);
     }
     this.fetchKeyUi.handleOnPaste($('.pubkey'));

--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -411,7 +411,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
       const recipientsHasPgp: RecipientElement[] = [];
       for (const recipient of noPgpRecipients) {
         const [contact] = await ContactStore.get(undefined, [recipient.email]);
-        if (contact && contact.has_pgp) {
+        if (contact && contact.hasPgp) {
           $(recipient.element).removeClass('no_pgp').find('i').remove();
           clearInterval(this.addedPubkeyDbLookupInterval);
           recipientsHasPgp.push(recipient);
@@ -584,16 +584,16 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
     this.view.errModule.debug(`renderSearchRes len: ${contacts.length}`);
     // have pgp on top, no pgp bottom. Sort each groups by last use
     const sortedContacts = contacts.sort((a: ContactPreview, b: ContactPreview) => {
-      if (a.has_pgp && !b.has_pgp) {
+      if (a.hasPgp && !b.hasPgp) {
         return -1;
       }
-      if (!a.has_pgp && b.has_pgp) {
+      if (!a.hasPgp && b.hasPgp) {
         return 1;
       }
-      if ((a.last_use || 0) > (b.last_use || 0)) {
+      if ((a.lastUse || 0) > (b.lastUse || 0)) {
         return -1;
       }
-      if ((a.last_use || 0) < (b.last_use || 0)) {
+      if ((a.lastUse || 0) < (b.lastUse || 0)) {
         return 1;
       }
       return 0;
@@ -603,7 +603,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
       let ulHtml = '';
       for (const contact of renderableContacts) {
         ulHtml += `<li class="select_contact" email="${Xss.escape(contact.email.replace(/<\/?b>/g, ''))}">`;
-        if (contact.has_pgp) {
+        if (contact.hasPgp) {
           ulHtml += '<img class="lock-icon" src="/img/svgs/locked-icon-green.svg" />';
         } else {
           ulHtml += '<img class="lock-icon" src="/img/svgs/locked-icon-gray.svg" />';
@@ -835,7 +835,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
         'you an updated public key.' + this.recipientKeyIdText(contact));
     } else if (contact.pubkey) {
       recipient.status = RecipientStatus.HAS_PGP;
-      $(el).addClass("has_pgp");
+      $(el).addClass('has_pgp');
       Xss.sanitizePrepend(el, '<img class="lock-icon" src="/img/svgs/locked-icon.svg" />');
       $(el).attr('title', 'Does use encryption' + this.recipientKeyIdText(contact));
     } else {

--- a/extension/chrome/elements/compose-modules/compose-send-btn-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-send-btn-module.ts
@@ -120,7 +120,7 @@ export class ComposeSendBtnModule extends ViewModule<ComposeView> {
           return; // user has canceled the pass phrase dialog, or didn't respond to it in time
         }
       }
-      await ContactStore.update(undefined, Array.prototype.concat.apply([], Object.values(newMsgData.recipients)), { last_use: Date.now() });
+      await ContactStore.update(undefined, Array.prototype.concat.apply([], Object.values(newMsgData.recipients)), { lastUse: Date.now() });
       const msgObj = await GeneralMailFormatter.processNewMsg(this.view, newMsgData, senderKi, signingPrv);
       await this.finalizeSendableMsg(msgObj, senderKi);
       await this.doSendMsg(msgObj);

--- a/extension/chrome/elements/compose-modules/formatters/signed-msg-mail-formatter.ts
+++ b/extension/chrome/elements/compose-modules/formatters/signed-msg-mail-formatter.ts
@@ -32,7 +32,7 @@ export class SignedMsgMailFormatter extends BaseMailFormatter {
       newMsg.plaintext = newMsg.plaintext.split('\n').map(l => l.replace(/\s+$/g, '')).join('\n').trim();
       const signedData = await MsgUtil.sign(signingPrv, newMsg.plaintext);
       const allContacts = [...newMsg.recipients.to || [], ...newMsg.recipients.cc || [], ...newMsg.recipients.bcc || []];
-      ContactStore.update(undefined, allContacts, { last_use: Date.now() }).catch(Catch.reportErr);
+      ContactStore.update(undefined, allContacts, { lastUse: Date.now() }).catch(Catch.reportErr);
       return await SendableMsg.createPgpInline(this.acctEmail, this.headers(newMsg), signedData, attachments);
     }
     // pgp/mime detached signature - it must be signed later, while being mime-encoded

--- a/extension/chrome/elements/pgp_pubkey.ts
+++ b/extension/chrome/elements/pgp_pubkey.ts
@@ -128,7 +128,7 @@ View.run(class PgpPubkeyView extends View {
     } else {
       const [contact] = await ContactStore.get(undefined, [String($('.input_email').val())]);
       $('.action_add_contact')
-        .text(contact?.has_pgp ? 'update key' : `import ${this.isExpired ? 'expired ' : ''}key`)
+        .text(contact?.hasPgp ? 'update key' : `import ${this.isExpired ? 'expired ' : ''}key`)
         .css('background-color', this.isExpired ? '#989898' : '');
     }
   }

--- a/extension/chrome/settings/modules/contacts.ts
+++ b/extension/chrome/settings/modules/contacts.ts
@@ -66,7 +66,7 @@ View.run(class ContactsView extends View {
   // --- PRIVATE
 
   private loadAndRenderContactList = async () => {
-    this.contacts = await ContactStore.search(undefined, { has_pgp: true, limit: 500, substring: String($('.input-search-contacts').val()) });
+    this.contacts = await ContactStore.search(undefined, { hasPgp: true, limit: 500, substring: String($('.input-search-contacts').val()) });
     let lineActionsHtml = '&nbsp;&nbsp;<a href="#" class="action_export_all">export all</a>&nbsp;&nbsp;' +
       '&nbsp;&nbsp;<a href="#" class="action_view_bulk_import" data-test="action-show-import-public-keys-form">import public keys</a>&nbsp;&nbsp;';
     if (this.orgRules.getCustomSksPubkeyServer()) {
@@ -109,7 +109,7 @@ View.run(class ContactsView extends View {
   }
 
   private actionExportAllKeysHandler = async () => {
-    const allArmoredPublicKeys = (await ContactStore.searchPubkeys(undefined, { has_pgp: true })).map(a => a!.trim()).join('\n');
+    const allArmoredPublicKeys = (await ContactStore.searchPubkeys(undefined, { hasPgp: true })).map(a => a!.trim()).join('\n');
     const exportFile = new Attachment({ name: 'public-keys-export.asc', type: 'application/pgp-keys', data: Buf.fromUtfStr(allArmoredPublicKeys) });
     Browser.saveToDownloads(exportFile);
   }
@@ -152,7 +152,7 @@ View.run(class ContactsView extends View {
       try {
         // parse will throw if the key is not recognized
         const pubkey = await KeyUtil.parse(armoredPubkey);
-        await ContactStore.update(undefined, email, { pubkey, last_use: Date.now() });
+        await ContactStore.update(undefined, email, { pubkey, lastUse: Date.now() });
         await this.loadAndRenderContactList();
       } catch (e) {
         await Ui.modal.warning('Cannot recognize a valid public key, please try again. Let us know at human@flowcrypt.com if you need help.');

--- a/extension/js/background_page/migrations.ts
+++ b/extension/js/background_page/migrations.ts
@@ -84,8 +84,8 @@ const moveContactsBatchToEmailsAndPubkeys = async (db: IDBDatabase, count?: numb
       update: {
         name: entry.name,
         pubkey,
-        last_use: entry.last_use,
-        pubkey_last_check: pubkey ? entry.pubkey_last_check : undefined
+        lastUse: entry.last_use,
+        pubkeyLastCheck: pubkey ? entry.pubkey_last_check : undefined
       } as ContactUpdate
     };
   }));

--- a/extension/js/common/core/crypto/key.ts
+++ b/extension/js/common/core/crypto/key.ts
@@ -51,10 +51,10 @@ export type Contact = {
   email: string;
   name: string | null;
   pubkey: Key | undefined;
-  has_pgp: 0 | 1;
+  hasPgp: 0 | 1;
   fingerprint: string | null;
-  last_use: number | null;
-  pubkey_last_check: number | null;
+  lastUse: number | null;
+  pubkeyLastCheck: number | null;
   expiresOn: number | null;
 };
 

--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -704,7 +704,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
                   }
                 } catch (e) {
                   ApiErr.reportIfSignificant(e);
-                  // this is a low-importance request, so evaluate has_pgp as false on errors
+                  // this is a low-importance request, so evaluate hasPgp as false on errors
                   // this way faulty requests wouldn't unnecessarily repeat and overwhelm Attester
                   this.recipientHasPgpCache[email] = false;
                   everyoneUsesEncryption = false;

--- a/test/source/platform/store/contact-store.ts
+++ b/test/source/platform/store/contact-store.ts
@@ -68,7 +68,7 @@ export class ContactStore {
       pubkey: pk,
       hasPgp: 1, // number because we use it for sorting
       fingerprint: pk.id,
-      lastUse: lastUse,
+      lastUse,
       pubkeyLastCheck: lastCheck,
     } as Contact;
     return contact;

--- a/test/source/platform/store/contact-store.ts
+++ b/test/source/platform/store/contact-store.ts
@@ -11,7 +11,7 @@ export type ContactUpdate = {
   email?: string;
   name?: string | null;
   pubkey?: Key;
-  last_use?: number | null;
+  lastUse?: number | null;
 };
 
 export class ContactStore {
@@ -44,7 +44,7 @@ export class ContactStore {
       updated.pubkey = key;
       updated.fingerprint = key.id;
       updated.expiresOn = key.expiration ? Number(key.expiration) : null;
-      updated.has_pgp = 1;
+      updated.hasPgp = 1;
     }
   }
 
@@ -54,10 +54,10 @@ export class ContactStore {
         email,
         name: name || null,
         pubkey: undefined,
-        has_pgp: 0, // number because we use it for sorting
+        hasPgp: 0, // number because we use it for sorting
         fingerprint: null,
-        last_use: lastUse || null,
-        pubkey_last_check: null,
+        lastUse: lastUse || null,
+        pubkeyLastCheck: null,
         expiresOn: null
       };
     }
@@ -66,10 +66,10 @@ export class ContactStore {
       email,
       name,
       pubkey: pk,
-      has_pgp: 1, // number because we use it for sorting
+      hasPgp: 1, // number because we use it for sorting
       fingerprint: pk.id,
-      last_use: lastUse,
-      pubkey_last_check: lastCheck,
+      lastUse: lastUse,
+      pubkeyLastCheck: lastCheck,
     } as Contact;
     return contact;
   }

--- a/test/source/tests/browser-unit-tests/unit-ContactStore.js
+++ b/test/source/tests/browser-unit-tests/unit-ContactStore.js
@@ -41,26 +41,26 @@ BROWSER_UNIT_TEST_NAME(`ContactStore is able to search by partial email address`
   });
   await ContactStore.save(undefined, [contactABBDEF, contactABCDEF, contactABCDDF, contactABDDEF,
     contactABCDVWXYZHELLOCOM]);
-  const contactsABC = await ContactStore.search(undefined, { has_pgp: true, substring: 'abc' });
+  const contactsABC = await ContactStore.search(undefined, { hasPgp: true, substring: 'abc' });
   if (contactsABC.length !== 3) {
     throw Error(`Expected 3 contacts to match "abc" but got "${contactsABC.length}"`);
   }
-  const contactsABCD = await ContactStore.search(undefined, { has_pgp: true, substring: 'abcd' });
+  const contactsABCD = await ContactStore.search(undefined, { hasPgp: true, substring: 'abcd' });
   if (contactsABCD.length !== 3) {
     throw Error(`Expected 3 contacts to match "abcd" but got "${contactsABCD.length}"`);
   }
-  const contactsABCDE = await ContactStore.search(undefined, { has_pgp: true, substring: 'abcde' });
+  const contactsABCDE = await ContactStore.search(undefined, { hasPgp: true, substring: 'abcde' });
   if (contactsABCDE.length !== 1) {
     throw Error(`Expected 1 contact to match "abcde" but got "${contactsABCDE.length}"`);
   }
   if (contactsABCDE[0].email !== 'abcdef@test.com') {
     throw Error(`Expected "abcdef@test.com" but got "${contactsABCDE[0].email}"`);
   }
-  const contactsVWX = await ContactStore.search(undefined, { has_pgp: true, substring: 'vwx' });
+  const contactsVWX = await ContactStore.search(undefined, { hasPgp: true, substring: 'vwx' });
   if (contactsVWX.length !== 1) {
     throw Error(`Expected 1 contact to match "vwx" but got "${contactsVWX.length}"`);
   }
-  const contactsHEL = await ContactStore.search(undefined, { has_pgp: true, substring: 'hel' });
+  const contactsHEL = await ContactStore.search(undefined, { hasPgp: true, substring: 'hel' });
   if (contactsHEL.length !== 1) {
     throw Error(`Expected 1 contact to match "hel" but got "${contactsHEL.length}"`);
   }
@@ -104,7 +104,7 @@ BROWSER_UNIT_TEST_NAME(`ContactStore doesn't store smaller words in searchable w
   return 'pass';
 })();
 
-BROWSER_UNIT_TEST_NAME(`ContactStore.update updates correct 'pubkey_last_check'`);
+BROWSER_UNIT_TEST_NAME(`ContactStore.update updates correct 'pubkeyLastCheck'`);
 (async () => {
   const db = await ContactStore.dbOpen();
   const email = 'flowcrypt.compatibility@gmail.com';
@@ -146,8 +146,8 @@ BROWSER_UNIT_TEST_NAME(`ContactStore.update updates correct 'pubkey_last_check'`
   const pubkey1 = await KeyUtil.parse(testConstants.flowcryptcompatibilityPublicKey7FDE685548AEA788);
   const pubkey2 = await KeyUtil.parse(testConstants.flowcryptcompatibilityPublicKeyADAC279C95093207);
   const date1_1 = date2_0 + 1000;
-  // update entity 1 with pubkey_last_check = date1_1
-  await ContactStore.update(db, email, { pubkey_last_check: date1_1, pubkey: pubkey1 });
+  // update entity 1 with pubkeyLastCheck = date1_1
+  await ContactStore.update(db, email, { pubkeyLastCheck: date1_1, pubkey: pubkey1 });
   // extract the entities from the database
   entity1 = await getEntity(fp1);
   entity2 = await getEntity(fp2);
@@ -158,9 +158,9 @@ BROWSER_UNIT_TEST_NAME(`ContactStore.update updates correct 'pubkey_last_check'`
     throw Error(`Expected lastCheck=${date2_0} for ${fp2} but got ${entity2.lastCheck}`);
   }
   const date2_2 = date1_1 + 10000;
-  // updating with undefined value shouldn't modify pubkey_last_check
-  await ContactStore.update(db, email, { pubkey_last_check: undefined, pubkey: pubkey1 });
-  await ContactStore.update(db, email, { pubkey_last_check: date2_2, pubkey: pubkey2 });
+  // updating with undefined value shouldn't modify pubkeyLastCheck
+  await ContactStore.update(db, email, { pubkeyLastCheck: undefined, pubkey: pubkey1 });
+  await ContactStore.update(db, email, { pubkeyLastCheck: date2_2, pubkey: pubkey2 });
   // extract the entities from the database
   entity1 = await getEntity(fp1);
   entity2 = await getEntity(fp2);
@@ -170,7 +170,7 @@ BROWSER_UNIT_TEST_NAME(`ContactStore.update updates correct 'pubkey_last_check'`
   if (entity2.lastCheck !== date2_2) {
     throw Error(`Expected lastCheck=${date2_2} for ${fp2} but got ${entity2.lastCheck}`);
   }
-  // updating contact details without specifying a pubkey shouln't update pubkey_last_check
+  // updating contact details without specifying a pubkey shouln't update pubkeyLastCheck
   await ContactStore.update(db, email, { name: 'Some Name' });
   // extract the entities from the database
   entity1 = await getEntity(fp1);
@@ -228,10 +228,10 @@ BROWSER_UNIT_TEST_NAME(`ContactStore.update tests`);
   await compareEntities();
   const date = new Date();
   expectedObj2.lastUse = date.getTime();
-  await ContactStore.update(db, email2, { last_use: date });
+  await ContactStore.update(db, email2, { lastUse: date });
   await compareEntities();
   expectedObj2.lastUse = undefined;
-  await ContactStore.update(db, email2, { last_use: undefined });
+  await ContactStore.update(db, email2, { lastUse: undefined });
   await compareEntities();
   return 'pass';
 })();
@@ -245,11 +245,11 @@ BROWSER_UNIT_TEST_NAME(`ContactStore saves and returns dates as numbers`);
   const contact = await ContactStore.obj({ email, pubkey: testConstants.expiredPub, lastCheck, lastUse });
   await ContactStore.save(undefined, [contact]);
   const [loaded] = await ContactStore.get(undefined, [email]);
-  if (typeof loaded.last_use !== 'number') {
-    throw Error(`last_use was expected to be a number, but got ${typeof loaded.last_use}`);
+  if (typeof loaded.lastUse !== 'number') {
+    throw Error(`lastUse was expected to be a number, but got ${typeof loaded.lastUse}`);
   }
-  if (typeof loaded.pubkey_last_check !== 'number') {
-    throw Error(`pubkey_last_check was expected to be a number, but got ${typeof loaded.pubkey_last_check}`);
+  if (typeof loaded.pubkeyLastCheck !== 'number') {
+    throw Error(`pubkeyLastCheck was expected to be a number, but got ${typeof loaded.pubkeyLastCheck}`);
   }
   if (typeof loaded.expiresOn !== 'number') {
     throw Error(`expiresOn was expected to be a number, but got ${typeof loaded.expiresOn}`);

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -582,13 +582,13 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await composeFrame.waitAndClick('.swal2-cancel');
       await composeFrame.waitAndClick('@action-close-new-message');
       await inboxPage.waitTillGone('@container-new-message');
-      // check that contacts are ordered according to has_pgp and last_use
+      // check that contacts are ordered according to hasPgp and lastUse
       composeFrame = await InboxPageRecipe.openAndGetComposeFrame(inboxPage);
       await composeFrame.type('@input-to', 'testsearchorder');
       await expectContactsResultEqual(composeFrame, [
-        'testsearchorder3@flowcrypt.com', // has_pgp + last_use
-        'testsearchorder9@flowcrypt.com', // has_pgp
-        'testsearchorder5@flowcrypt.com', // last_use
+        'testsearchorder3@flowcrypt.com', // hasPgp + lastUse
+        'testsearchorder9@flowcrypt.com', // hasPgp
+        'testsearchorder5@flowcrypt.com', // lastUse
         'testsearchorder1@flowcrypt.com',
         'testsearchorder2@flowcrypt.com',
         'testsearchorder4@flowcrypt.com',


### PR DESCRIPTION
This PR replaces has_pgp, last_use and pubkey_last_check with hasPgp, lastUse and pubkeyLastCheck accordingly,
EXCEPT in: 1) CSS -- `has_pgp` is retained.
2) ContactV3 in migration from older version of the database.

close #3539


