### PR TITLE
Do not unnecessary trigger `evaluateRecipients()` for empty set of recipients

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -415,10 +415,10 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
           $(recipient.element).removeClass('no_pgp').find('i').remove();
           clearInterval(this.addedPubkeyDbLookupInterval);
           recipientsHasPgp.push(recipient);
+          await this.evaluateRecipients(recipientsHasPgp);
+          await this.setEmailsPreview(this.getRecipients());
         }
       }
-      await this.evaluateRecipients(recipientsHasPgp);
-      await this.setEmailsPreview(this.getRecipients());
     }, 1000);
   }
 


### PR DESCRIPTION
When the "Add a pubkey to email address" modal is opened, there's the `addedPubkeyDbLookupInterval` interval which calls `evaluateRecipients()`. Previously `evaluateRecipients()` was unnecessary called every second with an empty set of recipients which caused saving a draft every second.

This PR makes sure that `evaluateRecipients()` is executed once, when the contact is actually updated.

close #3688

----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
