### PR TITLE
Add blob as valid frame-src to prevent Firefox key download bug

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -91,5 +91,5 @@
     "/chrome/elements/shared/footer.htm"
   ],
   "minimum_chrome_version": "61",
-  "content_security_policy": "upgrade-insecure-requests; script-src 'self'; frame-ancestors https://mail.google.com 'self'; img-src 'self' https://*.googleusercontent.com data: blob:; frame-src 'self'; worker-src 'self'; form-action 'none'; media-src 'none'; font-src 'none'; manifest-src 'none'; object-src 'none'; base-uri 'self'"
+  "content_security_policy": "upgrade-insecure-requests; script-src 'self'; frame-ancestors https://mail.google.com 'self'; img-src 'self' https://*.googleusercontent.com data: blob:; frame-src 'self' blob:; worker-src 'self'; form-action 'none'; media-src 'none'; font-src 'none'; manifest-src 'none'; object-src 'none'; base-uri 'self'"
 }


### PR DESCRIPTION
Because of how Firefox interprets the frame-src CSP directive, users on Firefox are unable to download their private keys (and probably do other things). This weakens the directive to make this functionality work for FF users.

close https://github.com/FlowCrypt/flowcrypt-browser/issues/3774

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test because we don't have Firefox specific tests (yet! https://github.com/FlowCrypt/flowcrypt-browser/issues/3411)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
