### PR TITLE
Fix rendering attachments with double whitespaces in their filenames

### DIFF
--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -2028,8 +2028,8 @@ table#compose #fineuploader .qq-upload-list li {
 }
 
 table#compose #fineuploader .qq-upload-list li .qq-upload-file {
-  line-height: 1em;
-  height: 1.1em;
+  line-height: 18px;
+  height: 18px;
   color: black;
   overflow-y: hidden;
 }

--- a/extension/css/settings.css
+++ b/extension/css/settings.css
@@ -25,6 +25,8 @@ html {
   display: inline-block;
   margin-left: 4px;
   border: 1px solid #31a217;
+  border-radius: 3px;
+  padding: 0 5px;
 }
 
 #header-row .logo-row .subscription > button:focus {

--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -422,7 +422,7 @@ div#cryptup_dialog iframe.tall {
 }
 
 .swal2-container.ui-modal-attachment .swal2-html-container {
-  height: 100%;
+  height: 100vh;
   padding: 0;
 }
 

--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -504,7 +504,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
 
   private filterAttachments = (potentialMatches: JQueryEl | HTMLElement, regExp: RegExp) => {
     return $(potentialMatches).filter('span.aZo:visible, span.a5r:visible').find('span.aV3').filter(function () {
-      const name = this.innerText.trim();
+      const name = this.innerHTML.trim();
       return regExp.test(name);
     }).closest('span.aZo, span.a5r');
   }

--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -504,7 +504,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
 
   private filterAttachments = (potentialMatches: JQueryEl | HTMLElement, regExp: RegExp) => {
     return $(potentialMatches).filter('span.aZo:visible, span.a5r:visible').find('span.aV3').filter(function () {
-      const name = this.innerHTML.trim();
+      const name = $(this).text().trim();
       return regExp.test(name);
     }).closest('span.aZo, span.a5r');
   }


### PR DESCRIPTION
This PR fixes rendering attachments with double whitespaces in their filenames.

close #3642

`innerText` is the representation and should never be used as data:

![image](https://user-images.githubusercontent.com/6059356/118489955-19894980-b726-11eb-863b-7c86397efcba.png)


---

Also fixed some small styling issues:

1. Expired subscription badge:

Before | After
-|- 
<img width="202" alt="CleanShot 2021-05-17 at 13 16 38@2x" src="https://user-images.githubusercontent.com/6059356/118492520-c2d13f00-b728-11eb-8d28-9afd305a1f1a.png"> | <img width="212" alt="CleanShot 2021-05-17 at 13 16 57@2x" src="https://user-images.githubusercontent.com/6059356/118492546-ca90e380-b728-11eb-8409-0bfa29117090.png">

2. Attachment filenames with special chars like `Č`:

Before | After
-|- 
<img width="186" alt="CleanShot 2021-05-17 at 15 08 29@2x" src="https://user-images.githubusercontent.com/6059356/118492674-eb593900-b728-11eb-910a-49aece68c15b.png"> | <img width="189" alt="CleanShot 2021-05-17 at 15 08 53@2x" src="https://user-images.githubusercontent.com/6059356/118492700-f14f1a00-b728-11eb-972c-266c68bd1c97.png">

3. Fixed vertical alignments of attachments (missed this one in #3639)


----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
