### PR TITLE
upgrade ws package to nonvulnerable version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8177,7 +8177,7 @@
         "tmp": "0.2.1",
         "update-notifier": "5.1.0",
         "watchpack": "2.1.1",
-        "ws": "7.4.3",
+        "ws": "7.4.6",
         "yargs": "16.2.0",
         "zip-dir": "2.0.0"
       },
@@ -8459,8 +8459,8 @@
       }
     },
     "ws": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
       "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6370,7 +6370,7 @@
         "ws": {
           "version": "7.4.6",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+          "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==",
           "dev": true
         }
       }


### PR DESCRIPTION
This manually upgrades the ws to a nonvulnerable version, per the Dependabot alert.

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
