### PR TITLE
Get rid of #cryptup_dialog

### DIFF
--- a/extension/chrome/elements/attachment.ts
+++ b/extension/chrome/elements/attachment.ts
@@ -104,8 +104,8 @@ export class AttachmentDownloadView extends View {
         }
       });
     }
-    BrowserMsg.addListener('passphrase_entry', async ({ entered, attachmentId }: Bm.PassphraseEntry) => {
-      if (entered && attachmentId === this.attachment.id) {
+    BrowserMsg.addListener('passphrase_entry', async ({ entered, initiatorFrameId }: Bm.PassphraseEntry) => {
+      if (entered && initiatorFrameId === this.frameId) {
         await this.previewAttachmentClickedHandler();
       } else {
         this.downloadInProgress = false;
@@ -249,7 +249,7 @@ export class AttachmentDownloadView extends View {
       this.attachment.length = this.size!;
     }
     const factory = new XssSafeFactory(this.acctEmail, this.parentTabId);
-    const iframeUrl = factory.srcPgpAttachmentIframe(this.attachment, this.isEncrypted, undefined, 'chrome/elements/attachment_preview.htm', errorDetailsOpened);
+    const iframeUrl = factory.srcPgpAttachmentIframe(this.attachment, this.isEncrypted, undefined, 'chrome/elements/attachment_preview.htm', errorDetailsOpened, this.frameId);
     BrowserMsg.send.showAttachmentPreview(this.parentTabId, { iframeUrl });
   }
 

--- a/extension/chrome/elements/attachment.ts
+++ b/extension/chrome/elements/attachment.ts
@@ -110,7 +110,7 @@ export class AttachmentDownloadView extends View {
         this.downloadButton.show();
         this.ppChangedPromiseCancellation.cancel = true; // update original object which is monitored by a promise
         this.ppChangedPromiseCancellation = { cancel: false }; // set to a new, not yet used object
-        BrowserMsg.send.closeSwal(this.parentTabId); // attachment preview
+        BrowserMsg.send.closeDialog(this.parentTabId); // attachment preview
       }
     });
     BrowserMsg.listen(this.tabId);

--- a/extension/chrome/elements/attachment.ts
+++ b/extension/chrome/elements/attachment.ts
@@ -104,13 +104,14 @@ export class AttachmentDownloadView extends View {
         }
       });
     }
-    BrowserMsg.addListener('passphrase_entry', async ({ entered }: Bm.PassphraseEntry) => {
-      if (!entered) {
+    BrowserMsg.addListener('passphrase_entry', async ({ entered, attachmentId }: Bm.PassphraseEntry) => {
+      if (entered && attachmentId === this.attachment.id) {
+        await this.previewAttachmentClickedHandler();
+      } else {
         this.downloadInProgress = false;
         this.downloadButton.show();
         this.ppChangedPromiseCancellation.cancel = true; // update original object which is monitored by a promise
         this.ppChangedPromiseCancellation = { cancel: false }; // set to a new, not yet used object
-        BrowserMsg.send.closeDialog(this.parentTabId); // attachment preview
       }
     });
     BrowserMsg.listen(this.tabId);

--- a/extension/chrome/elements/attachment_preview.ts
+++ b/extension/chrome/elements/attachment_preview.ts
@@ -55,7 +55,7 @@ View.run(class AttachmentPreviewView extends AttachmentDownloadView {
         }
         $('body').click((e) => {
           if (e.target === document.body || $('body').children().toArray().indexOf(e.target) !== -1) {
-            BrowserMsg.send.closeSwal(this.parentTabId);
+            BrowserMsg.send.closeDialog(this.parentTabId);
           }
         });
         $('#attachment-preview-download').css('display', 'flex').click((e) => {

--- a/extension/chrome/elements/attachment_preview.ts
+++ b/extension/chrome/elements/attachment_preview.ts
@@ -2,6 +2,7 @@
 
 'use strict';
 
+import { Assert } from '../../js/common/assert.js';
 import { Attachment } from '../../js/common/core/attachment.js';
 import { AttachmentDownloadView } from './attachment.js';
 import { AttachmentPreviewPdf } from '../../js/common/ui/attachment_preview_pdf.js';
@@ -13,16 +14,20 @@ import { MsgUtil, DecryptError, DecryptErrTypes, DecryptSuccess, DecryptionError
 import { View } from '../../js/common/view.js';
 import { Xss } from '../../js/common/platform/xss.js';
 import { Ui } from '../../js/common/browser/ui.js';
+import { Url } from '../../js/common/core/common.js';
 
 type AttachmentType = 'img' | 'txt' | 'pdf';
 
 declare const pdfjsLib: any; // tslint:disable-line:ban-types
 
 View.run(class AttachmentPreviewView extends AttachmentDownloadView {
+  protected readonly initiatorFrameId: string;
   private attachmentPreviewContainer = $('#attachment-preview-container');
 
   constructor() {
     super();
+    const uncheckedUrlParams = Url.parse(['initiatorFrameId']);
+    this.initiatorFrameId = Assert.urlParamRequire.string(uncheckedUrlParams, 'initiatorFrameId');
   }
 
   public render = async () => {
@@ -85,7 +90,7 @@ View.run(class AttachmentPreviewView extends AttachmentDownloadView {
     if ((result as DecryptSuccess).content) {
       return result.content;
     } else if ((result as DecryptError).error.type === DecryptErrTypes.needPassphrase) {
-      return BrowserMsg.send.passphraseDialog(this.parentTabId, { type: 'attachment', longids: (result as DecryptError).longids.needPassphrase, attachmentId: this.attachment.id });
+      return BrowserMsg.send.passphraseDialog(this.parentTabId, { type: 'attachment', longids: (result as DecryptError).longids.needPassphrase, initiatorFrameId: this.initiatorFrameId });
     }
     throw new DecryptionError(result as DecryptError);
   }

--- a/extension/chrome/elements/attachment_preview.ts
+++ b/extension/chrome/elements/attachment_preview.ts
@@ -10,7 +10,6 @@ import { BrowserMsg } from '../../js/common/browser/browser-msg.js';
 import { KeyStore } from '../../js/common/platform/store/key-store.js';
 import { PDFDocumentProxy } from '../../types/pdf.js';
 import { MsgUtil, DecryptError, DecryptErrTypes, DecryptSuccess, DecryptionError } from '../../js/common/core/crypto/pgp/msg-util.js';
-import { PassphraseStore } from '../../js/common/platform/store/passphrase-store.js';
 import { View } from '../../js/common/view.js';
 import { Xss } from '../../js/common/platform/xss.js';
 import { Ui } from '../../js/common/browser/ui.js';
@@ -86,11 +85,7 @@ View.run(class AttachmentPreviewView extends AttachmentDownloadView {
     if ((result as DecryptSuccess).content) {
       return result.content;
     } else if ((result as DecryptError).error.type === DecryptErrTypes.needPassphrase) {
-      BrowserMsg.send.passphraseDialog(this.parentTabId, { type: 'attachment', longids: (result as DecryptError).longids.needPassphrase });
-      if (! await PassphraseStore.waitUntilPassphraseChanged(this.acctEmail, (result as DecryptError).longids.needPassphrase, 1000, this.ppChangedPromiseCancellation)) {
-        return;
-      }
-      return await this.render();
+      return BrowserMsg.send.passphraseDialog(this.parentTabId, { type: 'attachment', longids: (result as DecryptError).longids.needPassphrase, attachmentId: this.attachment.id });
     }
     throw new DecryptionError(result as DecryptError);
   }

--- a/extension/chrome/elements/attachment_preview.ts
+++ b/extension/chrome/elements/attachment_preview.ts
@@ -21,13 +21,13 @@ type AttachmentType = 'img' | 'txt' | 'pdf';
 declare const pdfjsLib: any; // tslint:disable-line:ban-types
 
 View.run(class AttachmentPreviewView extends AttachmentDownloadView {
-  protected readonly initiatorFrameId: string;
+  protected readonly initiatorFrameId?: string;
   private attachmentPreviewContainer = $('#attachment-preview-container');
 
   constructor() {
     super();
     const uncheckedUrlParams = Url.parse(['initiatorFrameId']);
-    this.initiatorFrameId = Assert.urlParamRequire.string(uncheckedUrlParams, 'initiatorFrameId');
+    this.initiatorFrameId = Assert.urlParamRequire.optionalString(uncheckedUrlParams, 'initiatorFrameId');
   }
 
   public render = async () => {

--- a/extension/chrome/elements/passphrase.ts
+++ b/extension/chrome/elements/passphrase.ts
@@ -21,15 +21,17 @@ View.run(class PassphraseView extends View {
   private readonly parentTabId: string;
   private readonly longids: string[];
   private readonly type: string;
+  private readonly attachmentId?: string;
   private keysWeNeedPassPhraseFor: KeyInfo[] | undefined;
 
   constructor() {
     super();
-    const uncheckedUrlParams = Url.parse(['acctEmail', 'parentTabId', 'longids', 'type']);
+    const uncheckedUrlParams = Url.parse(['acctEmail', 'parentTabId', 'longids', 'type', 'attachmentId']);
     this.acctEmail = Assert.urlParamRequire.string(uncheckedUrlParams, 'acctEmail');
     this.parentTabId = Assert.urlParamRequire.string(uncheckedUrlParams, 'parentTabId');
     this.longids = Assert.urlParamRequire.string(uncheckedUrlParams, 'longids').split(',');
     this.type = Assert.urlParamRequire.oneof(uncheckedUrlParams, 'type', ['embedded', 'sign', 'message', 'draft', 'attachment', 'quote', 'backup']);
+    this.attachmentId = Assert.urlParamRequire.optionalString(uncheckedUrlParams, 'attachmentId');
   }
 
   public render = async () => {
@@ -124,9 +126,9 @@ View.run(class PassphraseView extends View {
     $('#passphrase').attr('placeholder', 'Please try again');
   }
 
-  private closeDialog = (entered: boolean = false) => {
-    BrowserMsg.send.passphraseEntry('broadcast', { entered });
+  private closeDialog = (entered: boolean = false, attachmentId?: string) => {
     BrowserMsg.send.closeDialog(this.parentTabId);
+    BrowserMsg.send.passphraseEntry('broadcast', { entered, attachmentId });
   }
 
   private submitHandler = async () => {
@@ -155,7 +157,7 @@ View.run(class PassphraseView extends View {
       }
     }
     if (atLeastOneMatched) {
-      this.closeDialog(true);
+      this.closeDialog(true, this.attachmentId);
     } else {
       this.renderFailedEntryPpPrompt();
       Catch.setHandledTimeout(() => this.renderNormalPpPrompt(), 1500);

--- a/extension/chrome/elements/passphrase.ts
+++ b/extension/chrome/elements/passphrase.ts
@@ -21,17 +21,17 @@ View.run(class PassphraseView extends View {
   private readonly parentTabId: string;
   private readonly longids: string[];
   private readonly type: string;
-  private readonly attachmentId?: string;
+  private readonly initiatorFrameId?: string;
   private keysWeNeedPassPhraseFor: KeyInfo[] | undefined;
 
   constructor() {
     super();
-    const uncheckedUrlParams = Url.parse(['acctEmail', 'parentTabId', 'longids', 'type', 'attachmentId']);
+    const uncheckedUrlParams = Url.parse(['acctEmail', 'parentTabId', 'longids', 'type', 'initiatorFrameId']);
     this.acctEmail = Assert.urlParamRequire.string(uncheckedUrlParams, 'acctEmail');
     this.parentTabId = Assert.urlParamRequire.string(uncheckedUrlParams, 'parentTabId');
     this.longids = Assert.urlParamRequire.string(uncheckedUrlParams, 'longids').split(',');
     this.type = Assert.urlParamRequire.oneof(uncheckedUrlParams, 'type', ['embedded', 'sign', 'message', 'draft', 'attachment', 'quote', 'backup']);
-    this.attachmentId = Assert.urlParamRequire.optionalString(uncheckedUrlParams, 'attachmentId');
+    this.initiatorFrameId = Assert.urlParamRequire.optionalString(uncheckedUrlParams, 'initiatorFrameId');
   }
 
   public render = async () => {
@@ -126,9 +126,9 @@ View.run(class PassphraseView extends View {
     $('#passphrase').attr('placeholder', 'Please try again');
   }
 
-  private closeDialog = (entered: boolean = false, attachmentId?: string) => {
+  private closeDialog = (entered: boolean = false, initiatorFrameId?: string) => {
     BrowserMsg.send.closeDialog(this.parentTabId);
-    BrowserMsg.send.passphraseEntry('broadcast', { entered, attachmentId });
+    BrowserMsg.send.passphraseEntry('broadcast', { entered, initiatorFrameId });
   }
 
   private submitHandler = async () => {
@@ -157,7 +157,7 @@ View.run(class PassphraseView extends View {
       }
     }
     if (atLeastOneMatched) {
-      this.closeDialog(true, this.attachmentId);
+      this.closeDialog(true, this.initiatorFrameId);
     } else {
       this.renderFailedEntryPpPrompt();
       Catch.setHandledTimeout(() => this.renderNormalPpPrompt(), 1500);

--- a/extension/chrome/settings/inbox/inbox.ts
+++ b/extension/chrome/settings/inbox/inbox.ts
@@ -122,22 +122,14 @@ export class InboxView extends View {
     BrowserMsg.addListener('close_new_message', async () => {
       $('div.new_message').remove();
     });
-    BrowserMsg.addListener('passphrase_dialog', async ({ longids, type }: Bm.PassphraseDialog) => {
-      if (!$('#cryptup_dialog').length) {
-        $('body').append(this.factory.dialogPassphrase(longids, type))  // xss-safe-factory;
-          .click(this.setHandler(() => { // click on the area outside the iframe
-            BrowserMsg.send.passphraseEntry('broadcast', { entered: false });
-            $('#cryptup_dialog').remove();
-          }));
-      }
+    BrowserMsg.addListener('passphrase_dialog', async ({ longids }: Bm.PassphraseDialog) => {
+      await this.factory.showAddPubkeyDialog(longids);
     });
     BrowserMsg.addListener('add_pubkey_dialog', async ({ emails }: Bm.AddPubkeyDialog) => {
-      if (!$('#cryptup_dialog').length) {
-        $('body').append(this.factory.dialogAddPubkey(emails)); // xss-safe-factory
-      }
+      await this.factory.showAddPubkeyDialog(emails);
     });
     BrowserMsg.addListener('close_dialog', async () => {
-      $('#cryptup_dialog').remove();
+      Swal.close();
     });
     BrowserMsg.addListener('close_swal', async () => {
       Swal.close();

--- a/extension/chrome/settings/inbox/inbox.ts
+++ b/extension/chrome/settings/inbox/inbox.ts
@@ -122,8 +122,8 @@ export class InboxView extends View {
     BrowserMsg.addListener('close_new_message', async () => {
       $('div.new_message').remove();
     });
-    BrowserMsg.addListener('passphrase_dialog', async ({ longids, type, attachmentId }: Bm.PassphraseDialog) => {
-      await this.factory.showPassphraseDialog(longids, type, attachmentId);
+    BrowserMsg.addListener('passphrase_dialog', async ({ longids, type, initiatorFrameId }: Bm.PassphraseDialog) => {
+      await this.factory.showPassphraseDialog(longids, type, initiatorFrameId);
     });
     BrowserMsg.addListener('add_pubkey_dialog', async ({ emails }: Bm.AddPubkeyDialog) => {
       await this.factory.showAddPubkeyDialog(emails);

--- a/extension/chrome/settings/inbox/inbox.ts
+++ b/extension/chrome/settings/inbox/inbox.ts
@@ -122,8 +122,8 @@ export class InboxView extends View {
     BrowserMsg.addListener('close_new_message', async () => {
       $('div.new_message').remove();
     });
-    BrowserMsg.addListener('passphrase_dialog', async ({ longids }: Bm.PassphraseDialog) => {
-      await this.factory.showAddPubkeyDialog(longids);
+    BrowserMsg.addListener('passphrase_dialog', async ({ longids, type }: Bm.PassphraseDialog) => {
+      await this.factory.showPassphraseDialog(longids, type);
     });
     BrowserMsg.addListener('add_pubkey_dialog', async ({ emails }: Bm.AddPubkeyDialog) => {
       await this.factory.showAddPubkeyDialog(emails);

--- a/extension/chrome/settings/inbox/inbox.ts
+++ b/extension/chrome/settings/inbox/inbox.ts
@@ -131,9 +131,6 @@ export class InboxView extends View {
     BrowserMsg.addListener('close_dialog', async () => {
       Swal.close();
     });
-    BrowserMsg.addListener('close_swal', async () => {
-      Swal.close();
-    });
     BrowserMsg.addListener('show_attachment_preview', async ({ iframeUrl }: Bm.ShowAttachmentPreview) => {
       await Ui.modal.attachmentPreview(iframeUrl);
     });

--- a/extension/chrome/settings/inbox/inbox.ts
+++ b/extension/chrome/settings/inbox/inbox.ts
@@ -122,8 +122,8 @@ export class InboxView extends View {
     BrowserMsg.addListener('close_new_message', async () => {
       $('div.new_message').remove();
     });
-    BrowserMsg.addListener('passphrase_dialog', async ({ longids, type }: Bm.PassphraseDialog) => {
-      await this.factory.showPassphraseDialog(longids, type);
+    BrowserMsg.addListener('passphrase_dialog', async ({ longids, type, attachmentId }: Bm.PassphraseDialog) => {
+      await this.factory.showPassphraseDialog(longids, type, attachmentId);
     });
     BrowserMsg.addListener('add_pubkey_dialog', async ({ emails }: Bm.AddPubkeyDialog) => {
       await this.factory.showAddPubkeyDialog(emails);

--- a/extension/chrome/settings/index.ts
+++ b/extension/chrome/settings/index.ts
@@ -110,7 +110,7 @@ View.run(class SettingsView extends View {
       this.reload(advanced);
     });
     BrowserMsg.addListener('add_pubkey_dialog', async ({ emails }: Bm.AddPubkeyDialog) => {
-      // todo: use Ui.modal.iframe_DANGEROUS just like passphrase_dialog does
+      // todo: use iframe_DANGEROUS just like passphrase_dialog does
       const factory = new XssSafeFactory(this.acctEmail!, this.tabId);
       window.open(factory.srcAddPubkeyDialog(emails, 'settings'), '_blank', 'height=680,left=100,menubar=no,status=no,toolbar=no,top=30,width=660');
     });

--- a/extension/chrome/settings/index.ts
+++ b/extension/chrome/settings/index.ts
@@ -129,9 +129,9 @@ View.run(class SettingsView extends View {
     BrowserMsg.addListener('open_google_auth_dialog', async ({ acctEmail, scopes }: Bm.OpenGoogleAuthDialog) => {
       await Settings.newGoogleAcctAuthPromptThenAlertOrForward(this.tabId, acctEmail, scopes);
     });
-    BrowserMsg.addListener('passphrase_dialog', async ({ longids, type }: Bm.PassphraseDialog) => {
+    BrowserMsg.addListener('passphrase_dialog', async ({ longids, type, attachmentId }: Bm.PassphraseDialog) => {
       const factory = new XssSafeFactory(this.acctEmail!, this.tabId);
-      await factory.showPassphraseDialog(longids, type);
+      await factory.showPassphraseDialog(longids, type, attachmentId);
     });
     BrowserMsg.addListener('notification_show_auth_popup_needed', async ({ acctEmail }: Bm.NotificationShowAuthPopupNeeded) => {
       this.notifications!.showAuthPopupNeeded(acctEmail);

--- a/extension/chrome/settings/index.ts
+++ b/extension/chrome/settings/index.ts
@@ -110,7 +110,7 @@ View.run(class SettingsView extends View {
       this.reload(advanced);
     });
     BrowserMsg.addListener('add_pubkey_dialog', async ({ emails }: Bm.AddPubkeyDialog) => {
-      // todo: use #cryptup_dialog just like passphrase_dialog does
+      // todo: use Ui.modal.iframe_DANGEROUS just like passphrase_dialog does
       const factory = new XssSafeFactory(this.acctEmail!, this.tabId);
       window.open(factory.srcAddPubkeyDialog(emails, 'settings'), '_blank', 'height=680,left=100,menubar=no,status=no,toolbar=no,top=30,width=660');
     });
@@ -130,16 +130,14 @@ View.run(class SettingsView extends View {
       await Settings.newGoogleAcctAuthPromptThenAlertOrForward(this.tabId, acctEmail, scopes);
     });
     BrowserMsg.addListener('passphrase_dialog', async ({ longids, type }: Bm.PassphraseDialog) => {
-      if (!$('#cryptup_dialog').length) {
-        const factory = new XssSafeFactory(this.acctEmail!, this.tabId);
-        $('body').append(factory.dialogPassphrase(longids, type)); // xss-safe-factory
-      }
+      const factory = new XssSafeFactory(this.acctEmail!, this.tabId);
+      await factory.showPassphraseDialog(longids, type);
     });
     BrowserMsg.addListener('notification_show_auth_popup_needed', async ({ acctEmail }: Bm.NotificationShowAuthPopupNeeded) => {
       this.notifications!.showAuthPopupNeeded(acctEmail);
     });
     BrowserMsg.addListener('close_dialog', async () => {
-      $('#cryptup_dialog').remove();
+      Swal.close();
     });
     BrowserMsg.listen(this.tabId);
     $('.show_settings_page').click(this.setHandler(async target => {

--- a/extension/chrome/settings/index.ts
+++ b/extension/chrome/settings/index.ts
@@ -110,7 +110,7 @@ View.run(class SettingsView extends View {
       this.reload(advanced);
     });
     BrowserMsg.addListener('add_pubkey_dialog', async ({ emails }: Bm.AddPubkeyDialog) => {
-      // todo: use iframe_DANGEROUS just like passphrase_dialog does
+      // todo: use Ui.modal.iframe just like passphrase_dialog does
       const factory = new XssSafeFactory(this.acctEmail!, this.tabId);
       window.open(factory.srcAddPubkeyDialog(emails, 'settings'), '_blank', 'height=680,left=100,menubar=no,status=no,toolbar=no,top=30,width=660');
     });
@@ -129,9 +129,9 @@ View.run(class SettingsView extends View {
     BrowserMsg.addListener('open_google_auth_dialog', async ({ acctEmail, scopes }: Bm.OpenGoogleAuthDialog) => {
       await Settings.newGoogleAcctAuthPromptThenAlertOrForward(this.tabId, acctEmail, scopes);
     });
-    BrowserMsg.addListener('passphrase_dialog', async ({ longids, type, attachmentId }: Bm.PassphraseDialog) => {
+    BrowserMsg.addListener('passphrase_dialog', async ({ longids, type, initiatorFrameId }: Bm.PassphraseDialog) => {
       const factory = new XssSafeFactory(this.acctEmail!, this.tabId);
-      await factory.showPassphraseDialog(longids, type, attachmentId);
+      await factory.showPassphraseDialog(longids, type, initiatorFrameId);
     });
     BrowserMsg.addListener('notification_show_auth_popup_needed', async ({ acctEmail }: Bm.NotificationShowAuthPopupNeeded) => {
       this.notifications!.showAuthPopupNeeded(acctEmail);

--- a/extension/chrome/settings/modules/decrypt.ts
+++ b/extension/chrome/settings/modules/decrypt.ts
@@ -60,7 +60,7 @@ View.run(class ManualDecryptView extends View {
       const attachment = new Attachment({ name: encrypted.name.replace(/\.(pgp|gpg|asc)$/i, ''), type: encrypted.type, data: result.content });
       Browser.saveToDownloads(attachment);
     } else if (result.error.type === DecryptErrTypes.needPassphrase) {
-      await this.factory!.showEmbeddedPassphraseDialog(result.longids.needPassphrase);
+      $('.passphrase_dialog').html(this.factory!.embeddedPassphrase(result.longids.needPassphrase)); // xss-safe-factory
     } else {
       console.info(result);
       await Ui.modal.error('These was a problem decrypting this file, details are in the console.');

--- a/extension/chrome/settings/modules/decrypt.ts
+++ b/extension/chrome/settings/modules/decrypt.ts
@@ -45,7 +45,7 @@ View.run(class ManualDecryptView extends View {
     const ids = this.attachmentUi.getAttachmentIds();
     if (ids.length === 1) {
       const origContent = $(button).html();
-      Xss.sanitizeRender(button, 'Decrypting.. ' + Ui.spinner('white'));
+      Xss.sanitizeRender(button, '<span>Decrypting..</span>' + Ui.spinner('white'));
       const collected = await this.attachmentUi.collectAttachment(ids[0]);
       await this.decryptAndDownload(collected);
       Xss.sanitizeRender('.action_decrypt_and_download', origContent);

--- a/extension/chrome/settings/modules/decrypt.ts
+++ b/extension/chrome/settings/modules/decrypt.ts
@@ -60,7 +60,7 @@ View.run(class ManualDecryptView extends View {
       const attachment = new Attachment({ name: encrypted.name.replace(/\.(pgp|gpg|asc)$/i, ''), type: encrypted.type, data: result.content });
       Browser.saveToDownloads(attachment);
     } else if (result.error.type === DecryptErrTypes.needPassphrase) {
-      $('.passphrase_dialog').html(this.factory!.embeddedPassphrase(result.longids.needPassphrase)); // xss-safe-factory
+      await this.factory!.showEmbeddedPassphraseDialog(result.longids.needPassphrase);
     } else {
       console.info(result);
       await Ui.modal.error('These was a problem decrypting this file, details are in the console.');

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -288,7 +288,6 @@ body#settings.whitebg {
 
 body#settings > div#content {
   margin-top: 70px;
-  margin-bottom: 150px;
   position: relative;
 }
 
@@ -1027,6 +1026,8 @@ body#settings > div#content.dialog {
   background: white;
   z-index: 2;
   margin-top: 0;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 body#settings > div#content.dialog h1 {
@@ -2756,45 +2757,6 @@ body#select_account .action_add_account::before {
   content: '';
   left: 19px;
   top: 13px;
-}
-
-/* cryptup dialog */
-div#cryptup_dialog {
-  position: fixed;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  margin: 0 auto;
-  z-index: 1100;
-  background-color: rgba(255, 255, 255, 0.85);
-}
-
-div#cryptup_dialog iframe {
-  position: absolute;
-  width: 640px;
-  height: 370px;
-  top: 50%;
-  left: 50%;
-  margin-left: -300px;
-  margin-top: -200px;
-  border: none;
-  box-shadow: 10px 10px 5px #888;
-  box-shadow: 0 0 25px #aaa;
-}
-
-div#cryptup_dialog iframe.short {
-  height: 300px;
-  margin-top: -300px;
-}
-
-div#cryptup_dialog iframe.medium {
-  height: 500px;
-  margin-top: -300px;
-}
-
-div#cryptup_dialog iframe.tall {
-  height: 780px;
-  margin-top: -390px;
 }
 
 .lightboxed {

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -165,8 +165,13 @@ span.gray { color: #b7b7b7; }
   padding: 0;
 }
 
-.swal2-popup.ui-modal-iframe .swal2-close { color: #666; }
-.swal2-popup.ui-modal-iframe iframe { max-width: 100%; }
+.swal2-popup.ui-modal-iframe .swal2-close { color: #999; }
+
+.swal2-popup.ui-modal-iframe iframe {
+  display: flex;
+  max-width: 100%;
+}
+
 .swal2-container.ui-modal-page { background: rgba(0, 0, 0, 0.6) !important; }
 
 .swal2-container.ui-modal-fullscreen { padding: 0; }

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -34,6 +34,7 @@
 }
 .button.long { width: 200px; }
 .button.longer { width: 250px; }
+.button > * { vertical-align: middle; }
 
 button.swal2-styled:focus,
 .button:focus {

--- a/extension/css/settings.css
+++ b/extension/css/settings.css
@@ -778,6 +778,7 @@ body#settings .settings-border .key_list {
   margin-left: 20px;
   cursor: pointer;
 }
+#settings.client > #banner > .action_finish_session img { height: 32px; }
 #settings.client .attachments { margin-top: 12px; }
 
 #settings.client .attachments span.pgp_attachment {

--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -207,6 +207,7 @@ body.cryptup_gmail .action_finish_session {
   display: flex;
   align-items: center;
   justify-content: center;
+  height: 28px;
   color: #000;
   text-decoration: none;
   background: rgba(200, 200, 200, 0.95);
@@ -222,7 +223,7 @@ body.cryptup_gmail .action_finish_session:hover {
 }
 
 body.cryptup_gmail .action_finish_session img {
-  height: 24px;
+  height: 18px;
   margin: 0 15px 0 -15px;
 }
 

--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -201,19 +201,18 @@ body.cryptup_gmail.cryptup_gmail_new div.ade.appended span.cryptup_convo_button 
 /* The 'End Pass Phrase Session' button */
 body.cryptup_gmail .action_finish_session {
   position: fixed;
-  bottom: 3px;
-  left: 50%;
-  width: 300px;
-  margin-left: -30px;
+  bottom: 0;
+  left: 0;
+  right: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   color: #000;
   text-decoration: none;
-  background: rgba(0, 0, 0, 0.2);
+  background: rgba(200, 200, 200, 0.95);
   padding: 6px 0;
   cursor: pointer;
-  z-index: 1;
+  z-index: 3;
   border-radius: 3px;
   opacity: 0.9;
 }

--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -366,48 +366,13 @@ body.cryptup_gmail div.recipients_use_encryption a {
   right: 20px;
 }
 
-/* cryptup dialog */
-div#cryptup_dialog {
-  position: fixed;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  margin: 0 auto;
-  z-index: 1100;
-  background-color: rgba(255, 255, 255, 0.85);
+.swal2-popup.ui-modal-iframe {
+  padding: 0;
+  border-radius: 0;
 }
 
-div#cryptup_dialog iframe {
-  position: absolute;
-  width: 640px;
-  height: 370px;
-  top: 50%;
-  left: 50%;
-  margin-left: -300px;
-  margin-top: -200px;
-  border: none;
-  box-shadow: 10px 10px 5px #888;
-  box-shadow: 0 0 25px #aaa;
-}
-
-div#cryptup_dialog iframe.short {
-  height: 300px;
-  margin-top: -300px;
-}
-
-div#cryptup_dialog iframe.medium {
-  height: 500px;
-  margin-top: -300px;
-}
-
-div#cryptup_dialog iframe.mediumtall {
-  height: 630px;
-  margin-top: -315px;
-}
-
-div#cryptup_dialog iframe.tall {
-  height: 780px;
-  margin-top: -390px;
+.swal2-popup.ui-modal-iframe .swal2-html-container {
+  padding: 0;
 }
 
 .swal2-container.ui-modal-attachment {

--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -375,6 +375,13 @@ body.cryptup_gmail div.recipients_use_encryption a {
   padding: 0;
 }
 
+.swal2-popup.ui-modal-iframe .swal2-close { color: #999; }
+
+.swal2-popup.ui-modal-iframe iframe {
+  display: flex;
+  max-width: 100%;
+}
+
 .swal2-container.ui-modal-attachment {
   padding: 0;
   background: rgba(0, 0, 0, 0.85) !important;

--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -201,9 +201,10 @@ body.cryptup_gmail.cryptup_gmail_new div.ade.appended span.cryptup_convo_button 
 /* The 'End Pass Phrase Session' button */
 body.cryptup_gmail .action_finish_session {
   position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  bottom: 3px;
+  left: 50%;
+  width: 300px;
+  margin-left: -150px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/extension/js/common/browser/browser-msg.ts
+++ b/extension/js/common/browser/browser-msg.ts
@@ -32,7 +32,7 @@ export namespace Bm {
   export type SetCss = { css: Dict<string>, traverseUp?: number, selector: string; };
   export type AddOrRemoveClass = { class: string, selector: string; };
   export type Settings = { path?: string, page?: string, acctEmail?: string, pageUrlParams?: UrlParams, addNewAcct?: boolean };
-  export type PassphraseDialog = { type: PassphraseDialogType, longids: string[] };
+  export type PassphraseDialog = { type: PassphraseDialogType, longids: string[], attachmentId?: string };
   export type ScrollToReplyBox = { replyMsgId: string };
   export type ScrollToCursorInReplyBox = { replyMsgId: string, cursorOffsetTop: number };
   export type NotificationShow = { notification: string, callbacks?: Dict<() => void> };
@@ -48,7 +48,7 @@ export namespace Bm {
   export type OpenGoogleAuthDialog = { acctEmail?: string, scopes?: string[] };
   export type OpenPage = { page: string, addUrlText?: string | UrlParams };
   export type StripeResult = { token: string };
-  export type PassphraseEntry = { entered: boolean; };
+  export type PassphraseEntry = { entered: boolean, attachmentId?: string };
   export type Db = { f: string, args: any[] };
   export type StoreSessionSet = { acctEmail: string, key: string, value: string | undefined };
   export type StoreSessionGet = { acctEmail: string, key: string };

--- a/extension/js/common/browser/browser-msg.ts
+++ b/extension/js/common/browser/browser-msg.ts
@@ -163,7 +163,6 @@ export class BrowserMsg {
     closeDialog: (dest: Bm.Dest) => BrowserMsg.sendCatch(dest, 'close_dialog', {}),
     closePage: (dest: Bm.Dest) => BrowserMsg.sendCatch(dest, 'close_page', {}),
     closeNewMessage: (dest: Bm.Dest) => BrowserMsg.sendCatch(dest, 'close_new_message', {}),
-    closeSwal: (dest: Bm.Dest) => BrowserMsg.sendCatch(dest, 'close_swal', {}),
     focusBody: (dest: Bm.Dest) => BrowserMsg.sendCatch(dest, 'focus_body', {}),
     focusFrame: (dest: Bm.Dest, bm: Bm.FocusFrame) => BrowserMsg.sendCatch(dest, 'focus_frame', bm),
     closeReplyMessage: (dest: Bm.Dest, bm: Bm.CloseReplyMessage) => BrowserMsg.sendCatch(dest, 'close_reply_message', bm),

--- a/extension/js/common/browser/browser-msg.ts
+++ b/extension/js/common/browser/browser-msg.ts
@@ -32,7 +32,7 @@ export namespace Bm {
   export type SetCss = { css: Dict<string>, traverseUp?: number, selector: string; };
   export type AddOrRemoveClass = { class: string, selector: string; };
   export type Settings = { path?: string, page?: string, acctEmail?: string, pageUrlParams?: UrlParams, addNewAcct?: boolean };
-  export type PassphraseDialog = { type: PassphraseDialogType, longids: string[], attachmentId?: string };
+  export type PassphraseDialog = { type: PassphraseDialogType, longids: string[], initiatorFrameId?: string };
   export type ScrollToReplyBox = { replyMsgId: string };
   export type ScrollToCursorInReplyBox = { replyMsgId: string, cursorOffsetTop: number };
   export type NotificationShow = { notification: string, callbacks?: Dict<() => void> };
@@ -48,7 +48,7 @@ export namespace Bm {
   export type OpenGoogleAuthDialog = { acctEmail?: string, scopes?: string[] };
   export type OpenPage = { page: string, addUrlText?: string | UrlParams };
   export type StripeResult = { token: string };
-  export type PassphraseEntry = { entered: boolean, attachmentId?: string };
+  export type PassphraseEntry = { entered: boolean, initiatorFrameId?: string };
   export type Db = { f: string, args: any[] };
   export type StoreSessionSet = { acctEmail: string, key: string, value: string | undefined };
   export type StoreSessionGet = { acctEmail: string, key: string };

--- a/extension/js/common/browser/ui.ts
+++ b/extension/js/common/browser/ui.ts
@@ -241,6 +241,7 @@ export class Ui {
       });
       Ui.activateModalPageLinkTags(); // in case the page itself has data-swal-page links
     },
+    // tslint:disable-next-line:variable-name
     iframe_DANGEROUS: async (iframeUrl_MUST_BE_XSS_SAFE: string, dataTest?: string): Promise<SweetAlertResult> => { // xss-dangerous-function
       const iframeWidth = Math.min(800, $('body').width()! - 200);
       const iframeHeight = $('body').height()! - ($('body').height()! > 800 ? 150 : 75);

--- a/extension/js/common/browser/ui.ts
+++ b/extension/js/common/browser/ui.ts
@@ -5,7 +5,7 @@
 import { ApiErr } from '../api/shared/api-error.js';
 import { Catch } from '../platform/catch.js';
 import { Dict, Url } from '../core/common.js';
-import Swal from 'sweetalert2';
+import Swal, { SweetAlertResult } from 'sweetalert2';
 import { Xss } from '../platform/xss.js';
 
 type NamedSels = Dict<JQuery<HTMLElement>>;
@@ -241,9 +241,12 @@ export class Ui {
       });
       Ui.activateModalPageLinkTags(); // in case the page itself has data-swal-page links
     },
-    iframe: async (iframeUrl: string, iframeWidth: number, iframeHeight: number): Promise<void> => {
-      await Ui.swal().fire({
+    iframe_DANGEROUS: async (iframeUrl_MUST_BE_XSS_SAFE: string): Promise<SweetAlertResult> => { // xss-dangerous-function
+      const iframeWidth = Math.min(800, $('body').width()! - 200);
+      const iframeHeight = $('body').height()! - ($('body').height()! > 800 ? 150 : 75);
+      return await Ui.swal().fire({
         didOpen: () => {
+          debugger
           $(Swal.getPopup()!).attr('data-test', 'dialog');
           $(Swal.getCloseButton()!).attr('data-test', 'dialog-close').blur();
         },
@@ -252,7 +255,7 @@ export class Ui {
           window.history.pushState('', '', urlWithoutPageParam);
         },
         keydownListenerCapture: true,
-        html: `<iframe src="${Xss.escape(iframeUrl)}" width="${iframeWidth}" height="${iframeHeight}" style="border: 0"></iframe>`,
+        html: `<iframe src="${iframeUrl_MUST_BE_XSS_SAFE}" width="${iframeWidth}" height="${iframeHeight}" style="border: 0"></iframe>`,
         width: 'auto',
         backdrop: 'rgba(0, 0, 0, 0.6)',
         showCloseButton: true,

--- a/extension/js/common/browser/ui.ts
+++ b/extension/js/common/browser/ui.ts
@@ -241,13 +241,12 @@ export class Ui {
       });
       Ui.activateModalPageLinkTags(); // in case the page itself has data-swal-page links
     },
-    iframe_DANGEROUS: async (iframeUrl_MUST_BE_XSS_SAFE: string): Promise<SweetAlertResult> => { // xss-dangerous-function
+    iframe_DANGEROUS: async (iframeUrl_MUST_BE_XSS_SAFE: string, dataTest?: string): Promise<SweetAlertResult> => { // xss-dangerous-function
       const iframeWidth = Math.min(800, $('body').width()! - 200);
       const iframeHeight = $('body').height()! - ($('body').height()! > 800 ? 150 : 75);
       return await Ui.swal().fire({
         didOpen: () => {
-          debugger
-          $(Swal.getPopup()!).attr('data-test', 'dialog');
+          $(Swal.getPopup()!).attr('data-test', dataTest || 'dialog');
           $(Swal.getCloseButton()!).attr('data-test', 'dialog-close').blur();
         },
         willClose: () => {

--- a/extension/js/common/browser/ui.ts
+++ b/extension/js/common/browser/ui.ts
@@ -241,8 +241,7 @@ export class Ui {
       });
       Ui.activateModalPageLinkTags(); // in case the page itself has data-swal-page links
     },
-    // tslint:disable-next-line:variable-name
-    iframe_DANGEROUS: async (iframeUrl_MUST_BE_XSS_SAFE: string, iframeHeight?: number, dataTest?: string): Promise<SweetAlertResult> => { // xss-dangerous-function
+    iframe: async (iframeUrl: string, iframeHeight?: number, dataTest?: string): Promise<SweetAlertResult> => {
       const iframeWidth = Math.min(800, $('body').width()! - 200);
       iframeHeight = iframeHeight || $('body').height()! - ($('body').height()! > 800 ? 150 : 75);
       return await Ui.swal().fire({
@@ -255,7 +254,7 @@ export class Ui {
           window.history.pushState('', '', urlWithoutPageParam);
         },
         keydownListenerCapture: true,
-        html: `<iframe src="${iframeUrl_MUST_BE_XSS_SAFE}" width="${iframeWidth}" height="${iframeHeight}" style="border: 0"></iframe>`,
+        html: `<iframe src="${Xss.escape(iframeUrl)}" width="${iframeWidth}" height="${iframeHeight}" style="border: 0"></iframe>`,
         width: 'auto',
         backdrop: 'rgba(0, 0, 0, 0.6)',
         showCloseButton: true,

--- a/extension/js/common/browser/ui.ts
+++ b/extension/js/common/browser/ui.ts
@@ -242,9 +242,9 @@ export class Ui {
       Ui.activateModalPageLinkTags(); // in case the page itself has data-swal-page links
     },
     // tslint:disable-next-line:variable-name
-    iframe_DANGEROUS: async (iframeUrl_MUST_BE_XSS_SAFE: string, dataTest?: string): Promise<SweetAlertResult> => { // xss-dangerous-function
+    iframe_DANGEROUS: async (iframeUrl_MUST_BE_XSS_SAFE: string, iframeHeight?: number, dataTest?: string): Promise<SweetAlertResult> => { // xss-dangerous-function
       const iframeWidth = Math.min(800, $('body').width()! - 200);
-      const iframeHeight = $('body').height()! - ($('body').height()! > 800 ? 150 : 75);
+      iframeHeight = iframeHeight || $('body').height()! - ($('body').height()! > 800 ? 150 : 75);
       return await Ui.swal().fire({
         didOpen: () => {
           $(Swal.getPopup()!).attr('data-test', dataTest || 'dialog');

--- a/extension/js/common/settings.ts
+++ b/extension/js/common/settings.ts
@@ -34,11 +34,7 @@ export class Settings {
   }
 
   public static renderSubPage = async (acctEmail: string | undefined, tabId: string, page: string, addUrlTextOrParams?: string | UrlParams) => {
-    await Ui.modal.iframe(
-      Settings.prepareNewSettingsLocationUrl(acctEmail, tabId, page, addUrlTextOrParams),
-      Math.min(800, $('body').width()! - 200),
-      $('body').height()! - ($('body').height()! > 800 ? 150 : 75)
-    );
+    await Ui.modal.iframe_DANGEROUS(Settings.prepareNewSettingsLocationUrl(acctEmail, tabId, page, addUrlTextOrParams)); // xss-safe-value
   }
 
   public static redirectSubPage = (acctEmail: string, parentTabId: string, page: string, addUrlTextOrParams?: string | UrlParams) => {

--- a/extension/js/common/settings.ts
+++ b/extension/js/common/settings.ts
@@ -34,7 +34,7 @@ export class Settings {
   }
 
   public static renderSubPage = async (acctEmail: string | undefined, tabId: string, page: string, addUrlTextOrParams?: string | UrlParams) => {
-    await Ui.modal.iframe_DANGEROUS(Settings.prepareNewSettingsLocationUrl(acctEmail, tabId, page, addUrlTextOrParams)); // xss-safe-value
+    await Ui.modal.iframe(Settings.prepareNewSettingsLocationUrl(acctEmail, tabId, page, addUrlTextOrParams));
   }
 
   public static redirectSubPage = (acctEmail: string, parentTabId: string, page: string, addUrlTextOrParams?: string | UrlParams) => {

--- a/extension/js/common/xss-safe-factory.ts
+++ b/extension/js/common/xss-safe-factory.ts
@@ -16,7 +16,6 @@ import { Ui } from './browser/ui.js';
 import { WebMailName } from './browser/env.js';
 import { Xss } from './platform/xss.js';
 import { SendAsAlias } from './platform/store/acct-store.js';
-import Swal from 'sweetalert2';
 
 type Placement = 'settings' | 'settings_compose' | 'default' | 'dialog' | 'gmail' | 'embedded' | 'compose';
 export type WebmailVariantString = undefined | 'html' | 'standard' | 'new';
@@ -178,7 +177,7 @@ export class XssSafeFactory {
 
   public showPassphraseDialog = async (longids: string[], type: PassphraseDialogType, initiatorFrameId?: string) => {
     const result = await Ui.modal.iframe(this.srcPassphraseDialog(longids, type, initiatorFrameId), 500, 'dialog-passphrase');
-    if (result.dismiss === Swal.DismissReason.backdrop || result.dismiss === Swal.DismissReason.esc) {
+    if (result.dismiss) { // dialog is dismissed by user interaction, not by closeDialog()
       BrowserMsg.send.passphraseEntry('broadcast', { entered: false });
     }
   }

--- a/extension/js/common/xss-safe-factory.ts
+++ b/extension/js/common/xss-safe-factory.ts
@@ -114,20 +114,27 @@ export class XssSafeFactory {
     return this.frameSrc(this.extUrl('chrome/elements/compose.htm'), { frameId: this.newId(), draftId });
   }
 
-  public srcPassphraseDialog = (longids: string[] = [], type: PassphraseDialogType, attachmentId?: string) => {
-    return this.frameSrc(this.extUrl('chrome/elements/passphrase.htm'), { type, longids, attachmentId });
+  public srcPassphraseDialog = (longids: string[] = [], type: PassphraseDialogType, initiatorFrameId?: string) => {
+    return this.frameSrc(this.extUrl('chrome/elements/passphrase.htm'), { type, longids, initiatorFrameId });
   }
 
   public srcAddPubkeyDialog = (emails: string[], placement: Placement) => {
     return this.frameSrc(this.extUrl('chrome/elements/add_pubkey.htm'), { emails, placement });
   }
 
-  public srcPgpAttachmentIframe = (a: Attachment, isEncrypted: boolean, parentTabId?: string, iframeUrl = 'chrome/elements/attachment.htm', errorDetailsOpened?: boolean) => {
+  public srcPgpAttachmentIframe = (
+    a: Attachment,
+    isEncrypted: boolean,
+    parentTabId?: string,
+    iframeUrl = 'chrome/elements/attachment.htm',
+    errorDetailsOpened?: boolean,
+    initiatorFrameId?: string
+  ) => {
     if (!a.id && !a.url && a.hasData()) { // data provided directly, pass as object url
       a.url = Browser.objUrlCreate(a.getData());
     }
     return this.frameSrc(this.extUrl(iframeUrl), {
-      frameId: this.newId(), msgId: a.msgId, name: a.name, type: a.type, size: a.length, attachmentId: a.id, url: a.url, isEncrypted, errorDetailsOpened
+      frameId: this.newId(), msgId: a.msgId, name: a.name, type: a.type, size: a.length, attachmentId: a.id, url: a.url, isEncrypted, errorDetailsOpened, initiatorFrameId
     }, parentTabId);
   }
 
@@ -168,8 +175,8 @@ export class XssSafeFactory {
     return `<link class="${this.destroyableCls}" rel="stylesheet" href="${this.extUrl(`css/${file}.css`)}" />`;
   }
 
-  public showPassphraseDialog = async (longids: string[], type: PassphraseDialogType, attachmentId?: string) => {
-    const result = await Ui.modal.iframe_DANGEROUS(this.srcPassphraseDialog(longids, type, attachmentId), 'dialog-passphrase'); // xss-safe-factory
+  public showPassphraseDialog = async (longids: string[], type: PassphraseDialogType, initiatorFrameId?: string) => {
+    const result = await Ui.modal.iframe_DANGEROUS(this.srcPassphraseDialog(longids, type, initiatorFrameId), 'dialog-passphrase'); // xss-safe-factory
     if (result.isDismissed) {
       BrowserMsg.send.passphraseEntry('broadcast', { entered: false });
     }

--- a/extension/js/common/xss-safe-factory.ts
+++ b/extension/js/common/xss-safe-factory.ts
@@ -177,14 +177,14 @@ export class XssSafeFactory {
   }
 
   public showPassphraseDialog = async (longids: string[], type: PassphraseDialogType, initiatorFrameId?: string) => {
-    const result = await Ui.modal.iframe_DANGEROUS(this.srcPassphraseDialog(longids, type, initiatorFrameId), 500, 'dialog-passphrase'); // xss-safe-factory
+    const result = await Ui.modal.iframe(this.srcPassphraseDialog(longids, type, initiatorFrameId), 500, 'dialog-passphrase');
     if (result.dismiss === Swal.DismissReason.backdrop || result.dismiss === Swal.DismissReason.esc) {
       BrowserMsg.send.passphraseEntry('broadcast', { entered: false });
     }
   }
 
   public showAddPubkeyDialog = async (emails: string[]) => {
-    await Ui.modal.iframe_DANGEROUS(this.srcAddPubkeyDialog(emails, 'gmail'), undefined, 'dialog-add-pubkey'); // xss-safe-factory
+    await Ui.modal.iframe(this.srcAddPubkeyDialog(emails, 'gmail'), undefined, 'dialog-add-pubkey');
   }
 
   public embeddedCompose = (draftId?: string) => {

--- a/extension/js/common/xss-safe-factory.ts
+++ b/extension/js/common/xss-safe-factory.ts
@@ -169,14 +169,14 @@ export class XssSafeFactory {
   }
 
   public showPassphraseDialog = async (longids: string[], type: PassphraseDialogType) => {
-    const result = await Ui.modal.iframe_DANGEROUS(this.srcPassphraseDialog(longids, type)); // xss-safe-value
+    const result = await Ui.modal.iframe_DANGEROUS(this.srcPassphraseDialog(longids, type), 'dialog-passphrase'); // xss-safe-factory
     if (result.isDismissed) {
       BrowserMsg.send.passphraseEntry('broadcast', { entered: false });
     }
   }
 
   public showAddPubkeyDialog = async (emails: string[]) => {
-    await Ui.modal.iframe_DANGEROUS(this.srcAddPubkeyDialog(emails, 'gmail')); // xss-safe-value
+    await Ui.modal.iframe_DANGEROUS(this.srcAddPubkeyDialog(emails, 'gmail'), 'dialog-add-pubkey'); // xss-safe-factory
   }
 
   public embeddedCompose = (draftId?: string) => {
@@ -204,7 +204,7 @@ export class XssSafeFactory {
   }
 
   public showEmbeddedPassphraseDialog = async (longids: string[]) => {
-    await Ui.modal.iframe_DANGEROUS(this.srcPassphraseDialog(longids, 'embedded')); // xss-safe-value
+    await Ui.modal.iframe_DANGEROUS(this.srcPassphraseDialog(longids, 'embedded'), 'embedded-passphrase'); // xss-safe-factory
   }
 
   public embeddedAttachmentStatus = (content: string) => {

--- a/extension/js/common/xss-safe-factory.ts
+++ b/extension/js/common/xss-safe-factory.ts
@@ -210,8 +210,8 @@ export class XssSafeFactory {
     return this.iframe(this.srcReplyMsgIframe(convoParams, skipClickPrompt, ignoreDraft), ['reply_message']);
   }
 
-  public showEmbeddedPassphraseDialog = async (longids: string[]) => {
-    await Ui.modal.iframe_DANGEROUS(this.srcPassphraseDialog(longids, 'embedded'), 'embedded-passphrase'); // xss-safe-factory
+  public embeddedPassphrase = (longids: string[]) => {
+    return this.iframe(this.srcPassphraseDialog(longids, 'embedded'), [], { 'data-test': 'embedded-passphrase' }); // xss-safe-factory
   }
 
   public embeddedAttachmentStatus = (content: string) => {

--- a/extension/js/common/xss-safe-factory.ts
+++ b/extension/js/common/xss-safe-factory.ts
@@ -176,14 +176,14 @@ export class XssSafeFactory {
   }
 
   public showPassphraseDialog = async (longids: string[], type: PassphraseDialogType, initiatorFrameId?: string) => {
-    const result = await Ui.modal.iframe_DANGEROUS(this.srcPassphraseDialog(longids, type, initiatorFrameId), 'dialog-passphrase'); // xss-safe-factory
+    const result = await Ui.modal.iframe_DANGEROUS(this.srcPassphraseDialog(longids, type, initiatorFrameId), 500, 'dialog-passphrase'); // xss-safe-factory
     if (result.isDismissed) {
       BrowserMsg.send.passphraseEntry('broadcast', { entered: false });
     }
   }
 
   public showAddPubkeyDialog = async (emails: string[]) => {
-    await Ui.modal.iframe_DANGEROUS(this.srcAddPubkeyDialog(emails, 'gmail'), 'dialog-add-pubkey'); // xss-safe-factory
+    await Ui.modal.iframe_DANGEROUS(this.srcAddPubkeyDialog(emails, 'gmail'), undefined, 'dialog-add-pubkey'); // xss-safe-factory
   }
 
   public embeddedCompose = (draftId?: string) => {
@@ -240,7 +240,7 @@ export class XssSafeFactory {
 
   public btnEndPPSession = (webmailName: string) => {
     return `<a href="#" class="action_finish_session" title="End Pass Phrase Session" data-test="action-finish-session">
-              <img src="${this.srcImg('svgs/unlock.svg')}" height="32">
+              <img src="${this.srcImg('svgs/unlock.svg')}">
               ${webmailName === 'gmail' ? 'End Pass Phrase Session' : ''}
             </a>`;
   }

--- a/extension/js/common/xss-safe-factory.ts
+++ b/extension/js/common/xss-safe-factory.ts
@@ -114,8 +114,8 @@ export class XssSafeFactory {
     return this.frameSrc(this.extUrl('chrome/elements/compose.htm'), { frameId: this.newId(), draftId });
   }
 
-  public srcPassphraseDialog = (longids: string[] = [], type: PassphraseDialogType) => {
-    return this.frameSrc(this.extUrl('chrome/elements/passphrase.htm'), { type, longids });
+  public srcPassphraseDialog = (longids: string[] = [], type: PassphraseDialogType, attachmentId?: string) => {
+    return this.frameSrc(this.extUrl('chrome/elements/passphrase.htm'), { type, longids, attachmentId });
   }
 
   public srcAddPubkeyDialog = (emails: string[], placement: Placement) => {
@@ -168,8 +168,8 @@ export class XssSafeFactory {
     return `<link class="${this.destroyableCls}" rel="stylesheet" href="${this.extUrl(`css/${file}.css`)}" />`;
   }
 
-  public showPassphraseDialog = async (longids: string[], type: PassphraseDialogType) => {
-    const result = await Ui.modal.iframe_DANGEROUS(this.srcPassphraseDialog(longids, type), 'dialog-passphrase'); // xss-safe-factory
+  public showPassphraseDialog = async (longids: string[], type: PassphraseDialogType, attachmentId?: string) => {
+    const result = await Ui.modal.iframe_DANGEROUS(this.srcPassphraseDialog(longids, type, attachmentId), 'dialog-passphrase'); // xss-safe-factory
     if (result.isDismissed) {
       BrowserMsg.send.passphraseEntry('broadcast', { entered: false });
     }

--- a/extension/js/common/xss-safe-factory.ts
+++ b/extension/js/common/xss-safe-factory.ts
@@ -16,6 +16,7 @@ import { Ui } from './browser/ui.js';
 import { WebMailName } from './browser/env.js';
 import { Xss } from './platform/xss.js';
 import { SendAsAlias } from './platform/store/acct-store.js';
+import Swal from 'sweetalert2';
 
 type Placement = 'settings' | 'settings_compose' | 'default' | 'dialog' | 'gmail' | 'embedded' | 'compose';
 export type WebmailVariantString = undefined | 'html' | 'standard' | 'new';
@@ -177,7 +178,7 @@ export class XssSafeFactory {
 
   public showPassphraseDialog = async (longids: string[], type: PassphraseDialogType, initiatorFrameId?: string) => {
     const result = await Ui.modal.iframe_DANGEROUS(this.srcPassphraseDialog(longids, type, initiatorFrameId), 500, 'dialog-passphrase'); // xss-safe-factory
-    if (result.isDismissed) {
+    if (result.dismiss === Swal.DismissReason.backdrop || result.dismiss === Swal.DismissReason.esc) {
       BrowserMsg.send.passphraseEntry('broadcast', { entered: false });
     }
   }

--- a/extension/js/content_scripts/webmail/setup-webmail-content-script.ts
+++ b/extension/js/content_scripts/webmail/setup-webmail-content-script.ts
@@ -138,7 +138,7 @@ export const contentScriptSetupIfVacant = async (webmailSpecific: WebmailSpecifi
       }
     });
     BrowserMsg.addListener('close_dialog', async () => {
-      $('#cryptup_dialog').remove();
+      Swal.close();
     });
     BrowserMsg.addListener('close_swal', async () => {
       Swal.close();
@@ -150,18 +150,10 @@ export const contentScriptSetupIfVacant = async (webmailSpecific: WebmailSpecifi
       webmailSpecific.getReplacer().scrollToCursorInReplyBox(replyMsgId, cursorOffsetTop);
     });
     BrowserMsg.addListener('passphrase_dialog', async ({ longids, type }: Bm.PassphraseDialog) => {
-      if (!$('#cryptup_dialog').length) {
-        $('body').append(factory.dialogPassphrase(longids, type)) // xss-safe-factory;
-          .click(Ui.event.handle(() => { // click on the area outside the iframe
-            BrowserMsg.send.passphraseEntry('broadcast', { entered: false });
-            $('#cryptup_dialog').remove();
-          }));
-      }
+      await factory.showPassphraseDialog(longids, type);
     });
     BrowserMsg.addListener('add_pubkey_dialog', async ({ emails }: Bm.AddPubkeyDialog) => {
-      if (!$('#cryptup_dialog').length) {
-        $('body').append(factory.dialogAddPubkey(emails)); // xss-safe-factory
-      }
+      await factory.showAddPubkeyDialog(emails);
     });
     BrowserMsg.addListener('notification_show', async ({ notification, callbacks }: Bm.NotificationShow) => {
       notifications.show(notification, callbacks);

--- a/extension/js/content_scripts/webmail/setup-webmail-content-script.ts
+++ b/extension/js/content_scripts/webmail/setup-webmail-content-script.ts
@@ -146,8 +146,8 @@ export const contentScriptSetupIfVacant = async (webmailSpecific: WebmailSpecifi
     BrowserMsg.addListener('scroll_to_cursor_in_reply_box', async ({ replyMsgId, cursorOffsetTop }: Bm.ScrollToCursorInReplyBox) => {
       webmailSpecific.getReplacer().scrollToCursorInReplyBox(replyMsgId, cursorOffsetTop);
     });
-    BrowserMsg.addListener('passphrase_dialog', async ({ longids, type }: Bm.PassphraseDialog) => {
-      await factory.showPassphraseDialog(longids, type);
+    BrowserMsg.addListener('passphrase_dialog', async ({ longids, type, attachmentId }: Bm.PassphraseDialog) => {
+      await factory.showPassphraseDialog(longids, type, attachmentId);
     });
     BrowserMsg.addListener('add_pubkey_dialog', async ({ emails }: Bm.AddPubkeyDialog) => {
       await factory.showAddPubkeyDialog(emails);

--- a/extension/js/content_scripts/webmail/setup-webmail-content-script.ts
+++ b/extension/js/content_scripts/webmail/setup-webmail-content-script.ts
@@ -146,8 +146,8 @@ export const contentScriptSetupIfVacant = async (webmailSpecific: WebmailSpecifi
     BrowserMsg.addListener('scroll_to_cursor_in_reply_box', async ({ replyMsgId, cursorOffsetTop }: Bm.ScrollToCursorInReplyBox) => {
       webmailSpecific.getReplacer().scrollToCursorInReplyBox(replyMsgId, cursorOffsetTop);
     });
-    BrowserMsg.addListener('passphrase_dialog', async ({ longids, type, attachmentId }: Bm.PassphraseDialog) => {
-      await factory.showPassphraseDialog(longids, type, attachmentId);
+    BrowserMsg.addListener('passphrase_dialog', async ({ longids, type, initiatorFrameId }: Bm.PassphraseDialog) => {
+      await factory.showPassphraseDialog(longids, type, initiatorFrameId);
     });
     BrowserMsg.addListener('add_pubkey_dialog', async ({ emails }: Bm.AddPubkeyDialog) => {
       await factory.showAddPubkeyDialog(emails);

--- a/extension/js/content_scripts/webmail/setup-webmail-content-script.ts
+++ b/extension/js/content_scripts/webmail/setup-webmail-content-script.ts
@@ -140,9 +140,6 @@ export const contentScriptSetupIfVacant = async (webmailSpecific: WebmailSpecifi
     BrowserMsg.addListener('close_dialog', async () => {
       Swal.close();
     });
-    BrowserMsg.addListener('close_swal', async () => {
-      Swal.close();
-    });
     BrowserMsg.addListener('scroll_to_reply_box', async ({ replyMsgId }: Bm.ScrollToReplyBox) => {
       webmailSpecific.getReplacer().scrollToReplyBox(replyMsgId);
     });

--- a/test/source/tests/settings.ts
+++ b/test/source/tests/settings.ts
@@ -214,11 +214,6 @@ export let defineSettingsTests = (testVariant: TestVariant, testWithBrowser: Tes
       const attachmentImage = await inboxPage.getFrame(['attachment.htm', 'name=tiny-face.png']);
       await attachmentImage.waitForSelTestState('ready');
       await attachmentImage.click('body');
-      await Util.sleep(2);
-      await (inboxPage.target as Page).mouse.click(1, 1); // test closing the passphrase dialog by clicking its backdrop
-      await Util.sleep(2);
-      await inboxPage.notPresent('@dialog-passphrase');
-      await attachmentImage.click('body');
       const passphraseDialog = await inboxPage.getFrame(['passphrase.htm']);
       await passphraseDialog.waitAndType('@input-pass-phrase', k.passphrase);
       await passphraseDialog.waitAndClick('@action-confirm-pass-phrase-entry');


### PR DESCRIPTION
This PR removes a few instances of `#cryptup_dialog` usage and replaces them with already existed functionality of showing `<iframe>` inside SweetAlert2 modal.

close #3677

---

Also fixed the `.action_finish_session` button. It was unusable when a user has a long list of emails (the button was covered by email rows, their `z-index` is `2`):

![CleanShot 2021-05-24 at 22 39 43](https://user-images.githubusercontent.com/6059356/119641530-7077d880-be22-11eb-9964-58d98e4956ac.gif)

---

Also fixed the vertical alignment in `.button`, e.g. in `decrypt.htm`:

Before | After
-|-
<img width="248" alt="CleanShot 2021-05-26 at 13 26 59@2x" src="https://user-images.githubusercontent.com/6059356/119646044-5f7d9600-be27-11eb-9cf1-56e57590a5e2.png"> | <img width="208" alt="CleanShot 2021-05-26 at 13 28 38@2x" src="https://user-images.githubusercontent.com/6059356/119646084-6e644880-be27-11eb-9de9-0a96e81fb4b5.png">



----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
