### PR TITLE
Add .icon_white class

### DIFF
--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -111,6 +111,10 @@ span.gray { color: #b7b7b7; }
   background-color: #b7b7b7;
 }
 
+.icon_white {
+  filter: brightness(255);
+}
+
 .swal2-popup .swal2-styled.swal2-confirm,
 .swal2-popup .swal2-styled.swal2-cancel {
   padding: 7px 15px;


### PR DESCRIPTION
This PR allow to turn most of SVG icons into white ones.

In our codebase we mostly use SVG icons with `<img>` tags. This creates a limitation with styling, because it's not possible to affect SVG **images** like that, more details: https://stackoverflow.com/q/24933430

Thie `.icon_white` class will allow us a simple way to turn an icon into a white one: 

```html
<img src="revoked.svg" class="icon_white">
```

Importnat note: this technique will not work with icons with a fill color of `#000`. There should be at least `1` in all of the rgb channels, in other words at least `#010101`. More details: https://css-tricks.com/solved-with-css-colorizing-svg-backgrounds/

issue https://github.com/FlowCrypt/flowcrypt-browser/pull/3663#issuecomment-846378623

----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
