### PR TITLE
Modified passphrase mismatch message #3192

### DIFF
--- a/extension/js/common/core/crypto/pgp/openpgp-key.ts
+++ b/extension/js/common/core/crypto/pgp/openpgp-key.ts
@@ -313,10 +313,10 @@ export class OpenPGPKey {
       result.set(`key decrypt`, await KeyUtil.formatResultAsync(async () => {
         try {
           await key.decrypt(passphrase); // throws on password mismatch
-          return true;
+          return 'success';
         } catch (e) {
           if (e instanceof Error && e.message.toLowerCase().includes('incorrect key passphrase')) {
-            return false;
+            return 'INCORRECT PASSPHRASE';
           } else {
             throw e;
           }

--- a/test/source/tests/unit-node.ts
+++ b/test/source/tests/unit-node.ts
@@ -1036,7 +1036,7 @@ ZAvn6PBX7vsaReOVa2zsnuY5g70xCxvzHIwR94POu5cENwRtCkrppFnISALpQ1kA
       expect(result.get('Fingerprint')).to.equal('6628 5F84 B985 71BD 01C0 18EE 8B3B B9CF C476 EE16');
       expect(result.get('Subkeys')).to.equal('[-] 1');
       expect(result.get('Primary key algo')).to.equal('[-] rsa_encrypt_sign');
-      expect(result.get('key decrypt')).to.equal('[-] false');
+      expect(result.get('key decrypt')).to.equal('[-] INCORRECT PASSPHRASE');
       expect(result.get('isFullyDecrypted')).to.equal('[-] false');
       expect(result.get('isFullyEncrypted')).to.equal('[-] true');
       expect(result.get('Primary key verify')).to.equal('[-] valid');
@@ -1075,7 +1075,7 @@ ZAvn6PBX7vsaReOVa2zsnuY5g70xCxvzHIwR94POu5cENwRtCkrppFnISALpQ1kA
       expect(result.get('Fingerprint')).to.equal('6628 5F84 B985 71BD 01C0 18EE 8B3B B9CF C476 EE16');
       expect(result.get('Subkeys')).to.equal('[-] 1');
       expect(result.get('Primary key algo')).to.equal('[-] rsa_encrypt_sign');
-      expect(result.get('key decrypt')).to.equal('[-] true');
+      expect(result.get('key decrypt')).to.equal('[-] success');
       expect(result.get('isFullyDecrypted')).to.equal('[-] true');
       expect(result.get('isFullyEncrypted')).to.equal('[-] false');
       expect(result.get('Primary key verify')).to.equal('[-] valid');
@@ -1383,7 +1383,7 @@ jA==
       expect(result.get('Fingerprint')).to.equal('6628 5F84 B985 71BD 01C0 18EE 8B3B B9CF C476 EE16');
       expect(result.get('Subkeys')).to.equal('[-] 1');
       expect(result.get('Primary key algo')).to.equal('[-] rsa_encrypt_sign');
-      expect(result.get('key decrypt')).to.equal('[-] true');
+      expect(result.get('key decrypt')).to.equal('[-] success');
       expect(result.get('isFullyDecrypted')).to.equal('[-] true');
       expect(result.get('isFullyEncrypted')).to.equal('[-] false');
       expect(result.get('Primary key verify')).to.equal('[-] valid');


### PR DESCRIPTION
This PR changes passphrase mismatch message to more evident 'INCORRECT PASSPHRASE'

close #3192

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
