### PR TITLE
Never reset Contact's name and lastUse

### DIFF
--- a/test/source/tests/browser-unit-tests/unit-ContactStore.js
+++ b/test/source/tests/browser-unit-tests/unit-ContactStore.js
@@ -226,6 +226,8 @@ BROWSER_UNIT_TEST_NAME(`ContactStore.update tests`);
   expectedObj1.name = 'New Name for contact 1';
   await ContactStore.update(db, email1, { name: expectedObj1.name });
   await compareEntities();
+  await ContactStore.update(db, email1, { name: undefined }); // won't affect the entity
+  await compareEntities();
   const date = new Date();
   expectedObj2.lastUse = date.getTime();
   await ContactStore.update(db, email2, { lastUse: date });

--- a/test/source/tests/browser-unit-tests/unit-ContactStore.js
+++ b/test/source/tests/browser-unit-tests/unit-ContactStore.js
@@ -230,8 +230,7 @@ BROWSER_UNIT_TEST_NAME(`ContactStore.update tests`);
   expectedObj2.lastUse = date.getTime();
   await ContactStore.update(db, email2, { lastUse: date });
   await compareEntities();
-  expectedObj2.lastUse = undefined;
-  await ContactStore.update(db, email2, { lastUse: undefined });
+  await ContactStore.update(db, email2, { lastUse: undefined }); // won't affect the entity
   await compareEntities();
   return 'pass';
 })();


### PR DESCRIPTION
This PR retains `name` and `lastUse` values of existing records
when `save` or `update` calls didn't have corresponding non-null values as parameters

close #3552

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
