### PR TITLE
Import revocation information automatically #3637

### DIFF
--- a/extension/chrome/elements/pgp_pubkey.ts
+++ b/extension/chrome/elements/pgp_pubkey.ts
@@ -40,18 +40,17 @@ View.run(class PgpPubkeyView extends View {
   public render = async () => {
     Ui.event.protect();
     try {
-      this.publicKeys = [await KeyUtil.parse(this.armoredPubkey)];
+      const pubKey = await KeyUtil.parse(this.armoredPubkey);
+      this.isExpired = KeyUtil.expired(pubKey);
+      if (pubKey.revoked) {
+        await ContactStore.saveRevocation(undefined, pubKey);
+      }
+      this.publicKeys = [pubKey];
     } catch (e) {
       console.error('Unusable key: ' + e);
       this.publicKeys = [];
     }
     this.primaryPubKey = this.publicKeys ? this.publicKeys[0] : undefined;
-    try {
-      const pubKey = await KeyUtil.parse(this.armoredPubkey);
-      this.isExpired = KeyUtil.expired(pubKey);
-    } catch (e) {
-      console.error('Unusable key: ' + e);
-    }
     $('.pubkey').text(this.armoredPubkey);
     if (this.compact) {
       $('.hide_if_compact').remove();


### PR DESCRIPTION
This PR doesn't allow to import a revoked public key to 'emails' and 'pubkeys' still,
but automatically imports revocation info to 'revocations' store,
with an intention to protect against further possible import of an older version of the revoked key.

close #3637

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
