### PR TITLE
Fix .warning_revoked

### DIFF
--- a/extension/chrome/elements/compose.htm
+++ b/extension/chrome/elements/compose.htm
@@ -127,7 +127,7 @@
           </div>
           <div>
             <div class="warning_nopgp" data-test="warning-nopgp">emails <span class="grey">in grey</span> don't use encryption </div>
-            <div class="warning_revoked" data-test="warning-revoked"></div>emails <span class="orange">in orange</span> have expired or revoked key</div>
+            <div class="warning_revoked" data-test="warning-revoked">emails <span class="orange">in orange</span> have expired or revoked key</div>
             <br /><a href="#" class="add_pubkey" data-test="action-open-add-pubkey-dialog">Add their Public Key</a>
             <div class="warning_nopgp"> or ask them to get FlowCrypt.</div>
             <br />Or send email password protected:

--- a/flowcrypt-browser.code-workspace
+++ b/flowcrypt-browser.code-workspace
@@ -13,6 +13,9 @@
       "typescript",
     ],
     "html.format.enable": false,
+    "htmlhint.options": {
+      "doctype-first": false
+    },
     "files.exclude": {
       "**/node_modules/**": true
     },
@@ -48,6 +51,7 @@
       "dbaeumer.vscode-eslint",
       "stylelint.vscode-stylelint",
       "ms-vscode.vscode-typescript-tslint-plugin",
+      "mkaufman.htmlhint",
       "philhindle.errorlens"
     ]
   }


### PR DESCRIPTION
This PR fixes the HTML markup of `compose.htm` and also

close #3726

I was able to catch this issue with the help of `mkaufman.htmlhint` extension. @tomholub If you think that I should add it to `flowcrypt-browser.code-workspace`'s recommendations, let me know.


<img width="652" alt="CleanShot 2021-07-19 at 14 43 41@2x" src="https://user-images.githubusercontent.com/6059356/126155043-88261340-f08d-4528-a0fe-f32a12fbd974.png">

----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
