### PR TITLE
issue 3672 cleanup for web portal

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-storage-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-storage-module.ts
@@ -13,7 +13,6 @@ import { ViewModule } from '../../../js/common/view-module.js';
 import { ComposeView } from '../compose.js';
 import { KeyStore } from '../../../js/common/platform/store/key-store.js';
 import { AcctStore } from '../../../js/common/platform/store/acct-store.js';
-import { GlobalStore } from '../../../js/common/platform/store/global-store.js';
 import { ContactStore, ContactUpdate } from '../../../js/common/platform/store/contact-store.js';
 import { PassphraseStore } from '../../../js/common/platform/store/passphrase-store.js';
 import { Settings } from '../../../js/common/settings.js';
@@ -53,13 +52,6 @@ export class ComposeStorageModule extends ViewModule<ComposeView> {
     const drafts = draftStorage.drafts_reply || {};
     delete drafts[threadId];
     await AcctStore.set(this.view.acctEmail, { drafts_reply: drafts });
-  }
-
-  public addAdminCodes = async (shortId: string, codes: string[]) => {
-    const adminCodeStorage = await GlobalStore.get(['admin_codes']);
-    adminCodeStorage.admin_codes = adminCodeStorage.admin_codes || {};
-    adminCodeStorage.admin_codes[shortId] = { date: Date.now(), codes };
-    await GlobalStore.set(adminCodeStorage);
   }
 
   public collectAllAvailablePublicKeys = async (senderEmail: string, senderKi: KeyInfo, recipients: string[]): Promise<CollectPubkeysResult> => {

--- a/extension/js/common/api/account-server.ts
+++ b/extension/js/common/api/account-server.ts
@@ -52,14 +52,6 @@ export class AccountServer extends Api {
     return await FlowCryptComApi.messageToken(fcAuth);
   }
 
-  public messageExpiration = async (fcAuth: FcUuidAuth, adminCodes: string[], addDays?: number): Promise<BackendRes.ApirFcMsgExpiration> => {
-    return await FlowCryptComApi.messageExpiration(fcAuth, adminCodes, addDays);
-  }
-
-  public linkMessage = async (short: string): Promise<BackendRes.FcLinkMsg> => {
-    return await FlowCryptComApi.linkMessage(short);
-  }
-
   private isFesUsed = async (): Promise<boolean> => {
     const { fesUrl } = await AcctStore.get(this.acctEmail, ['fesUrl']);
     return Boolean(fesUrl);

--- a/extension/js/common/api/account-servers/flowcrypt-com-api.ts
+++ b/extension/js/common/api/account-servers/flowcrypt-com-api.ts
@@ -26,7 +26,7 @@ export namespace BackendRes {
   export type FcAccountSubscribe = { subscription: SubscriptionInfo };
   export type FcAccountCheck = { email: string | null, subscription: SubscriptionInfo | null };
   export type FcMsgToken = { token: string };
-  export type FcMsgUpload = { short: string, admin_code: string };
+  export type FcMsgUpload = { url: string };
   export type FcLinkMsg = { expire: string, deleted: boolean, url: string, expired: boolean };
   export type FcLinkMe$profile = {
     alias: string | null, name: string | null, photo: string | null, intro: string | null, web: string | null,
@@ -72,21 +72,6 @@ export class FlowCryptComApi extends Api {
   public static messageToken = async (fcAuth: FcUuidAuth): Promise<BackendRes.FcMsgToken> => {
     FlowCryptComApi.throwIfMissingUuid(fcAuth);
     return await FlowCryptComApi.request<BackendRes.FcMsgToken>('message/token', { ...fcAuth });
-  }
-
-  public static messageExpiration = async (fcAuth: FcUuidAuth, adminCodes: string[], addDays?: number): Promise<BackendRes.ApirFcMsgExpiration> => {
-    FlowCryptComApi.throwIfMissingUuid(fcAuth);
-    return await FlowCryptComApi.request<BackendRes.ApirFcMsgExpiration>('message/expiration', {
-      ...fcAuth,
-      admin_codes: adminCodes,
-      add_days: addDays || null, // tslint:disable-line:no-null-keyword
-    });
-  }
-
-  public static linkMessage = async (short: string): Promise<BackendRes.FcLinkMsg> => {
-    return await FlowCryptComApi.request<BackendRes.FcLinkMsg>('link/message', {
-      short,
-    });
   }
 
   private static request = async <RT>(path: string, vals: Dict<any>, fmt: ReqFmt = 'JSON', addHeaders: Dict<string> = {}, progressCbs?: ProgressCbs): Promise<RT> => {

--- a/extension/js/common/api/flowcrypt-website.ts
+++ b/extension/js/common/api/flowcrypt-website.ts
@@ -23,7 +23,6 @@ export class FlowCryptWebsite extends Api {
       api: BACKEND_API_HOST,
       me: `https://flowcrypt.com/me/${resource}`,
       pubkey: `https://flowcrypt.com/pub/${resource}`,
-      decrypt: `https://flowcrypt.com/${resource}`,
       web: 'https://flowcrypt.com/',
     } as Dict<string>)[type];
   }

--- a/extension/js/common/platform/store/global-store.ts
+++ b/extension/js/common/platform/store/global-store.ts
@@ -3,7 +3,7 @@
 import { BrowserMsg } from '../../browser/browser-msg.js';
 import { Env } from '../../browser/env.js';
 import { RawStore, AbstractStore } from './abstract-store.js';
-import { Dict, Value } from '../../core/common.js';
+import { Value } from '../../core/common.js';
 import { storageLocalSet, storageLocalGet, storageLocalRemove } from '../../browser/chrome.js';
 import { Catch } from '../catch.js';
 
@@ -15,7 +15,6 @@ export type GlobalStoreDict = {
   settings_seen?: boolean;
   hide_pass_phrases?: boolean;
   dev_outlook_allow?: boolean;
-  admin_codes?: Dict<StoredAdminCode>;
   install_mobile_app_notification_dismissed?: boolean;
   key_info_store_fingerprints_added?: boolean;
   contact_store_x509_fingerprints_and_longids_updated?: boolean;
@@ -23,7 +22,7 @@ export type GlobalStoreDict = {
 };
 
 export type GlobalIndex = 'version' | 'account_emails' | 'settings_seen' | 'hide_pass_phrases' |
-  'dev_outlook_allow' | 'admin_codes' | 'install_mobile_app_notification_dismissed' | 'key_info_store_fingerprints_added' |
+  'dev_outlook_allow' | 'install_mobile_app_notification_dismissed' | 'key_info_store_fingerprints_added' |
   'contact_store_x509_fingerprints_and_longids_updated' | 'contact_store_opgp_revoked_flags_updated';
 
 /**

--- a/test/source/mock/backend/backend-endpoints.ts
+++ b/test/source/mock/backend/backend-endpoints.ts
@@ -53,7 +53,7 @@ export const mockBackendEndpoints: HandlersDefinition = {
     return { sent: true, text: 'Feedback sent' };
   },
   '/api/message/upload': async ({ }) => {
-    return { url: 'https://flowcrypt.com/mockmsg000' };
+    return { short: 'mockmsg000' };
   },
   '/api/link/me': async ({ }, req) => {
     throw new Error(`${req.url} mock not implemented`);

--- a/test/source/mock/backend/backend-endpoints.ts
+++ b/test/source/mock/backend/backend-endpoints.ts
@@ -53,7 +53,7 @@ export const mockBackendEndpoints: HandlersDefinition = {
     return { sent: true, text: 'Feedback sent' };
   },
   '/api/message/upload': async ({ }) => {
-    return { short: '0000000000', url: 'https://example.com/msg-123', admin_code: 'mocked-admin-code' };
+    return { url: 'https://example.com/msg-123' };
   },
   '/api/link/message': async ({ }) => {
     return { "url": "https://example.com/msg-123", "repliable": "False", "expire": "2100-05-18 16:31:28", "expired": "False", "deleted": "False" };

--- a/test/source/mock/backend/backend-endpoints.ts
+++ b/test/source/mock/backend/backend-endpoints.ts
@@ -53,10 +53,7 @@ export const mockBackendEndpoints: HandlersDefinition = {
     return { sent: true, text: 'Feedback sent' };
   },
   '/api/message/upload': async ({ }) => {
-    return { url: 'https://example.com/msg-123' };
-  },
-  '/api/link/message': async ({ }) => {
-    return { "url": "https://example.com/msg-123", "repliable": "False", "expire": "2100-05-18 16:31:28", "expired": "False", "deleted": "False" };
+    return { url: 'https://flowcrypt.com/mockmsg000' };
   },
   '/api/link/me': async ({ }, req) => {
     throw new Error(`${req.url} mock not implemented`);

--- a/test/source/tests/flaky.ts
+++ b/test/source/tests/flaky.ts
@@ -97,7 +97,7 @@ export const defineFlakyTests = (testVariant: TestVariant, testWithBrowser: Test
       await ComposePageRecipe.sendAndClose(composePage, { timeout: 60, expectProgress: true });
     }));
 
-    ava.default.only('compose - send pwd encrypted msg & check on flowcrypt site', testWithBrowser('compatibility', async (t, browser) => {
+    ava.default('compose - send pwd encrypted msg & check on flowcrypt site', testWithBrowser('compatibility', async (t, browser) => {
       const msgPwd = 'super hard password for the message';
       const subject = 'PWD encrypted message with attachment';
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');

--- a/test/source/tests/flaky.ts
+++ b/test/source/tests/flaky.ts
@@ -97,7 +97,7 @@ export const defineFlakyTests = (testVariant: TestVariant, testWithBrowser: Test
       await ComposePageRecipe.sendAndClose(composePage, { timeout: 60, expectProgress: true });
     }));
 
-    ava.default('compose - send pwd encrypted msg & check on flowcrypt site', testWithBrowser('compatibility', async (t, browser) => {
+    ava.default.only('compose - send pwd encrypted msg & check on flowcrypt site', testWithBrowser('compatibility', async (t, browser) => {
       const msgPwd = 'super hard password for the message';
       const subject = 'PWD encrypted message with attachment';
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');


### PR DESCRIPTION
This PR cleans up deprecated functionality.

- [x] remove unused API calls `messageExpiration` and `messageLink` (deprecated / unused)
- [x] stop saving `admin_code` (deprecated / unused)
- [x] ~update code to stop using `short`, instead use `url` response field from backend~ compute the `url` field using returned `short` in the API client method itself

The actual backend already returns the `url` parameter that we newly use here.

issue #3672

----------------------------------

- Tests added or updated (mock updated to reflect changes, although from user perspective there are no changes in behavior)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
