### PR TITLE
issue 3779 fix confusing h1 during setup

### DIFF
--- a/extension/chrome/settings/setup.htm
+++ b/extension/chrome/settings/setup.htm
@@ -54,7 +54,7 @@
       <a href="#" class="action_show_help" page="modules/help.htm">
         <img src="/img/svgs/question-icon.svg" alt="Help icon">
       </a>
-      <h1></h1>
+      <h1>Set Up FlowCrypt</h1>
       <br />
     </div>
 

--- a/extension/chrome/settings/setup.ts
+++ b/extension/chrome/settings/setup.ts
@@ -171,7 +171,7 @@ export class SetupView extends View {
   }
 
   public actionBackHandler = () => {
-    $('h1').text('Set Up');
+    $('h1').text('Set Up FlowCrypt');
     this.setupRender.displayBlock('step_1_easy_or_manual');
   }
 

--- a/extension/chrome/settings/setup/setup-render.ts
+++ b/extension/chrome/settings/setup/setup-render.ts
@@ -19,7 +19,6 @@ export class SetupRenderModule {
   }
 
   public renderInitial = async (): Promise<void> => {
-    $('h1').text(this.view.orgRules.mustAutoImportOrAutogenPrvWithKeyManager() ? 'Setting up FlowCrypt, please wait...' : 'Set Up FlowCrypt');
     $('.email-address').text(this.view.acctEmail);
     $('#button-go-back').css('visibility', 'hidden');
     if (this.view.storage!.email_provider === 'gmail') { // show alternative account addresses in setup form + save them for later


### PR DESCRIPTION
This PR fixes a setup title that suggested that user should wait, when in fact user was supposed to fill out a form.

close #3779

----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
