### PR TITLE
Disable password automcomplete leaks previous passwords on protected 

### DIFF
--- a/extension/chrome/elements/compose.htm
+++ b/extension/chrome/elements/compose.htm
@@ -131,7 +131,7 @@
             <br /><a href="#" class="add_pubkey" data-test="action-open-add-pubkey-dialog">Add their Public Key</a>
             <div class="warning_nopgp"> or ask them to get FlowCrypt.</div>
             <br />Or send email password protected:
-            <div class="password_input_container"><input id="input_password" placeholder="" tabindex="5"
+            <div class="password_input_container"><input id="input_password" autocomplete="off" placeholder="" tabindex="5"
                 data-test="input-password"></div>
           </div>
         </td>


### PR DESCRIPTION
Suggesting a PR to disable autocomplete on password field when creating/sending a protected message. Adding a `autocomplete='off'` attribute to input_password

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any) - no issue filed, I'll add this PR to milestone directly
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
