### PR TITLE
Issue 3716 expiration note position

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-pwd-or-pubkey-container-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-pwd-or-pubkey-container-module.ts
@@ -37,8 +37,7 @@ export class ComposePwdOrPubkeyContainerModule extends ViewModule<ComposeView> {
 
   public inputPwdFocusHandler = () => {
     const passwordContainerHeight = this.view.S.cached('password_or_pubkey').outerHeight() || 0;
-    const footerHeight = this.view.S.cached('footer').outerHeight() || 0;
-    this.view.S.cached('expiration_note').css({ bottom: (passwordContainerHeight + footerHeight) + 'px' });
+    this.view.S.cached('expiration_note').css({ bottom: passwordContainerHeight });
     this.view.S.cached('expiration_note').fadeIn();
     this.showHideContainerAndColorSendBtn(); // tslint:disable-line:no-floating-promises
   }

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -2140,6 +2140,7 @@ table#compose tr#password_or_pubkey_container td {
   animation: fadeInUp 1s;
   border-top: 1px solid #cfcfcf;
   line-height: 1.5;
+  position: relative;
 }
 table#compose tr#password_or_pubkey_container td input#input_password::-webkit-input-placeholder { color: #d14836; }
 


### PR DESCRIPTION
This PR fixes the position of `#expiration_note` block, as well as adds comma between `.warning_nopgp` and `. warning_revoked`.

close #3716

----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
