### PR TITLE
Disallow attester search for all domains when * as specified #3563

### DIFF
--- a/extension/js/common/org-rules.ts
+++ b/extension/js/common/org-rules.ts
@@ -172,8 +172,15 @@ export class OrgRules {
    * This is because they already have other means to obtain public keys for these domains, such as from their own internal keyserver
    */
   public canLookupThisRecipientOnAttester = (emailAddr: string): boolean => {
-    const forbidden = ['*', Str.getDomainFromEmailAddress(emailAddr) || 'NONE'];
-    return !(this.domainRules.disallow_attester_search_for_domains || []).some(domain => forbidden.includes(domain));
+    const disallowedDomains = this.domainRules.disallow_attester_search_for_domains || [];
+    if (disallowedDomains.includes('*')) {
+      return false;
+    }
+    const userDomain = Str.getDomainFromEmailAddress(emailAddr);
+    if (!userDomain) {
+      throw new Error(`Not a valid email ${emailAddr}`);
+    }
+    return !disallowedDomains.includes(userDomain);
   }
 
   /**

--- a/extension/js/common/org-rules.ts
+++ b/extension/js/common/org-rules.ts
@@ -172,7 +172,8 @@ export class OrgRules {
    * This is because they already have other means to obtain public keys for these domains, such as from their own internal keyserver
    */
   public canLookupThisRecipientOnAttester = (emailAddr: string): boolean => {
-    return !(this.domainRules.disallow_attester_search_for_domains || []).includes(Str.getDomainFromEmailAddress(emailAddr) || 'NONE');
+    const forbidden = ['*', Str.getDomainFromEmailAddress(emailAddr) || 'NONE'];
+    return !(this.domainRules.disallow_attester_search_for_domains || []).some(domain => forbidden.includes(domain));
   }
 
   /**

--- a/test/source/mock/backend/backend-data.ts
+++ b/test/source/mock/backend/backend-data.ts
@@ -89,6 +89,12 @@ export class BackendData {
         "disallow_attester_search_for_domains": ["flowcrypt.com"]
       };
     }
+    if (domain === 'no-search-wildcard-domains-org-rule.flowcrypt.test') {
+      return {
+        "flags": [],
+        "disallow_attester_search_for_domains": ["*"]
+      };
+    }
     const keyManagerAutogenRules = {
       "flags": [
         "NO_PRV_BACKUP",

--- a/test/source/tests/setup.ts
+++ b/test/source/tests/setup.ts
@@ -483,6 +483,18 @@ AN8G3r5Htj8olot+jm9mIa5XLXWzMNUZgg==
       await composePage.waitAll('@input-password');
     }));
 
+    ava.default('user@no-search-wildcard-domains-org-rule.flowcrypt.test - do not search attester for recipients on any domain', testWithBrowser(undefined, async (t, browser) => {
+      // disallowed searching attester for pubkeys on * domain
+      // below we search for mock.only.pubkey@other.com which normally has pubkey on attester, but none should be found due to the rule
+      const acct = 'user@no-search-wildcard-domains-org-rule.flowcrypt.test';
+      const settingsPage = await BrowserRecipe.openSettingsLoginApprove(t, browser, acct);
+      await SetupPageRecipe.manualEnter(settingsPage, 'flowcrypt.test.key.used.pgp');
+      const composePage = await ComposePageRecipe.openStandalone(t, browser, acct);
+      await ComposePageRecipe.fillMsg(composePage, { to: 'mock.only.pubkey@other.com' }, 'other.com domain should not be found');
+      await composePage.waitForContent('.email_address.no_pgp', 'mock.only.pubkey@other.com');
+      await composePage.waitAll('@input-password');
+    }));
+
     ava.default('get.key@key-manager-autogen.flowcrypt.test - automatic setup with key found on key manager', testWithBrowser(undefined, async (t, browser) => {
       const acct = 'get.key@key-manager-autogen.flowcrypt.test';
       const settingsPage = await BrowserRecipe.openSettingsLoginApprove(t, browser, acct);


### PR DESCRIPTION
This PR disallows attester search alltogether if one of the entries is '*'

close #3563

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation -> issue for docs filed separately https://github.com/FlowCrypt/flowcrypt-docs/issues/161
