### PR TITLE
Use official stylelint vscode plugin

### DIFF
--- a/flowcrypt-browser.code-workspace
+++ b/flowcrypt-browser.code-workspace
@@ -13,7 +13,6 @@
       "typescript",
     ],
     "html.format.enable": false,
-    "stylelint.autoFixOnSave": true,
     "files.exclude": {
       "**/node_modules/**": true
     },
@@ -25,7 +24,8 @@
     "editor.tabSize": 2,
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": true,
-      "source.fixAll.tslint": true
+      "source.fixAll.tslint": true,
+      "source.fixAll.stylelint": true
     },
     "tslint.exclude": [
       "test/**/*.ts"
@@ -46,7 +46,7 @@
   "extensions": {
     "recommendations": [
       "dbaeumer.vscode-eslint",
-      "hex-ci.stylelint-plus",
+      "stylelint.vscode-stylelint",
       "ms-vscode.vscode-typescript-tslint-plugin",
       "philhindle.errorlens"
     ]


### PR DESCRIPTION
We are currently using the unofficial https://github.com/hex-ci/vscode-stylelint-plus plugin because the "autofix on save" feature.

Now, the "autofix on save" feature is available in the official extension, switching to it because it's maintained by the stylelint team.