### PR TITLE
[Proposal] Always show cc bcc buttons

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -235,7 +235,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
       container.find('r_loader').remove();
     }
     Xss.sanitizeRender(container, '<span class="rest"><span id="rest_number"></span> more</span>');
-    const maxWidth = container.parent().width()!;
+    const maxWidth = container.parent().width()! - this.view.S.cached('container_cc_bcc_buttons').width()!;
     const rest = container.find('.rest');
     let processed = 0;
     while (container.width()! <= maxWidth && orderedRecipients.length >= processed + 1) {

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -1465,7 +1465,19 @@ table#compose td.recipients-inputs .small_spinner img {
 
 table#compose td.recipients-inputs > div#input_addresses_container.invisible {
   height: 0;
-  overflow: hidden;
+  pointer-events: none;
+}
+
+table#compose td.recipients-inputs > div#input_addresses_container.invisible [id^="input-container"] {
+  margin-bottom: -36px;
+}
+
+table#compose td.recipients-inputs > div#input_addresses_container.invisible input {
+  opacity: 0;
+}
+
+table#compose td.recipients-inputs > div#input_addresses_container.invisible .recipients {
+  display: none;
 }
 table#compose td.recipients-inputs > div#input_addresses_container > div { position: relative; }
 
@@ -1575,6 +1587,7 @@ table#compose td.recipients-inputs > div#input_addresses_container div span.cont
   bottom: 6px;
   white-space: nowrap;
   color: #636c72;
+  pointer-events: auto;
 }
 
 table#compose td.recipients-inputs > div#input_addresses_container div span.container-cc-bcc-buttons button {


### PR DESCRIPTION
This PR is a proposed solution for #3115

To clarify, I was not able to reproduce the reported issue in both browsers. Also, my assumption about what might be the cause of the user's issue was wrong (I was assuming that buttons clicks are not handled because buttons are getting hidden right before the click handler).

But, I had to come up with the solution, because the user clearly demonstrated with a video that the issue exists. 

Proposed solution: **always show cc and bcc buttons**. I personally think it is better to always show these buttons even though Gmail is not doing that (but Outlook for example always shows cc/bbc buttons), so users will always see them and be able to click them with one click. 

Another good part about UX is that keyboard users previously had cc/bcc buttons popping up from the invisible state when moving focus with `Tab` which is unexpected. With this change, all focusable elements are visible and expected.

close #3115

----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
