### PR TITLE
Fix images preview for Firefox

### DIFF
--- a/extension/chrome/elements/attachment_preview.ts
+++ b/extension/chrome/elements/attachment_preview.ts
@@ -6,6 +6,7 @@ import { Assert } from '../../js/common/assert.js';
 import { Attachment } from '../../js/common/core/attachment.js';
 import { AttachmentDownloadView } from './attachment.js';
 import { AttachmentPreviewPdf } from '../../js/common/ui/attachment_preview_pdf.js';
+import { blobToBase64 } from '../../js/common/platform/util.js';
 import { Browser } from '../../js/common/browser/browser.js';
 import { BrowserMsg } from '../../js/common/browser/browser-msg.js';
 import { KeyStore } from '../../js/common/platform/store/key-store.js';
@@ -38,12 +39,12 @@ View.run(class AttachmentPreviewView extends AttachmentDownloadView {
       const result = this.isEncrypted ? await this.decrypt() : this.attachment.getData();
       if (result) {
         const blob = new Blob([result], { type: this.type });
-        const url = window.URL.createObjectURL(blob);
+        const imgBase64 = await blobToBase64(blob);
         const attachmentType = this.getAttachmentType(this.origNameBasedOnFilename);
         const attachmentForSave = new Attachment({ name: this.origNameBasedOnFilename, type: this.type, data: result });
         if (attachmentType) {
           if (attachmentType === 'img') { // image
-            this.attachmentPreviewContainer.html(`<img src="${url}" class="attachment-preview-img" alt="${Xss.escape(this.origNameBasedOnFilename)}">`); // xss-escaped
+            this.attachmentPreviewContainer.html(`<img src="${imgBase64}" class="attachment-preview-img" alt="${Xss.escape(this.origNameBasedOnFilename)}">`); // xss-escaped
           } else if (attachmentType === 'txt') { // text
             this.attachmentPreviewContainer.html(`<div class="attachment-preview-txt">${Xss.escape(result.toString()).replace(/\n/g, '<br>')}</div>`); // xss-escaped
           } else if (attachmentType === 'pdf') { // PDF

--- a/extension/js/common/platform/util.ts
+++ b/extension/js/common/platform/util.ts
@@ -24,6 +24,19 @@ export const base64decode = (b64tr: string): string => {
   return atob(b64tr);
 };
 
+export const blobToBase64 = (blob: Blob) => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      resolve(reader.result);
+    };
+    reader.onerror = () => {
+      reject();
+    };
+    reader.readAsDataURL(blob);
+  });
+};
+
 export const moveElementInArray = <T>(arr: Array<T>, oldIndex: number, newIndex: number) => {
   while (oldIndex < 0) {
     oldIndex += arr.length;

--- a/extension/js/common/platform/util.ts
+++ b/extension/js/common/platform/util.ts
@@ -24,8 +24,8 @@ export const base64decode = (b64tr: string): string => {
   return atob(b64tr);
 };
 
-export const blobToBase64 = (blob: Blob) => {
-  return new Promise((resolve, reject) => {
+export const blobToBase64 = async (blob: Blob) => {
+  return await new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onloadend = () => {
       resolve(reader.result);


### PR DESCRIPTION
This PR changes the way of showing images in attachment preview to use base64 src.

close #3703

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test, we currently don't test in Firefox

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
