### PR TITLE
debug live Gmail tests failing

### DIFF
--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -68,7 +68,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       return gmailPage;
     };
 
-    ava.default('mail.google.com - setup prompt notif + hides when close clicked + reappears + setup link opens settings', testWithBrowser(undefined, async (t, browser) => {
+    ava.default('mail.google.com - setup prompt notif ++ hides when close clicked + reappears + setup link opens settings', testWithBrowser(undefined, async (t, browser) => {
       const settingsPage = await BrowserRecipe.openSettingsLoginButCloseOauthWindowBeforeGrantingPermission(t, browser, 'ci.tests.gmail@flowcrypt.dev');
       await settingsPage.close();
       let gmailPage = await BrowserRecipe.openGmailPage(t, browser);

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -128,7 +128,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       await gmailPage.notPresent(['@webmail-notification']);
     }));
 
-    ava.default('mail.google.com - setup prompt notification shows up + dismiss hides it + does not reappear if dismissed', testWithBrowser(undefined, async (t, browser) => {
+    ava.default.only('mail.google.com - setup prompt notification shows up + dismiss hides it + does not reappear if dismissed', testWithBrowser(undefined, async (t, browser) => {
       await BrowserRecipe.openSettingsLoginButCloseOauthWindowBeforeGrantingPermission(t, browser, 'ci.tests.gmail@flowcrypt.dev');
       let gmailPage = await BrowserRecipe.openGmailPage(t, browser);
       await gmailPage.waitAll(['@webmail-notification', '@notification-setup-action-open-settings', '@notification-setup-action-dismiss', '@notification-setup-action-close']);

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -68,7 +68,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       return gmailPage;
     };
 
-    ava.default('mail.google.com - setup prompt notif ++ hides when close clicked + reappears + setup link opens settings', testWithBrowser(undefined, async (t, browser) => {
+    ava.default('mail.google.com - setup prompt notif + hides when close clicked + reappears + setup link opens settings', testWithBrowser(undefined, async (t, browser) => {
       const settingsPage = await BrowserRecipe.openSettingsLoginButCloseOauthWindowBeforeGrantingPermission(t, browser, 'ci.tests.gmail@flowcrypt.dev');
       await settingsPage.close();
       let gmailPage = await BrowserRecipe.openGmailPage(t, browser);
@@ -128,7 +128,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       await gmailPage.notPresent(['@webmail-notification']);
     }));
 
-    ava.default.only('mail.google.com - setup prompt notification shows up + dismiss hides it + does not reappear if dismissed', testWithBrowser(undefined, async (t, browser) => {
+    ava.default('mail.google.com - setup prompt notification shows up + dismiss hides it + does not reappear if dismissed', testWithBrowser(undefined, async (t, browser) => {
       await BrowserRecipe.openSettingsLoginButCloseOauthWindowBeforeGrantingPermission(t, browser, 'ci.tests.gmail@flowcrypt.dev');
       let gmailPage = await BrowserRecipe.openGmailPage(t, browser);
       await gmailPage.waitAll(['@webmail-notification', '@notification-setup-action-open-settings', '@notification-setup-action-dismiss', '@notification-setup-action-close']);

--- a/test/source/tests/page-recipe/oauth-page-recipe.ts
+++ b/test/source/tests/page-recipe/oauth-page-recipe.ts
@@ -42,21 +42,21 @@ export class OauthPageRecipe extends PageRecipe {
     const auth = Config.secrets().auth.google.find(a => a.email === acctEmail);
     const acctPassword = auth?.password;
     const selectors = {
-      approve_button: '#submit_approve_access',
-      email_input: '#identifierId',
-      email_confirm_btn: '#identifierNext',
-      auth0_username: '#username',
-      auth0_password: '#password',
-      auth0_login_btn: 'button', // old: ._button-login
+      googleEmailInput: '#identifierId',
+      googleEmailConfirmBtn: '#identifierNext',
+      auth0username: '#username',
+      auth0password: '#password',
+      auth0loginBtn: 'button:contains("Continue")',
+      googleApproveBtn: '#submit_approve_access',
     };
     try {
       const alreadyLoggedSelector = '.w6VTHd, .wLBAL';
       const alreadyLoggedChooseOtherAccountSelector = '.bLzI3e, .BHzsHc';
       await oauthPage.waitAny(`#Email, #submit_approve_access, #identifierId, ${alreadyLoggedSelector}, #profileIdentifier`, { timeout: 45 });
-      if (await oauthPage.target.$(selectors.email_input) !== null) { // 2017-style login
-        await oauthPage.waitAll(selectors.email_input, { timeout: OauthPageRecipe.longTimeout });
-        await oauthPage.waitAndType(selectors.email_input, acctEmail, { delay: 2 });
-        await oauthPage.waitAndClick(selectors.email_confirm_btn, { delay: 2 });  // confirm email
+      if (await oauthPage.target.$(selectors.googleEmailInput) !== null) { // 2017-style login
+        await oauthPage.waitAll(selectors.googleEmailInput, { timeout: OauthPageRecipe.longTimeout });
+        await oauthPage.waitAndType(selectors.googleEmailInput, acctEmail, { delay: 2 });
+        await oauthPage.waitAndClick(selectors.googleEmailConfirmBtn, { delay: 2 });  // confirm email
         await oauthPage.waitForNavigationIfAny();
       } else if (await oauthPage.target.$(`#profileIdentifier[data-email="${acctEmail}"]`) !== null) { // already logged in - just choose an account
         await oauthPage.waitAndClick(`#profileIdentifier[data-email="${acctEmail}"]`, { delay: 1 });
@@ -77,20 +77,17 @@ export class OauthPageRecipe extends PageRecipe {
         }
         throw new Error('Oauth page didnt close after login. Should increase timeout or await close event');
       }
-      await oauthPage.waitAny([selectors.approve_button, selectors.auth0_username]);
-      if (await oauthPage.isElementPresent(selectors.auth0_username)) {
-        await oauthPage.waitAndType(selectors.auth0_username, acctEmail);
+      await oauthPage.waitAny([selectors.googleApproveBtn, selectors.auth0username]);
+      if (await oauthPage.isElementPresent(selectors.auth0username)) {
+        await oauthPage.waitAndType(selectors.auth0username, acctEmail);
         if (acctPassword) {
-          console.log('acctPassword is set');
-          await oauthPage.waitAndType(selectors.auth0_password, acctPassword);
+          await oauthPage.waitAndType(selectors.auth0password, acctPassword);
         }
-        console.log('username and password are entered:', await oauthPage.page.screenshot({ encoding: "base64" }));
-        await oauthPage.waitAndClick(selectors.auth0_login_btn);
+        await oauthPage.waitAndClick(selectors.auth0loginBtn);
         await oauthPage.waitForNavigationIfAny();
       }
       await Util.sleep(1);
-      console.log('username and password are submitted:', await oauthPage.page.screenshot({ encoding: "base64" }));
-      await oauthPage.waitAll(selectors.approve_button); // if succeeds, we are logged in and presented with approve/deny choice
+      await oauthPage.waitAll(selectors.googleApproveBtn); // if succeeds, we are logged in and presented with approve/deny choice
       // since we are successfully logged in, we may save cookies to keep them fresh
       // no need to await the API call because it's not crucial to always save it, can mostly skip errors
       if (action === 'close') {

--- a/test/source/tests/page-recipe/oauth-page-recipe.ts
+++ b/test/source/tests/page-recipe/oauth-page-recipe.ts
@@ -46,7 +46,7 @@ export class OauthPageRecipe extends PageRecipe {
       googleEmailConfirmBtn: '#identifierNext',
       auth0username: '#username',
       auth0password: '#password',
-      auth0loginBtn: 'button:contains("Continue")',
+      auth0loginBtn: 'button[type=submit][name=action][value=default]',
       googleApproveBtn: '#submit_approve_access',
     };
     try {

--- a/test/source/tests/page-recipe/oauth-page-recipe.ts
+++ b/test/source/tests/page-recipe/oauth-page-recipe.ts
@@ -83,10 +83,12 @@ export class OauthPageRecipe extends PageRecipe {
         if (acctPassword) {
           await oauthPage.waitAndType(selectors.auth0_password, acctPassword);
         }
+        console.log('username and password are entered:', await oauthPage.page.screenshot({ encoding: "base64" }));
         await oauthPage.waitAndClick(selectors.auth0_login_btn);
         await oauthPage.waitForNavigationIfAny();
       }
       await Util.sleep(1);
+      console.log('username and password are submitted:', await oauthPage.page.screenshot({ encoding: "base64" }));
       await oauthPage.waitAll(selectors.approve_button); // if succeeds, we are logged in and presented with approve/deny choice
       // since we are successfully logged in, we may save cookies to keep them fresh
       // no need to await the API call because it's not crucial to always save it, can mostly skip errors

--- a/test/source/tests/page-recipe/oauth-page-recipe.ts
+++ b/test/source/tests/page-recipe/oauth-page-recipe.ts
@@ -81,6 +81,7 @@ export class OauthPageRecipe extends PageRecipe {
       if (await oauthPage.isElementPresent(selectors.auth0_username)) {
         await oauthPage.waitAndType(selectors.auth0_username, acctEmail);
         if (acctPassword) {
+          console.log('acctPassword is set');
           await oauthPage.waitAndType(selectors.auth0_password, acctPassword);
         }
         console.log('username and password are entered:', await oauthPage.page.screenshot({ encoding: "base64" }));


### PR DESCRIPTION
This PR is not meant to be merged, it's the part of debugging #3785 

I don't remember where exactly, but some time ago I asked about taking screenshots from CI. I found the simple way to do that:

1. `console.log(await page.screenshot({ encoding: "base64" }))`
2. copy the output from CI log and paste it to https://codebeautify.org/base64-to-image-converter

---

As to debugging #3785 I think that `acctPassword` is not set for some reason, here's the screenshot of the state where email and password are supposed to be entered:

![image](https://user-images.githubusercontent.com/6059356/124395288-e158bd00-dd0b-11eb-9e75-afdadae2b0af.png)
