### PR TITLE
Add guidance when forgot pass phrase in already set up extension

### DIFF
--- a/extension/chrome/elements/passphrase.htm
+++ b/extension/chrome/elements/passphrase.htm
@@ -35,6 +35,8 @@
       <input type="checkbox" name="forget" id="forget" class="forget" checked="checked">
       <label for="forget">Forget passphrase when I close the browser</label>
     </div>
+    <div class="separator" style="margin-top: 85px;"></div>
+    <a href id="lost-pass-phrase">Lost pass phrase?</a>
   </div>
 
   <script src="/lib/purify.js"></script>

--- a/extension/chrome/elements/passphrase.ts
+++ b/extension/chrome/elements/passphrase.ts
@@ -75,11 +75,11 @@ View.run(class PassphraseView extends View {
     $('.action_ok').click(this.setHandler(() => this.submitHandler()));
     $('#lost-pass-phrase').click(this.setHandler((el, ev) => {
       ev.preventDefault();
+      // tslint:disable-next-line:no-floating-promises
       Ui.modal.info(`
         <div style="text-align: initial">
           <strong>Do you have at least one other working device where
           you can still read your encrypted email?</strong>
-
           <p><strong>If yes:</strong> open the working device and go to
           <code>FlowCrypt Settings</code> > <code>Security</code> >
           <code>Change Pass Phrase</code>.<br>
@@ -87,7 +87,6 @@ View.run(class PassphraseView extends View {
           <a href class="reset-flowcrypt">reset FlowCrypt on this device</a>
           and use the new pass phrase during the recovery step when
           you set up FlowCrypt on this device again.
-
           <p><strong>If no:</strong> unfortunately, you will not be able to read
           previously encrypted emails regardless of what you do.
           You can <a href class="reset-flowcrypt">reset FlowCrypt on this device</a>

--- a/extension/chrome/elements/passphrase.ts
+++ b/extension/chrome/elements/passphrase.ts
@@ -75,7 +75,6 @@ View.run(class PassphraseView extends View {
     $('.action_ok').click(this.setHandler(() => this.submitHandler()));
     $('#lost-pass-phrase').click(this.setHandler((el, ev) => {
       ev.preventDefault();
-      // tslint:disable-next-line:no-floating-promises
       Ui.modal.info(`
         <div style="text-align: initial">
           <strong>Do you have at least one other working device where
@@ -93,7 +92,7 @@ View.run(class PassphraseView extends View {
           and then click <code>Skip recovery and set up encryption again</code>
           during recovery step.
         </div>
-      `, true);
+      `, true).catch(Catch.reportErr);
       $('.reset-flowcrypt').click(this.setHandler(async (el, ev) => {
         ev.preventDefault();
         if (await Settings.resetAccount(this.acctEmail)) {

--- a/extension/chrome/elements/passphrase.ts
+++ b/extension/chrome/elements/passphrase.ts
@@ -14,6 +14,7 @@ import { Xss } from '../../js/common/platform/xss.js';
 import { initPassphraseToggle } from '../../js/common/ui/passphrase-ui.js';
 import { KeyStore } from '../../js/common/platform/store/key-store.js';
 import { PassphraseStore } from '../../js/common/platform/store/passphrase-store.js';
+import { Settings } from '../../js/common/settings.js';
 
 View.run(class PassphraseView extends View {
   private readonly acctEmail: string;
@@ -72,13 +73,42 @@ View.run(class PassphraseView extends View {
     $('#passphrase').keyup(this.setHandler(() => this.renderNormalPpPrompt()));
     $('.action_close').click(this.setHandler(() => this.closeDialog()));
     $('.action_ok').click(this.setHandler(() => this.submitHandler()));
+    $('#lost-pass-phrase').click(this.setHandler((el, ev) => {
+      ev.preventDefault();
+      Ui.modal.info(`
+        <div style="text-align: initial">
+          <strong>Do you have at least one other working device where
+          you can still read your encrypted email?</strong>
+
+          <p><strong>If yes:</strong> open the working device and go to
+          <code>FlowCrypt Settings</code> > <code>Security</code> >
+          <code>Change Pass Phrase</code>.<br>
+          It will let you change it without knowing the previous one. When done,
+          <a href class="reset-flowcrypt">reset FlowCrypt on this device</a>
+          and use the new pass phrase during the recovery step when
+          you set up FlowCrypt on this device again.
+
+          <p><strong>If no:</strong> unfortunately, you will not be able to read
+          previously encrypted emails regardless of what you do.
+          You can <a href class="reset-flowcrypt">reset FlowCrypt on this device</a>
+          and then click <code>Skip recovery and set up encryption again</code>
+          during recovery step.
+        </div>
+      `, true);
+      $('.reset-flowcrypt').click(this.setHandler(async (el, ev) => {
+        ev.preventDefault();
+        if (await Settings.resetAccount(this.acctEmail)) {
+          this.closeDialog();
+        }
+      }));
+    }));
     $('#passphrase').keydown(this.setHandler((el, ev) => {
-      if (ev.which === 13) {
+      if (ev.key === 'Enter') {
         $('.action_ok').click();
       }
     }));
     $('body').on('keydown', this.setHandler((el, ev) => {
-      if (ev.which === 27) { // If 'ESC' key
+      if (ev.key === 'Escape') {
         this.closeDialog();
       }
     }));

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -2807,6 +2807,14 @@ div#cryptup_dialog iframe.tall {
 
 .display_none { display: none; }
 
+code {
+  padding: 0.2em 0.4em;
+  margin: 0;
+  font-size: 85%;
+  background-color: #f3f4f4;
+  border-radius: 6px;
+}
+
 .scrollbar-measure {
   position: absolute;
   top: -9999px;

--- a/extension/js/common/browser/ui.ts
+++ b/extension/js/common/browser/ui.ts
@@ -136,9 +136,10 @@ export class Ui {
   };
 
   public static modal = {
-    info: async (text: string): Promise<void> => {
+    info: async (text: string, isHTML: boolean = false): Promise<void> => {
+      text = isHTML ? Xss.htmlSanitize(text) : Xss.escape(text).replace(/\n/g, '<br>');
       await Ui.swal().fire({
-        html: Xss.escape(text).replace(/\n/g, '<br>'),
+        html: text,
         allowOutsideClick: false,
         customClass: {
           popup: 'ui-modal-info',


### PR DESCRIPTION
This PR provides guidance when forgot pass phrase in already set up extension.

close #3323

![CleanShot 2021-05-19 at 16 16 33](https://user-images.githubusercontent.com/6059356/118819124-b5998900-b8bd-11eb-93d9-8addb603e643.gif)


----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
