### PR TITLE
Make the 'Secure Compose' button (almost) independent from Gmail styles

### DIFF
--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -51,6 +51,16 @@
   padding: 0;
 }
 
+.anZ.bhZ:not(.bym) #flowcrypt_new_message_button {
+  width: 40px;
+  height: 40px;
+  border-radius: 20px;
+}
+
+.anZ.bhZ:not(.bym) #flowcrypt_new_message_button::before {
+  min-width: 42px;
+}
+
 .aeN:not(.anZ) [class*=_destroyable].z0 {
   margin-bottom: 0 !important;
 }

--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -1,5 +1,60 @@
 /* © 2016-2018 FlowCrypt Limited. Limitations apply. Contact human@flowcrypt.com */
 
+/* Secure Compose button */
+#flowcrypt_new_message_button {
+  display: inline-flex;
+  align-items: center;
+  width: auto;
+  height: 48px;
+  margin: 0;
+  padding: 0 24px 0 0;
+  transition: box-shadow 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+  font-family: 'Google Sans', Roboto, RobotoDraft, Helvetica, Arial, sans-serif;
+  font-size: 0.875rem;
+  letter-spacing: 0.25px;
+  line-height: 32px;
+  background-color: #fff;
+  border: none;
+  border-radius: 24px;
+  box-shadow: 0 1px 2px 0 rgb(60 64 67 / 30%), 0 1px 3px 1px rgb(60 64 67 / 15%);
+  color: #3c4043;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-transform: none;
+  cursor: pointer;
+  user-select: none;
+  outline: 0;
+}
+
+#flowcrypt_new_message_button::before {
+  display: block;
+  content: '';
+  background-size: 24px;
+  min-width: 56px;
+  height: 48px;
+  background-image: url("/img/logo/logo.svg");
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+#flowcrypt_new_message_button:hover,
+#flowcrypt_new_message_button:focus {
+  box-shadow: 0 5px 10px 2px rgb(60 64 67 / 20%);
+}
+
+.bhZ:not(.bym) #flowcrypt_new_message_button {
+  width: 56px;
+  height: 56px;
+  border-radius: 28px;
+  font-size: 0;
+  padding: 0;
+}
+
+.aeN:not(.anZ) [class*=_destroyable].z0 {
+  margin-bottom: 0 !important;
+}
+
 /* notifications */
 div.webmail_notifications {
   position: absolute;
@@ -51,8 +106,6 @@ body.cryptup_outlook div.webmail_notifications div.webmail_notification { margin
 }
 
 /* buttons body.cryptup_inbox */
-body.cryptup_gmail_new .new_message_button::before { background-image: url("/img/logo/logo.svg") !important; }
-
 body.cryptup_inbox div.new_message_button {
   position: relative;
   width: 40px;

--- a/extension/js/common/inject.ts
+++ b/extension/js/common/inject.ts
@@ -26,7 +26,7 @@ export class Injector {
   private S: SelCache;
   private container: { [key: string]: Host } = {
     composeBtnSel: {
-      'gmail': 'div.aic',
+      'gmail': 'div.aeN',
       'outlook': 'div._fce_b',
       'settings': '#does_not_have',
     },
@@ -46,8 +46,7 @@ export class Injector {
     this.S = Ui.buildJquerySels({ // these are selectors that are not specific to any webmail variant
       body: 'body',
       compose_button_container: this.container.composeBtnSel[this.webmailName],
-      compose_button: 'div.new_message_button',
-      compose_button_label: '#cryptup_compose_button_label',
+      compose_button: '#flowcrypt_new_message_button',
       compose_window: 'div.new_message',
     });
   }

--- a/extension/js/common/xss-safe-factory.ts
+++ b/extension/js/common/xss-safe-factory.ts
@@ -213,10 +213,10 @@ export class XssSafeFactory {
 
   public btnCompose = (webmailName: WebMailName) => {
     if (webmailName === 'outlook') {
-      const btn = `<div class="new_message_button" title="New Secure Email"><img src="${this.srcImg('logo-19-19.png')}"></div>`;
+      const btn = `<div class="new_message_button" id="flowcrypt_new_message_button" title="New Secure Email"><img src="${this.srcImg('logo-19-19.png')}"></div>`;
       return `<div class="_fce_c ${this.destroyableCls} cryptup_compose_button_container" role="presentation">${btn}</div>`;
     } else {
-      const btn = `<div class="new_message_button T-I J-J5-Ji T-I-KE L3" id="flowcrypt_new_message_button" role="button" tabindex="0" data-test="action-secure-compose">Secure Compose</div>`;
+      const btn = `<div class="new_message_button" id="flowcrypt_new_message_button" role="button" tabindex="0" data-test="action-secure-compose">Secure Compose</div>`;
       return `<div class="${this.destroyableCls} z0">${btn}</div>`;
     }
   }


### PR DESCRIPTION
This PR places the 'Secure Compose' button under the Gmail logo and makes the styles of the 'Secure Compose' button independent from the layout. Because the layout can be different with different settings, e.g. Meet ebabled/disabled.

close #3558

**Tests**:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
