### PR TITLE
Fix flaky gmail test

### DIFF
--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -148,7 +148,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       await gmailPage.waitAndClick('[role="row"]'); // click the first message
       await gmailPage.waitForContent('.nH.if h2', `Automated puppeteer test: ${subject}`);
       const urls = await gmailPage.getFramesUrls(['/chrome/elements/pgp_block.htm'], { sleep: 1 });
-      await GmailPageRecipe.deleteMessage(gmailPage);
+      await GmailPageRecipe.deleteThread(gmailPage);
       expect(urls.length).to.eq(1);
     }));
 
@@ -229,8 +229,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       await pubkeyPage.waitForContent('@container-pgp-pubkey', 'Fingerprint: DCB2 74D2 4683 145E B053 BC0B 48E4 74A0 926B AE86');
     }));
 
-    // flaky test
-    ava.default.skip('mail.google.com - secure reply btn, reply draft', testWithBrowser('ci.tests.gmail', async (t, browser) => {
+    ava.default('mail.google.com - secure reply btn, reply draft', testWithBrowser('ci.tests.gmail', async (t, browser) => {
       const gmailPage = await openGmailPage(t, browser, '/FMfcgxwJXVGtMJwQTZmBDlspVWDvsnnL'); // encrypted convo
       await Util.sleep(5);
       await pageHasSecureReplyContainer(t, browser, gmailPage, { isReplyPromptAccepted: false });
@@ -239,7 +238,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       await gmailPage.page.keyboard.type('hey there');
       await Util.sleep(5);
       await gmailPage.page.reload();
-      await Util.sleep(3);
+      await Util.sleep(5);
       const replyBox = await pageHasSecureDraft(t, browser, gmailPage, 'hey there');
       await replyBox.waitAndClick('@action-send');
       await Util.sleep(5);

--- a/test/source/tests/page-recipe/gmail-page-recipe.ts
+++ b/test/source/tests/page-recipe/gmail-page-recipe.ts
@@ -28,17 +28,10 @@ export class GmailPageRecipe extends PageRecipe {
     await gmailPage.waitAndClick('@notification-successfully-setup-action-close');
   }
 
-  public static deleteMessage = async (gmailPage: ControllablePage) => {
-    // the toolbar needs to be focused in order for Delete button to work
-    await gmailPage.page.keyboard.down('Shift');
-    for (let i = 0; i < 5; i++) {
-      await gmailPage.press('Tab');
-    }
-    await gmailPage.page.keyboard.up('Shift');
-    await gmailPage.waitAndClick('[aria-label="Delete"]');
+  public static deleteThread = async (gmailPage: ControllablePage) => {
+    await gmailPage.page.keyboard.press('#');
   }
 
-  // todo - is this the same as the one above?
   public static deleteLastReply = async (gmailPage: ControllablePage) => {
     await gmailPage.waitAndClick('[aria-label="More"]');
     await gmailPage.press('ArrowDown', 5);


### PR DESCRIPTION
This PR fixes the flaky gmail test by increasing the sleep timeout before checking `pageHasSecureDraft()`, sometimes in CI it takes more than 3s to load the Gmail's UI and render the secure draft.

close #3481

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
