### PR TITLE
Add filename to attachment preview

### DIFF
--- a/extension/chrome/elements/attachment_preview.htm
+++ b/extension/chrome/elements/attachment_preview.htm
@@ -12,10 +12,15 @@
 </head>
 
 <body id="attachment-preview">
-  <button id="attachment-preview-download" class="display_none" data-test="attachment-preview-download">
-    <img src="/img/svgs/download-link-white.svg" alt="download attachment" width="28">
-    DOWNLOAD
-  </button>
+  <div class="attachment-preview-toolbar">
+    <div id="attachment-preview-filename" data-test="attachment-preview-filename"></div>
+    <button id="attachment-preview-download" class="display_none" data-test="attachment-preview-download">
+      <img src="/img/svgs/download-link-white.svg" alt="download attachment" width="28">
+      DOWNLOAD
+    </button>
+    <div></div>
+  </div>
+
   <div id="attachment-preview-container"></div>
 
   <script src="/lib/purify.js"></script>

--- a/extension/chrome/elements/attachment_preview.ts
+++ b/extension/chrome/elements/attachment_preview.ts
@@ -66,6 +66,7 @@ View.run(class AttachmentPreviewView extends AttachmentDownloadView {
           e.stopPropagation();
           Browser.saveToDownloads(attachmentForSave);
         });
+        $('#attachment-preview-filename').text(this.origNameBasedOnFilename);
       }
     } catch (e) {
       this.renderErr(e);

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -2542,11 +2542,29 @@ body.attachment .file-format-holder img#file-format {
   box-sizing: border-box;
 }
 
-#attachment-preview-download {
-  height: 80px;
-  display: none;
+.attachment-preview-toolbar {
+  display: flex;
+  height: 60px;
+  align-items: center;
+  padding: 0 50px;
   flex-shrink: 0;
-  margin: 0 auto;
+}
+
+.attachment-preview-toolbar div {
+  flex: 1;
+}
+
+#attachment-preview-filename {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 16px;
+  color: white;
+  white-space: nowrap;
+}
+
+#attachment-preview-download {
+  display: none;
+  align-self: stretch;
   padding: 0 50px;
   align-items: center;
   justify-content: center;
@@ -2556,7 +2574,7 @@ body.attachment .file-format-holder img#file-format {
   text-decoration: none;
   cursor: pointer;
   border: 0;
-  opacity: 0.7;
+  opacity: 0.8;
   transition: all 0.15s ease-in;
 }
 

--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -389,6 +389,11 @@ body.cryptup_gmail div.recipients_use_encryption a {
   overflow-y: hidden !important;
 }
 
+.swal2-container.ui-modal-attachment .swal2-close {
+  margin-top: 6px;
+  margin-bottom: -54px;
+}
+
 .swal2-container.ui-modal-attachment .swal2-popup {
   padding: 0;
   background: transparent;

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -891,6 +891,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await attachment.click('body');
       const attachmentPreviewImage = await inboxPage.getFrame(['attachment_preview.htm']);
       await attachmentPreviewImage.waitAll('#attachment-preview-container img.attachment-preview-img');
+      await attachmentPreviewImage.waitForContent('@attachment-preview-filename', 'small.png');
     }));
 
     ava.default('attachments - failed to decrypt', testWithBrowser('compatibility', async (t, browser) => {


### PR DESCRIPTION
This PR adds filename to the top left corner of attachment preview, so users will be aware what file they are previewing.

close #3689

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
