### PR TITLE
Prevent msgId path traversal workaround

### DIFF
--- a/extension/chrome/elements/pgp_block.ts
+++ b/extension/chrome/elements/pgp_block.ts
@@ -52,7 +52,7 @@ export class PgpBlockView extends View {
     const senderEmail = Assert.urlParamRequire.string(uncheckedUrlParams, 'senderEmail');
     this.senderEmail = Str.parseEmail(senderEmail).email || '';
     this.msgId = Assert.urlParamRequire.optionalString(uncheckedUrlParams, 'msgId');
-    if (this.msgId?.includes('/')) {
+    if (/\.\.|\\|\//.test(decodeURI(this.msgId || ""))) {
       throw new Error('API path traversal forbidden');
     }
     this.encryptedMsgUrlParam = uncheckedUrlParams.message ? Buf.fromUtfStr(Assert.urlParamRequire.string(uncheckedUrlParams, 'message')) : undefined;

--- a/test/source/tests/decrypt.ts
+++ b/test/source/tests/decrypt.ts
@@ -491,6 +491,14 @@ export const defineDecryptTests = (testVariant: TestVariant, testWithBrowser: Te
       await pgpBlockPage.waitForContent('@container-err-text', 'API path traversal forbidden');
     }));
 
+    ava.default(`decrypt - try path traversal forward slash workaround`, testWithBrowser('compatibility', async (t, browser) => {
+      const params = "?frame_id=frame_TWloVRhvZE&message=&message_id=..\\test&senderEmail=sender%40email.com&is_outgoing=___cu_false___&account_email=flowcrypt.compatibility%40gmail.com";
+      const pgpHostPage = await browser.newPage(t, `chrome/dev/ci_pgp_host_page.htm${params}`);
+      const pgpBlockPage = await pgpHostPage.getFrame(['pgp_block.htm']);
+      await pgpBlockPage.waitForSelTestState('ready', 5);
+      await pgpBlockPage.waitForContent('@container-err-text', 'API path traversal forbidden');
+    }));
+
     ava.default(`verify - sha1 shows error`, testWithBrowser('compatibility', async (t, browser) => {
       const msg = `-----BEGIN PGP MESSAGE-----
 


### PR DESCRIPTION
Prevents directory traversal by using a more robust defense. This change uses a regex to prevent the characters `.`, `/`, and 
 `\` from appearing in msgId. There was already a test for directory traversal, so I've added an additional one that tests for the workaround.

close https://github.com/FlowCrypt/flowcrypt-security/issues/134

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
