### PR TITLE
Add blob: as valid image source in extension CSP

### DIFF
--- a/extension/chrome/elements/attachment_preview.htm
+++ b/extension/chrome/elements/attachment_preview.htm
@@ -5,7 +5,6 @@
 <head>
   <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-  <meta http-equiv="Content-Security-Policy" content="script-src 'self'">
   <title>FlowCrypt</title>
   <link rel="stylesheet" href="/css/cryptup.css" />
   <link rel="stylesheet" href="/css/sweetalert2.css" />

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -91,5 +91,5 @@
     "/chrome/elements/shared/footer.htm"
   ],
   "minimum_chrome_version": "61",
-  "content_security_policy": "upgrade-insecure-requests; script-src 'self'; frame-ancestors https://mail.google.com 'self'; img-src 'self' https://*.googleusercontent.com data:; frame-src 'self'; worker-src 'self'; form-action 'none'; media-src 'none'; font-src 'none'; manifest-src 'none'; object-src 'none'; base-uri 'self'"
+  "content_security_policy": "upgrade-insecure-requests; script-src 'self'; frame-ancestors https://mail.google.com 'self'; img-src 'self' https://*.googleusercontent.com data: blob:; frame-src 'self'; worker-src 'self'; form-action 'none'; media-src 'none'; font-src 'none'; manifest-src 'none'; object-src 'none'; base-uri 'self'"
 }


### PR DESCRIPTION


This PR This fixes image previews in Firefox, and is an alternative to the approach used in https://github.com/FlowCrypt/flowcrypt-browser/pull/3704

close #3703

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test because we don't have Firefox tests (yet!)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
