### PR TITLE
don't require user to click to verify signature on first pubkey load

### DIFF
--- a/extension/chrome/elements/pgp_block_modules/pgp-block-decrypt-module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp-block-decrypt-module.ts
@@ -79,7 +79,7 @@ export class PgpBlockViewDecryptModule {
               if (!decryptResult.success) {
                 return undefined;
               } else {
-                return decryptResult.signature
+                return decryptResult.signature;
               }
             }, plainSubject);
         }

--- a/extension/chrome/elements/pgp_block_modules/pgp-block-decrypt-module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp-block-decrypt-module.ts
@@ -73,7 +73,15 @@ export class PgpBlockViewDecryptModule {
           console.info(`re-fetching message ${this.view.msgId} from api because failed signature check: ${!this.msgFetchedFromApi ? 'full' : 'raw'}`);
           await this.initialize(true);
         } else {
-          await this.view.renderModule.decideDecryptedContentFormattingAndRender(result.content, Boolean(result.isEncrypted), result.signature, plainSubject);
+          await this.view.renderModule.decideDecryptedContentFormattingAndRender(result.content, Boolean(result.isEncrypted), result.signature,
+            async () => {
+              const decryptResult = await BrowserMsg.send.bg.await.pgpMsgDecrypt({ kisWithPp, encryptedData });
+              if (!decryptResult.success) {
+                return undefined;
+              } else {
+                return decryptResult.signature
+              }
+            }, plainSubject);
         }
       } else if (result.error.type === DecryptErrTypes.format) {
         if (this.canReadEmails && this.msgFetchedFromApi !== 'raw') {
@@ -112,7 +120,8 @@ export class PgpBlockViewDecryptModule {
       // sometimes signatures come wrongly percent-encoded. Here we check for typical "=3Dabcd" at the end
       const sigText = Buf.fromUtfStr(this.view.signature.replace('\n=3D', '\n='));
       const signatureResult = await BrowserMsg.send.bg.await.pgpMsgVerifyDetached({ plaintext: encryptedData, sigText });
-      await this.view.renderModule.decideDecryptedContentFormattingAndRender(encryptedData, false, signatureResult);
+      await this.view.renderModule.decideDecryptedContentFormattingAndRender(encryptedData, false, signatureResult,
+        async () => { return await BrowserMsg.send.bg.await.pgpMsgVerifyDetached({ plaintext: encryptedData, sigText }); });
     }
   }
 

--- a/extension/chrome/elements/pgp_block_modules/pgp-block-render-module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp-block-render-module.ts
@@ -76,9 +76,10 @@ export class PgpBlockViewRenderModule {
     }
   }
 
-  public decideDecryptedContentFormattingAndRender = async (decryptedBytes: Buf, isEncrypted: boolean, sigResult: VerifyRes | undefined, plainSubject?: string) => {
+  public decideDecryptedContentFormattingAndRender = async (decryptedBytes: Buf, isEncrypted: boolean, sigResult: VerifyRes | undefined,
+    retryVerification: () => Promise<VerifyRes | undefined>, plainSubject?: string) => {
     this.setFrameColor(isEncrypted ? 'green' : 'gray');
-    this.view.signatureModule.renderPgpSignatureCheckResult(sigResult);
+    this.view.signatureModule.renderPgpSignatureCheckResult(sigResult, retryVerification);
     const publicKeys: string[] = [];
     let renderableAttachments: Attachment[] = [];
     let decryptedContent = decryptedBytes.toUtfStr();

--- a/extension/chrome/elements/pgp_block_modules/pgp-block-signature-module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp-block-signature-module.ts
@@ -63,7 +63,8 @@ export class PgpBlockViewSignatureModule {
   /**
    * don't have appropriate pubkey by longid in contacts
    */
-  private renderPgpSignatureCheckMissingPubkeyOptions = async (signerLongid: string, senderEmail: string, retryVerification?: () => Promise<VerifyRes | undefined>): Promise<VerifyRes | undefined> => {
+  private renderPgpSignatureCheckMissingPubkeyOptions = async (signerLongid: string, senderEmail: string,
+    retryVerification?: () => Promise<VerifyRes | undefined>): Promise<VerifyRes | undefined> => {
     const render = (note: string, action: () => void) => $('#pgp_signature').addClass('neutral').find('.result').text(note).click(this.view.setHandler(action));
     try {
       if (senderEmail) { // we know who sent it

--- a/extension/chrome/elements/pgp_block_modules/pgp-block-signature-module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp-block-signature-module.ts
@@ -16,19 +16,24 @@ export class PgpBlockViewSignatureModule {
   constructor(private view: PgpBlockView) {
   }
 
-  public renderPgpSignatureCheckResult = (signature: VerifyRes | undefined) => {
-    if (signature) {
-      const signerEmail = signature.signer?.primaryUserId ? Str.parseEmail(signature.signer.primaryUserId).email : undefined;
-      $('#pgp_signature > .cursive > span').text(signerEmail || 'Unknown Signer');
-      if (signature.signer && !signature.contact) {
-        this.view.renderModule.doNotSetStateAsReadyYet = true; // so that body state is not marked as ready too soon - automated tests need to know when to check results
-        // todo signerEmail?
-        this.renderPgpSignatureCheckMissingPubkeyOptions(signature.signer.longid, this.view.senderEmail).then(() => { // async so that it doesn't block rendering
-          this.view.renderModule.doNotSetStateAsReadyYet = false;
-          Ui.setTestState('ready');
-          $('#pgp_block').css('min-height', '100px'); // signature fail can have a lot of text in it to render
-          this.view.renderModule.resizePgpBlockFrame();
-        }).catch(Catch.reportErr);
+  public renderPgpSignatureCheckResult = (signature: VerifyRes | undefined, retryVerification?: () => Promise<VerifyRes | undefined>) => {
+    this.view.renderModule.doNotSetStateAsReadyYet = true; // so that body state is not marked as ready too soon - automated tests need to know when to check results
+    if (signature?.signer && !signature.contact) {
+      this.renderPgpSignatureCheckMissingPubkeyOptions(signature.signer.longid, this.view.senderEmail, retryVerification).then((newSignature) => { // async so that it doesn't block rendering
+        if (newSignature) {
+          return this.renderPgpSignatureCheckResult(newSignature, undefined);
+        }
+        PgpBlockViewSignatureModule.setSigner(signature);
+        this.view.renderModule.doNotSetStateAsReadyYet = false;
+        Ui.setTestState('ready');
+        $('#pgp_block').css('min-height', '100px'); // signature fail can have a lot of text in it to render
+        this.view.renderModule.resizePgpBlockFrame();
+      }).catch(Catch.reportErr);
+    } else {
+      if (!signature) {
+        $('#pgp_signature').addClass('bad');
+        $('#pgp_signature > .cursive').remove();
+        $('#pgp_signature > .result').text('Message Not Signed');
       } else if (signature.error) {
         $('#pgp_signature').addClass('bad');
         $('#pgp_signature > .result').text(signature.error);
@@ -41,18 +46,24 @@ export class PgpBlockViewSignatureModule {
         $('#pgp_signature > .result').text('signature does not match');
         this.view.renderModule.setFrameColor('red');
       }
-    } else {
-      $('#pgp_signature').addClass('bad');
-      $('#pgp_signature > .cursive').remove();
-      $('#pgp_signature > .result').text('Message Not Signed');
+      if (signature) {
+        PgpBlockViewSignatureModule.setSigner(signature);
+      }
+      this.view.renderModule.doNotSetStateAsReadyYet = false;
+      Ui.setTestState('ready');
     }
-    $('#pgp_signature').css('block');
+    // $('#pgp_signature').css('block');
+  }
+
+  private static setSigner = (signature: VerifyRes): void => {
+    const signerEmail = signature.signer?.primaryUserId ? Str.parseEmail(signature.signer.primaryUserId).email : undefined;
+    $('#pgp_signature > .cursive > span').text(signerEmail || 'Unknown Signer');
   }
 
   /**
    * don't have appropriate pubkey by longid in contacts
    */
-  private renderPgpSignatureCheckMissingPubkeyOptions = async (signerLongid: string, senderEmail: string): Promise<void> => {
+  private renderPgpSignatureCheckMissingPubkeyOptions = async (signerLongid: string, senderEmail: string, retryVerification?: () => Promise<VerifyRes | undefined>): Promise<VerifyRes | undefined> => {
     const render = (note: string, action: () => void) => $('#pgp_signature').addClass('neutral').find('.result').text(note).click(this.view.setHandler(action));
     try {
       if (senderEmail) { // we know who sent it
@@ -60,22 +71,28 @@ export class PgpBlockViewSignatureModule {
         if (senderContactByEmail && senderContactByEmail.pubkey) {
           const foundId = senderContactByEmail.pubkey.id;
           render(`Fetched the right pubkey ${signerLongid} from keyserver, but will not use it because you have conflicting pubkey ${foundId} loaded.`, () => undefined);
-          return;
+          return undefined;
         }
         // ---> and user doesn't have pubkey for that email addr
         const { pubkeys } = await this.view.pubLookup.lookupEmail(senderEmail);
         if (!pubkeys.length) {
           render(`Missing pubkey ${signerLongid}`, () => undefined);
-          return;
+          return undefined;
         }
         // ---> and pubkey found on keyserver by sender email
         const { key: pubkey } = await BrowserMsg.send.bg.await.keyMatch({ pubkeys, longid: signerLongid });
         if (!pubkey) {
           render(`Fetched ${pubkeys.length} sender's pubkeys but message was signed with a different key: ${signerLongid}, will not verify.`, () => undefined);
-          return;
+          return undefined;
         }
         // ---> and longid it matches signature
         await ContactStore.update(undefined, senderEmail, { pubkey }); // <= TOFU auto-import
+        if (retryVerification) {
+          const newResult = await retryVerification();
+          if (newResult) {
+            return newResult;
+          }
+        }
         render('Fetched pubkey, click to verify', () => window.location.reload());
       } else { // don't know who sent it
         render('Cannot verify: missing pubkey, missing sender info', () => undefined);
@@ -89,6 +106,7 @@ export class PgpBlockViewSignatureModule {
         render(`Could not look up sender's pubkey due to network error, click to retry.`, () => window.location.reload());
       }
     }
+    return undefined;
   }
 
 }

--- a/extension/chrome/elements/pgp_block_modules/pgp-block-signature-module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp-block-signature-module.ts
@@ -13,6 +13,11 @@ import { Str } from '../../../js/common/core/common.js';
 
 export class PgpBlockViewSignatureModule {
 
+  private static setSigner = (signature: VerifyRes): void => {
+    const signerEmail = signature.signer?.primaryUserId ? Str.parseEmail(signature.signer.primaryUserId).email : undefined;
+    $('#pgp_signature > .cursive > span').text(signerEmail || 'Unknown Signer');
+  }
+
   constructor(private view: PgpBlockView) {
   }
 
@@ -53,11 +58,6 @@ export class PgpBlockViewSignatureModule {
       Ui.setTestState('ready');
     }
     // $('#pgp_signature').css('block');
-  }
-
-  private static setSigner = (signature: VerifyRes): void => {
-    const signerEmail = signature.signer?.primaryUserId ? Str.parseEmail(signature.signer.primaryUserId).email : undefined;
-    $('#pgp_signature > .cursive > span').text(signerEmail || 'Unknown Signer');
   }
 
   /**

--- a/test/source/tests/decrypt.ts
+++ b/test/source/tests/decrypt.ts
@@ -385,22 +385,12 @@ export const defineDecryptTests = (testVariant: TestVariant, testWithBrowser: Te
       await BrowserRecipe.pgpBlockVerifyDecryptedContent(t, browser, {
         params,
         content: ["1234"],
-        signature: ["Fetched pubkey, click to verify"]
-      });
-      await BrowserRecipe.pgpBlockVerifyDecryptedContent(t, browser, {
-        params,
-        content: ["1234"],
         signature: ["matching signature", "Flowcrypt.Compatibility@Protonmail.Com"]
       });
     }));
 
     ava.default('decrypt - verify encrypted+signed message', testWithBrowser('compatibility', async (t, browser) => {
       const params = `?frameId=none&message=&msgId=1617429dc55600db&senderEmail=martin%40politick.ca&isOutgoing=___cu_false___&acctEmail=flowcrypt.compatibility%40gmail.com`; // eslint-disable-line max-len
-      await BrowserRecipe.pgpBlockVerifyDecryptedContent(t, browser, {
-        params,
-        content: ['4) signed + encrypted email if supported'],
-        signature: ["Fetched pubkey, click to verify"]
-      });
       await BrowserRecipe.pgpBlockVerifyDecryptedContent(t, browser, {
         params,
         content: ['4) signed + encrypted email if supported'],
@@ -512,11 +502,6 @@ d6Z36//MsmczN00Wd60t9T+qyLz0T4/UG2Y9lgf367f3d+kYPE0LS7mXuFmjlPXfw0nKyVsSeFiu
 =Ruyn
 -----END PGP MESSAGE-----`;
       const params = `?frame_id=frame_TWloVRhvZE&message=${encodeURIComponent(msg)}&message_id=none&senderEmail=sha1%40sign.com&is_outgoing=___cu_false___&account_email=flowcrypt.compatibility%40gmail.com`;
-      await BrowserRecipe.pgpBlockVerifyDecryptedContent(t, browser, {
-        params,
-        content: ['test'],
-        signature: ["Fetched pubkey, click to verify"]
-      });
       await BrowserRecipe.pgpBlockVerifyDecryptedContent(t, browser, {
         params,
         content: ['test'],

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -186,7 +186,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       const urls = await gmailPage.getFramesUrls(['/chrome/elements/pgp_pubkey.htm'], { sleep: 10, appearIn: 20 });
       expect(urls.length).to.equal(1);
       await pageHasSecureReplyContainer(t, browser, gmailPage);
-      await testMinimumElementHeight(gmailPage, '.pgp_block.signedMsg', 120);
+      await testMinimumElementHeight(gmailPage, '.pgp_block.signedMsg', 90);
       await testMinimumElementHeight(gmailPage, '.pgp_block.publicKey', 120);
       const pubkeyPage = await browser.newPage(t, urls[0]);
       await pubkeyPage.waitForContent('@container-pgp-pubkey', 'Fingerprint: DC26 454A FB71 D18E ABBA D73D 1C7E 6D3C 5563 A941');
@@ -196,7 +196,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       const gmailPage = await openGmailPage(t, browser, '/FMfcgxwKjBTWTbDjXSJVjDjKlWJGbWQd');
       const urls = await gmailPage.getFramesUrls(['/chrome/elements/pgp_block.htm'], { sleep: 10, appearIn: 20 });
       expect(urls.length).to.equal(1);
-      await testMinimumElementHeight(gmailPage, '.pgp_block.signedMsg', 120);
+      await testMinimumElementHeight(gmailPage, '.pgp_block.signedMsg', 90);
       await testMinimumElementHeight(gmailPage, '.pgp_block.publicKey', 120);
       const url = urls[0].split('/chrome/elements/pgp_block.htm')[1];
       const signature = ['Dhartley@Verdoncollege.School.Nz', 'matching signature'];

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -186,7 +186,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       const urls = await gmailPage.getFramesUrls(['/chrome/elements/pgp_pubkey.htm'], { sleep: 10, appearIn: 20 });
       expect(urls.length).to.equal(1);
       await pageHasSecureReplyContainer(t, browser, gmailPage);
-      await testMinimumElementHeight(gmailPage, '.pgp_block.signedMsg', 90);
+      await testMinimumElementHeight(gmailPage, '.pgp_block.signedMsg', 80);
       await testMinimumElementHeight(gmailPage, '.pgp_block.publicKey', 120);
       const pubkeyPage = await browser.newPage(t, urls[0]);
       await pubkeyPage.waitForContent('@container-pgp-pubkey', 'Fingerprint: DC26 454A FB71 D18E ABBA D73D 1C7E 6D3C 5563 A941');
@@ -196,7 +196,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       const gmailPage = await openGmailPage(t, browser, '/FMfcgxwKjBTWTbDjXSJVjDjKlWJGbWQd');
       const urls = await gmailPage.getFramesUrls(['/chrome/elements/pgp_block.htm'], { sleep: 10, appearIn: 20 });
       expect(urls.length).to.equal(1);
-      await testMinimumElementHeight(gmailPage, '.pgp_block.signedMsg', 90);
+      await testMinimumElementHeight(gmailPage, '.pgp_block.signedMsg', 80);
       await testMinimumElementHeight(gmailPage, '.pgp_block.publicKey', 120);
       const url = urls[0].split('/chrome/elements/pgp_block.htm')[1];
       const signature = ['Dhartley@Verdoncollege.School.Nz', 'matching signature'];


### PR DESCRIPTION
This PR verifies signature as soon as a pubkey is auto-loaded from lookup etc.

close #3105
----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
