### PR TITLE
Disable the 'Send Options' button when disabling the 'Send' button

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-send-btn-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-send-btn-module.ts
@@ -66,12 +66,12 @@ export class ComposeSendBtnModule extends ViewModule<ComposeView> {
 
   public disableBtn = () => {
     this.view.S.cached('send_btn').removeClass('green').addClass('gray').prop('disabled', true);
-    this.view.S.cached('toggle_send_options').removeClass('green').addClass('gray');
+    this.view.S.cached('toggle_send_options').removeClass('green').addClass('gray').prop('disabled', true);
   }
 
   public enableBtn = () => {
     this.view.S.cached('send_btn').removeClass('gray').addClass('green').prop('disabled', false);
-    this.view.S.cached('toggle_send_options').removeClass('gray').addClass('green');
+    this.view.S.cached('toggle_send_options').removeClass('gray').addClass('green').prop('disabled', false);
   }
 
   public renderUploadProgress = (progress: number | undefined, progressRepresents: 'FIRST-HALF' | 'SECOND-HALF' | 'EVERYTHING') => {

--- a/extension/chrome/elements/compose.htm
+++ b/extension/chrome/elements/compose.htm
@@ -64,7 +64,7 @@
             <div id="input-container-to" data-sending-type="to" data-test="container-to">
               <span class="recipients recipients-to"></span>
               <input id="input_to" spellcheck="false" tabindex="1" placeholder="Add Recipient" data-test="input-to"
-                data-sending-type="to" autocomplete="false" />
+                data-sending-type="to" autocomplete="off" />
               <span class="container-cc-bcc-buttons" data-test="container-cc-bcc-buttons">
                 <button id="cc" class="cc" tabindex="20" data-test="action-show-cc">cc</button>
                 <button id="bcc" class="bcc" tabindex="21" data-test="action-show-bcc">bcc</button>
@@ -74,13 +74,13 @@
             <div id="input-container-cc" style="display: none;" data-sending-type="cc" data-test="container-cc">
               <span class="recipients recipients-cc"></span>
               <input spellcheck="false" tabindex="1" placeholder="Add cc" data-test="input-cc" data-sending-type="cc"
-                autocomplete="false" />
+                autocomplete="off" />
             </div>
             <!-- bcc -->
             <div id="input-container-bcc" style="display: none;" data-test="container-bcc" data-sending-type="bcc">
               <span class="recipients recipients-bcc"></span>
               <input spellcheck="false" tabindex="1" placeholder="Add bcc" data-test="input-bcc" data-sending-type="bcc"
-                autocomplete="false" />
+                autocomplete="off" />
             </div>
           </div>
           <div id="recipients_placeholder" class="collapsed" data-test="action-show-container-cc-bcc-buttons"

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -607,8 +607,10 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, '');
       await composePage.waitAndClick('@action-send', { delay: 1 });
       expect(await composePage.isDisabled('#send_btn')).to.be.true;
+      expect(await composePage.isDisabled('#toggle_send_options')).to.be.true;
       await composePage.waitAndRespondToModal('confirm', 'cancel', 'Send without a subject?');
       expect(await composePage.isDisabled('#send_btn')).to.be.false;
+      expect(await composePage.isDisabled('#toggle_send_options')).to.be.false;
     }));
 
     ava.default('compose - load contacts through API', testWithBrowser('ci.tests.gmail', async (t, browser) => {


### PR DESCRIPTION
This PR disables the 'Send Options' button when disabling the 'Send' button in order to prevent unexpected behaviors

close #3650

---

Also changed `autocomplete="false"` to `autocomplete="off"`, because `autocomplete` [is not a boolean attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefautocomplete) and was not working in Chrome:

<img width="481" alt="CleanShot 2021-05-23 at 12 24 13@2x" src="https://user-images.githubusercontent.com/6059356/119255071-66579f00-bbc2-11eb-92cc-77191e32423f.png">

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
