### PR TITLE
Display the number of encrypted attachments

### DIFF
--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -64,6 +64,8 @@ export class GmailElementReplacer implements WebmailElementReplacer {
     standardComposeWin: '.aaZ:visible',
     settingsBtnContainer: 'div.aeH > div > .fY',
     standardComposeRecipient: 'div.az9 span[email][data-hovercard-id]',
+    numberOfAttachments: '.aVW',
+    numberOfAttachmentsDigit: '.aVW span'
   };
 
   constructor(factory: XssSafeFactory, orgRules: OrgRules, acctEmail: string, sendAs: Dict<SendAsAlias>,
@@ -372,7 +374,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
     const senderEmail = this.getSenderEmail(msgEl);
     const isOutgoing = !!this.sendAs[senderEmail];
     attachmentsContainerInner = $(attachmentsContainerInner);
-    attachmentsContainerInner.parent().find('span.aVW').hide(); // original gmail header showing amount of attachments
+    attachmentsContainerInner.parent().find(this.sel.numberOfAttachments).hide();
     let nRenderedAttachments = attachmentMetas.length;
     for (const a of attachmentMetas) {
       const treatAs = a.treatAs();
@@ -442,6 +444,10 @@ export class GmailElementReplacer implements WebmailElementReplacer {
           nRenderedAttachments++;
         }
       }
+    }
+    if (nRenderedAttachments >= 2) { // Aligned with Gmail, the label is shown only if there are 2 or more attachments
+      attachmentsContainerInner.parent().find(this.sel.numberOfAttachmentsDigit).text(nRenderedAttachments);
+      attachmentsContainerInner.parent().find(this.sel.numberOfAttachments).show();
     }
     if (nRenderedAttachments === 0) {
       attachmentsContainerInner.parents(this.sel.attachmentsContainerOuter).first().hide();

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -169,6 +169,13 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       await pgpBlockPage.waitForContent('@pgp-block-content', 'this should decrypt even offline');
     }));
 
+    ava.default('mail.google.com - rendering attachmnents', testWithBrowser('ci.tests.gmail', async (t, browser) => {
+      const gmailPage = await openGmailPage(t, browser, '/FMfcgzGkZZknDVSxBxbNbRqKczcTnZsw');
+      await gmailPage.waitForContent('.aVW', '4 Attachments');
+      const urls = await gmailPage.getFramesUrls(['/chrome/elements/attachment.htm']);
+      expect(urls.length).to.equal(4);
+    }));
+
     ava.default('mail.google.com - msg.asc message content renders', testWithBrowser('ci.tests.gmail', async (t, browser) => {
       const gmailPage = await openGmailPage(t, browser, '/QgrcJHsTjVVKpcZSxSPxWWhHVCCZWpMQCVQ');
       const urls = await gmailPage.getFramesUrls(['/chrome/elements/pgp_block.htm'], { sleep: 10, appearIn: 20 });


### PR DESCRIPTION
This PR displays the number of encrypted attachments:

<img width="365" alt="CleanShot 2021-07-23 at 22 59 25@2x" src="https://user-images.githubusercontent.com/6059356/126835042-9cb7f770-afcd-40e7-99ac-edab958b2824.png">

close #3654 

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
