### PR TITLE
issue 3782 dont offer backup when forbidden

### DIFF
--- a/extension/chrome/settings/modules/change_passphrase.ts
+++ b/extension/chrome/settings/modules/change_passphrase.ts
@@ -14,6 +14,7 @@ import { initPassphraseToggle } from '../../../js/common/ui/passphrase-ui.js';
 import { PassphraseStore } from '../../../js/common/platform/store/passphrase-store.js';
 import { KeyStore } from '../../../js/common/platform/store/key-store.js';
 import { OrgRules } from '../../../js/common/org-rules.js';
+import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
 
 View.run(class ChangePassPhraseView extends View {
 
@@ -114,8 +115,13 @@ View.run(class ChangePassPhraseView extends View {
       !!(await PassphraseStore.get(this.acctEmail, this.primaryKi!.fingerprints[0], true));
     await PassphraseStore.set('local', this.acctEmail, this.primaryKi!.fingerprints[0], shouldSavePassphraseInStorage ? newPp : undefined);
     await PassphraseStore.set('session', this.acctEmail, this.primaryKi!.fingerprints[0], shouldSavePassphraseInStorage ? undefined : newPp);
-    await Ui.modal.info('Now that you changed your pass phrase, you should back up your key. New backup will be protected with new passphrase.');
-    Settings.redirectSubPage(this.acctEmail, this.parentTabId, '/chrome/settings/modules/backup.htm', '&action=backup_manual');
+    if (this.orgRules.canBackupKeys()) {
+      await Ui.modal.info('Now that you changed your pass phrase, you should back up your key. New backup will be protected with new passphrase.');
+      Settings.redirectSubPage(this.acctEmail, this.parentTabId, '/chrome/settings/modules/backup.htm', '&action=backup_manual');
+    } else {
+      await Ui.modal.info('Pass phrase changed for this device');
+      BrowserMsg.send.closePage(this.parentTabId);
+    }
   }
 
   private displayBlock = (name: string) => {


### PR DESCRIPTION
This PR doesn't prompt the user to backup after changing pass phrase when forbidden with NO_PRV_BACKUP. (before, after the prompt, it showed "backups forbidden" anyway, so the prompt was just confusing)

close #3782

----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
