### PR TITLE
Remove pubkeys from contacts #3632

### DIFF
--- a/extension/chrome/settings/modules/contacts.ts
+++ b/extension/chrome/settings/modules/contacts.ts
@@ -55,7 +55,6 @@ View.run(class ContactsView extends View {
     $('.action_show_pubkey_list').off().click(this.setHandlerPrevent('double', this.actionRenderListPublicKeyHandler));
     $('#edit_contact .action_save_edited_pubkey').off().click(this.setHandlerPrevent('double', this.actionSaveEditedPublicKeyHandler));
     $('#bulk_import .action_process').off().click(this.setHandlerPrevent('double', this.actionProcessBulkImportTextInput));
-    $('.action_remove').off().click(this.setHandlerPrevent('double', this.actionRemovePublicKey));
     $('.action_export_all').off().click(this.setHandlerPrevent('double', this.actionExportAllKeysHandler));
     $('.action_view_bulk_import').off().click(this.setHandlerPrevent('double', this.actionRenderBulkImportPageHandler));
     $('.input-search-contacts').off().keyup(this.setHandlerPrevent('double', this.loadAndRenderContactList));
@@ -144,6 +143,7 @@ View.run(class ContactsView extends View {
       // remove all listeners from the old link by creating a new element
       const newElement = emailRow.cloneNode(true);
       emailRow!.parentNode!.replaceChild(newElement, emailRow);
+      $('.action_remove').off().click(this.setHandlerPrevent('double', this.actionRemovePublicKey));
       $('.action_show').off().click(this.setHandlerPrevent('double', this.actionRenderViewPublicKeyHandler));
       $('.action_change').off().click(this.setHandlerPrevent('double', this.actionRenderChangePublicKeyHandler));
     }
@@ -206,7 +206,11 @@ View.run(class ContactsView extends View {
   }
 
   private actionRemovePublicKey = async (rmPubkeyButton: HTMLElement) => {
-    await ContactStore.save(undefined, await ContactStore.obj({ email: $(rmPubkeyButton).closest('[email]').attr('email')! }));
+    const parentRow = $(rmPubkeyButton).closest('[email]');
+    const id = parentRow.attr('keyid')!;
+    const type = parentRow.attr('type')!;
+    const email = parentRow.attr('email')!;
+    await ContactStore.unlinkPubkey(undefined, email, { id, type });
     await this.loadAndRenderContactList();
   }
 

--- a/extension/js/common/platform/store/contact-store.ts
+++ b/extension/js/common/platform/store/contact-store.ts
@@ -318,7 +318,8 @@ export class ContactStore extends AbstractStore {
   public static unlinkPubkey = async (db: IDBDatabase | undefined, email: string, { id, type }: { id: string, type: string }):
     Promise<void> => {
     if (!db) { // relay op through background process
-      return await BrowserMsg.send.bg.await.db({ f: 'unlinkPubkey', args: [email, { id, type }] });
+      await BrowserMsg.send.bg.await.db({ f: 'unlinkPubkey', args: [email, { id, type }] });
+      return;
     }
     const internalFingerprint = ContactStore.getPubkeyId({ id, type });
     const tx = db.transaction(['emails', 'pubkeys'], 'readwrite');

--- a/extension/js/common/platform/store/contact-store.ts
+++ b/extension/js/common/platform/store/contact-store.ts
@@ -308,11 +308,34 @@ export class ContactStore extends AbstractStore {
     }
     const internalFingerprint = ContactStore.getPubkeyId({ id, type });
     const tx = db.transaction(['pubkeys'], 'readonly');
-    const emailEntity: Pubkey = await new Promise((resolve, reject) => {
+    const pubkeyEntity: Pubkey = await new Promise((resolve, reject) => {
       const req = tx.objectStore('pubkeys').get(internalFingerprint);
       ContactStore.setReqPipe(req, resolve, reject);
     });
-    return emailEntity?.armoredKey;
+    return pubkeyEntity?.armoredKey;
+  }
+
+  public static unlinkPubkey = async (db: IDBDatabase | undefined, email: string, { id, type }: { id: string, type: string }):
+    Promise<void> => {
+    if (!db) { // relay op through background process
+      return await BrowserMsg.send.bg.await.db({ f: 'unlinkPubkey', args: [email, { id, type }] });
+    }
+    const internalFingerprint = ContactStore.getPubkeyId({ id, type });
+    const tx = db.transaction(['emails', 'pubkeys'], 'readwrite');
+    await new Promise((resolve, reject) => {
+      ContactStore.setTxHandlers(tx, resolve, reject);
+      const req = tx.objectStore('emails').index('index_fingerprints').getAll(internalFingerprint);
+      ContactStore.setReqPipe(req,
+        (referencingEmails: Email[]) => {
+          for (const entity of referencingEmails.filter(e => e.email === email)) {
+            entity.fingerprints = entity.fingerprints.filter(fp => fp !== internalFingerprint);
+            tx.objectStore('emails').put(entity);
+          }
+          if (!referencingEmails.some(e => e.email !== email)) {
+            tx.objectStore('pubkeys').delete(internalFingerprint);
+          }
+        });
+    });
   }
 
   public static updateTx = (tx: IDBTransaction, email: string, update: ContactUpdate) => {

--- a/test/source/platform/store/contact-store.ts
+++ b/test/source/platform/store/contact-store.ts
@@ -13,6 +13,14 @@ export type ContactUpdate = {
   lastUse?: number | null;
 };
 
+export type Pubkey = {
+  fingerprint: string;
+  armoredKey: string;
+  longids: string[];
+  lastCheck: number | null,
+  expiresOn: number | null;
+};
+
 export class ContactStore {
 
   public static get = async (db: void, emailOrLongid: string[]): Promise<(Contact | undefined)[]> => {


### PR DESCRIPTION
This PR allows to remove a pubkey from a contact (email).
When a pubkey is no longer referenced by any email, it is deleted from the store.

close #3632

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
