### PR TITLE
Hide contacts when submit recipient

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -111,5 +111,27 @@
         "<node_internals>/**/*.js"
       ]
     },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug chrome_enterprise_mock",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/ava",
+      "preLaunchTask": "npm: pretest-incremental",
+      "runtimeArgs": [
+        "build/test/test/source/test.js",
+        "--verbose",
+        "--concurrency=1",
+        "--",
+        "ENTERPRISE-MOCK",
+        "STANDARD-GROUP",
+        "--retry=false",
+        "--debug",
+        "--pool-size=1",
+      ],
+      "outputCapture": "std",
+      "skipFiles": [
+        "<node_internals>/**/*.js"
+      ]
+    },
   ]
 }

--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -458,6 +458,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
         currentActive.removeClass('active');
       } else { // We need to force add recipient even it's invalid
         this.parseRenderRecipients($(e.target), true).catch(Catch.reportErr);
+        this.hideContacts();
       }
       e.target.focus();
       return true;

--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -579,6 +579,9 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
   }
 
   private renderSearchRes = (input: JQuery<HTMLElement>, contacts: ContactPreview[], query: ProviderContactsQuery) => {
+    if (!input.is(':focus')) { // focus was moved away from input
+      return;
+    }
     if ((input.val() as string).toLowerCase() !== query.substring.toLowerCase()) { // the input value has changed meanwhile
       return;
     }

--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -683,6 +683,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
         if (authResult.result === 'Success') {
           this.canSearchContacts = true;
           this.hideContacts();
+          input.focus();
           await this.searchContacts(input);
         } else if (authResult.result !== 'Closed') {
           await Ui.modal.error(`Could not enable Google Contact search. Please write us at human@flowcrypt.com\n\n[${authResult.result}] ${authResult.error}`);

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -716,7 +716,10 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
     ava.default('compose - enter recipient which is not in the contact list', testWithBrowser('compatibility', async (t, browser) => {
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
       await composePage.waitAndType(`@input-to`, 'unknown@flowcrypt.test');
-      await composePage.waitForContent('@container-contacts', 'No Contacts Found');
+      // for enterprise the 'No Contacts Found' popup won't be shown because Google is connected
+      if (testVariant === 'CONSUMER-MOCK') {
+        await composePage.waitForContent('@container-contacts', 'No Contacts Found');
+      }
       await composePage.press('Enter');
       await composePage.waitTillGone('@container-contacts');
     }));

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -713,6 +713,14 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await expectRecipientElements(composePage, { to: [] });
     }));
 
+    ava.default('compose - enter recipient which is not in the contact list', testWithBrowser('compatibility', async (t, browser) => {
+      const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
+      await composePage.waitAndType(`@input-to`, 'unknown@flowcrypt.test');
+      await composePage.waitForContent('@container-contacts', 'No Contacts Found');
+      await composePage.press('Enter');
+      await composePage.waitTillGone('@container-contacts');
+    }));
+
     ava.default('compose - new message, open footer', testWithBrowser('compatibility', async (t, browser) => {
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
       await ComposePageRecipe.fillRecipients(composePage, { to: 'human@flowcrypt.com' }, 'new');


### PR DESCRIPTION
This PR makes sure that the contacts popup is not showing when it's not expected, particularly in these 2 cases:

1. Submit the recipient which isn't in contacts, e.g. hide the "no results" popup after submitting a new email address
2. Do not render contacts suggestions if focus was moved away from input meanwhile

close #3698

----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
