### PR TITLE
Disable autocomplete for passwod field on setup.htm

### DIFF
--- a/extension/chrome/elements/passphrase.ts
+++ b/extension/chrome/elements/passphrase.ts
@@ -42,6 +42,9 @@ View.run(class PassphraseView extends View {
     if (!this.orgRules.forbidStoringPassPhrase()) {
       $('.forget').prop('disabled', false);
     }
+    if (this.orgRules.usesKeyManager()) {
+      $('#lost-pass-phrase').text("Ask your IT staff for help if you lost your pass phrase.")
+    }
     await initPassphraseToggle(['passphrase']);
     const allPrivateKeys = await KeyStore.get(this.acctEmail);
     this.keysWeNeedPassPhraseFor = allPrivateKeys.filter(ki => this.longids.includes(ki.longid));

--- a/extension/chrome/settings/setup.htm
+++ b/extension/chrome/settings/setup.htm
@@ -110,10 +110,10 @@
           data-swal-page="/chrome/texts/passphrase_help.htm">choosing
           secure pass phrases</a></div>
       <div class="line left">
-        <input class="input_password" type="text" placeholder="Pass phrase" style="margin-bottom: 0;" id="step_2a_manual_create_input_password" data-test="input-step2bmanualcreate-passphrase-1" />
+        <input class="input_password" autocomplete="off" type="text" placeholder="Pass phrase" style="margin-bottom: 0;" id="step_2a_manual_create_input_password" data-test="input-step2bmanualcreate-passphrase-1" />
       </div>
       <div class="line left">
-        <input class="input_password2" type="text" placeholder="Repeat pass phrase" id="step_2a_manual_create_input_password2" data-test="input-step2bmanualcreate-passphrase-2" />
+        <input class="input_password2" autocomplete="off" type="text" placeholder="Repeat pass phrase" id="step_2a_manual_create_input_password2" data-test="input-step2bmanualcreate-passphrase-2" />
       </div>
 
       <div class="line left">


### PR DESCRIPTION
This adds an attribute `autocomplete="off"` to setup.htm avoiding leaking of passwords in the browser autocomplete suggestion

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
