### PR TITLE
Untie Key structure from Storage, removed unused 'raw' field

### DIFF
--- a/extension/js/background_page/migrations.ts
+++ b/extension/js/background_page/migrations.ts
@@ -2,7 +2,7 @@
 
 'use strict';
 
-import { Key, KeyInfo, KeyUtil } from '../common/core/crypto/key.js';
+import { KeyInfo, KeyUtil } from '../common/core/crypto/key.js';
 import { SmimeKey } from '../common/core/crypto/smime/smime-key.js';
 import { ContactStore, ContactUpdate, Email, Pubkey } from '../common/platform/store/contact-store.js';
 import { GlobalStore } from '../common/platform/store/global-store.js';
@@ -12,7 +12,7 @@ import { KeyStore } from '../common/platform/store/key-store.js';
 type ContactV3 = {
   email: string;
   name: string | null;
-  pubkey: Key | string | null;
+  pubkey: { rawArmored: string, raw: string } | string | null;
   has_pgp: 0 | 1;
   fingerprint: string | null;
   last_use: number | null;
@@ -146,7 +146,7 @@ const moveContactsBatchToEmailsAndPubkeys = async (db: IDBDatabase, count?: numb
   // transform
   const converted = await Promise.all(entries.map(async (entry) => {
     const armoredPubkey = (entry.pubkey && typeof entry.pubkey === 'object')
-      ? KeyUtil.armor(entry.pubkey as Key) : entry.pubkey as string;
+      ? (entry.pubkey.rawArmored ?? entry.pubkey.raw) : entry.pubkey as string;
     // parse again to re-calculate expiration-related fields etc.
     const pubkey = armoredPubkey ? await KeyUtil.parse(armoredPubkey) : undefined;
     return {

--- a/extension/js/common/core/crypto/key.ts
+++ b/extension/js/common/core/crypto/key.ts
@@ -180,15 +180,11 @@ export class KeyUtil {
   }
 
   public static armor = (pubkey: Key): string => {
-    if (pubkey.type === 'openpgp') {
-      return OpenPGPKey.armor(pubkey);
-    } else if (pubkey.type === 'x509') {
-      // some keys saved by older version may have `raw` as string, so fall back on it
-      const rawFields = pubkey as unknown as { rawArmored: string, raw: string };
-      return rawFields.rawArmored ?? rawFields.raw;
-    } else {
-      throw new Error('Unknown pubkey type: ' + pubkey.type);
+    const armored = (pubkey as unknown as { rawArmored: string }).rawArmored;
+    if (!armored) {
+      throw new Error('The Key object has no rawArmored field.');
     }
+    return armored;
   }
 
   public static diagnose = async (key: Key, passphrase: string): Promise<Map<string, string>> => {

--- a/extension/js/common/core/crypto/pgp/openpgp-key.ts
+++ b/extension/js/common/core/crypto/pgp/openpgp-key.ts
@@ -271,18 +271,6 @@ export class OpenPGPKey {
     }
   }
 
-  public static armor = (pubkey: Key): string => {
-    if (pubkey.type !== 'openpgp') {
-      throw new UnexpectedKeyTypeError(`Key type is ${pubkey.type}, expecting OpenPGP`);
-    }
-    // some keys saved by older version may have `raw` as string, so fall back on it
-    const extensions = pubkey as unknown as { rawArmored: string, raw: string };
-    if (!extensions.rawArmored && !extensions.raw) {
-      throw new Error('Object has type == "openpgp" but no raw key.');
-    }
-    return extensions.rawArmored ?? extensions.raw;
-  }
-
   public static keyFlagsToString = (flags: OpenPGP.enums.keyFlags): string => {
     const strs: string[] = [];
     if (flags & opgp.enums.keyFlags.encrypt_communication) {


### PR DESCRIPTION
This PR unties `Key` structure from ContactStorage

close #3578

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test (concerns migration only from previous versions)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
