### PR TITLE
Add guidance when forgot pass phrase during setup

### DIFF
--- a/extension/chrome/elements/passphrase.ts
+++ b/extension/chrome/elements/passphrase.ts
@@ -89,8 +89,7 @@ View.run(class PassphraseView extends View {
           <p><strong>If no:</strong> unfortunately, you will not be able to read
           previously encrypted emails regardless of what you do.
           You can <a href class="reset-flowcrypt">reset FlowCrypt on this device</a>
-          and then click <code>Skip recovery and set up encryption again</code>
-          during recovery step.
+          and then click <code>Lost your pass phrase?</code> during recovery step.
         </div>
       `, true).catch(Catch.reportErr);
       $('.reset-flowcrypt').click(this.setHandler(async (el, ev) => {

--- a/extension/chrome/settings/setup.htm
+++ b/extension/chrome/settings/setup.htm
@@ -238,9 +238,8 @@
       <div class="wide line">
         <button class="button green longer action_recover_account" data-test="action-recover-account">RECOVER ACCOUNT</button>
       </div>
-      <div class="line line_skip_recovery">
-        <a href="#" class="action_skip_recovery">Skip recovery and set up encryption again. Your previous encrypted
-          emails will be unreadable.</a>
+      <div class="line line_skip_recovery center">
+        <a href="#" id="lost_pass_phrase">Lost your pass phrase?</a>
       </div>
       <div id="error_text_container" class="line">
         <div id="error_text">This password did not match your original setup.

--- a/extension/chrome/settings/setup.ts
+++ b/extension/chrome/settings/setup.ts
@@ -143,7 +143,7 @@ export class SetupView extends View {
     $('#button-go-back').off().click(this.setHandler(() => this.actionBackHandler()));
     $('#step_2_recovery .action_recover_account').click(this.setHandlerPrevent('double', () => this.setupRecoverKey.actionRecoverAccountHandler()));
     $('#step_4_more_to_recover .action_recover_remaining').click(this.setHandler(() => this.setupRecoverKey.actionRecoverRemainingKeysHandler()));
-    $('.action_skip_recovery').click(this.setHandler(() => this.setupRecoverKey.actionSkipRecoveryHandler()));
+    $('#lost_pass_phrase').click(this.setHandler(() => this.showLostPassPhraseModal()));
     $('.action_account_settings').click(this.setHandler(() => { window.location.href = Url.create('index.htm', { acctEmail: this.acctEmail }); }));
     $('.input_submit_key').click(this.setHandler(el => this.actionSubmitPublicKeyToggleHandler(el)));
     $('#step_0_found_key .action_manual_create_key, #step_1_easy_or_manual .action_manual_create_key').click(this.setHandler(() => this.setupRender.displayBlock('step_2a_manual_create')));
@@ -160,6 +160,28 @@ export class SetupView extends View {
   public actionBackHandler = () => {
     $('h1').text('Set Up');
     this.setupRender.displayBlock('step_1_easy_or_manual');
+  }
+
+  public showLostPassPhraseModal = () => {
+    Ui.modal.info(`
+        <div style="text-align: initial">
+          <p><strong>Do you have at least one working device where you can
+          still read your encrypted email?</strong></p>
+          <p><strong>If yes:</strong> open the working device and go to
+          <code>FlowCrypt Settings</code> > <code>Security</code> >
+          <code>Change Pass Phrase</code>.<br>
+          It will let you change it without knowing the previous one.
+          When done, <a href="#" class="reload_page">reload this page</a>
+          and use the new pass phrase.
+          <p><strong>If no:</strong> unfortunately, you will not be able to
+          read previously encrypted emails regardless of what you do.
+          You can <a href="#" class="action_skip_recovery">skip recovery
+          and create a new key instead</a>.
+          Your previous encrypted emails will remain unreadable.
+        </div>
+      `, true).catch(Catch.reportErr);
+    $('.action_skip_recovery').click(this.setHandler(() => this.setupRecoverKey.actionSkipRecoveryHandler()));
+    $('.reload_page').click(this.setHandler(() => window.location.reload()));
   }
 
   public actionSubmitPublicKeyToggleHandler = (target: HTMLElement) => {

--- a/extension/chrome/settings/setup/setup-recover-key.ts
+++ b/extension/chrome/settings/setup/setup-recover-key.ts
@@ -105,7 +105,7 @@ export class SetupRecoverKeyModule {
   }
 
   public renderAddKeyFromBackup = async () => { // at this point, account is already set up, and this page is showing in a lightbox after selecting "from backup" in add_key.htm
-    $('.profile-row, .skip_recover_remaining, .action_send, .action_account_settings, .action_skip_recovery').css({ display: 'none', visibility: 'hidden', opacity: 0 });
+    $('.profile-row, .skip_recover_remaining, .action_send, .action_account_settings, #lost_pass_phrase').css({ display: 'none', visibility: 'hidden', opacity: 0 });
     Xss.sanitizeRender($('h1').parent(), '<h1>Recover key from backup</h1>');
     $('.action_recover_account').text('load key from backup');
     try {

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -267,6 +267,7 @@ div.line {
 }
 div.wide.line { max-width: 850px; }
 div.line.left { text-align: left; }
+div.line.center { text-align: center; }
 
 div.line input[type=text],
 div.line input[type=email],
@@ -2811,6 +2812,7 @@ code {
   padding: 0.2em 0.4em;
   margin: 0;
   font-size: 85%;
+  color: #e83e8c;
   background-color: #f3f4f4;
   border-radius: 6px;
 }


### PR DESCRIPTION
This PR provides guidance when user forgot pass phrase during setup.

close #681


https://user-images.githubusercontent.com/6059356/119109385-cb2bc180-ba29-11eb-8d7f-c0e1cd33fbfb.mp4



----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
