### PR TITLE
Do not bother users with the "loading..." state of contacts suggestions

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -42,12 +42,12 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
 
   private dragged: Element | undefined = undefined;
 
-  private canSearchContacts: boolean;
+  private googleContactsSearchEnabled: boolean;
   private canReadEmails: boolean;
 
   constructor(view: ComposeView) {
     super(view);
-    this.canSearchContacts = this.view.scopes.readContacts;
+    this.googleContactsSearchEnabled = this.view.scopes.readContacts;
     this.canReadEmails = this.view.scopes.read || this.view.scopes.modify;
   }
 
@@ -522,7 +522,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
       this.view.errModule.debug(`searchContacts substring: ${substring}`);
       this.view.errModule.debug(`searchContacts db count: ${contacts.length}`);
       this.renderSearchRes(input, contacts, { substring });
-      if (contacts.length >= this.MAX_CONTACTS_LENGTH || !(this.canReadEmails || this.canSearchContacts)) {
+      if (contacts.length >= this.MAX_CONTACTS_LENGTH || !(this.canReadEmails || this.googleContactsSearchEnabled)) {
         this.view.errModule.debug(`searchContacts 2, count: ${contacts.length}`);
         return;
       }
@@ -544,13 +544,13 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
           this.renderSearchRes(input, contacts, { substring });
         });
       }
+      this.renderSearchResultsLoadingDone();
     } catch (e) {
       Ui.toast(`Error searching contacts: ${ApiErr.eli5(e)}`, 5);
       throw e;
     } finally {
       this.view.errModule.debug('searchContacts 7 - finishing');
       this.contactSearchInProgress = false;
-      this.renderSearchResultsLoadingDone();
     }
   }
 
@@ -572,7 +572,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
   }
 
   private searchContactsOnGoogle = async (query: string, knownContacts: ContactPreview[]): Promise<EmailProviderContact[]> => {
-    if (this.canSearchContacts) {
+    if (this.googleContactsSearchEnabled) {
       this.view.errModule.debug(`searchContacts (Google API) 5`);
       const contactsGoogle = await Google.contactsGet(this.view.acctEmail, query, undefined, this.MAX_CONTACTS_LENGTH);
       if (contactsGoogle && contactsGoogle.length) {
@@ -607,7 +607,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
       return 0;
     });
     const renderableContacts = sortedContacts.slice(0, this.MAX_CONTACTS_LENGTH);
-    if ((renderableContacts.length > 0 || this.contactSearchInProgress) || !this.canSearchContacts) {
+    if ((renderableContacts.length > 0 || this.contactSearchInProgress) || !this.googleContactsSearchEnabled) {
       let ulHtml = '';
       for (const contact of renderableContacts) {
         ulHtml += `<li class="select_contact" email="${Xss.escape(contact.email.replace(/<\/?b>/g, ''))}">`;
@@ -632,7 +632,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
         ulHtml += '</li>';
       }
       Xss.sanitizeRender(this.view.S.cached('contacts').find('ul'), ulHtml);
-      if (!this.canSearchContacts) {
+      if (!this.googleContactsSearchEnabled) {
         if (!contacts.length) {
           this.view.S.cached('contacts').find('ul').append('<li>No Contacts Found</li>'); // xss-direct
         }
@@ -682,7 +682,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
       .click(this.view.setHandler(async () => {
         const authResult = await BrowserMsg.send.bg.await.reconnectAcctAuthPopup({ acctEmail: this.view.acctEmail, scopes: GoogleAuth.defaultScopes('contacts') });
         if (authResult.result === 'Success') {
-          this.canSearchContacts = true;
+          this.googleContactsSearchEnabled = true;
           this.hideContacts();
           input.focus();
           await this.searchContacts(input);
@@ -784,7 +784,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
     this.removeRecipient(connectToGoogleRecipientLine.element);
     const authRes = await GoogleAuth.newAuthPopup({ acctEmail, scopes: GoogleAuth.defaultScopes('contacts') });
     if (authRes.result === 'Success') {
-      this.canSearchContacts = true;
+      this.googleContactsSearchEnabled = true;
       this.canReadEmails = true;
       this.view.scopes.readContacts = true;
       this.view.scopes.read = true;

--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -45,8 +45,6 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
   private canSearchContacts: boolean;
   private canReadEmails: boolean;
 
-  private preventDisplayingContacts: boolean = false;
-
   constructor(view: ComposeView) {
     super(view);
     this.canSearchContacts = this.view.scopes.readContacts;
@@ -633,14 +631,6 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
         }
         ulHtml += '</li>';
       }
-      this.preventDisplayingContacts = false;
-      if (this.contactSearchInProgress) {
-        if (this.canSearchContacts) {
-          this.preventDisplayingContacts = true;
-        } else {
-          ulHtml += '<li class="loading" data-test="container-contacts-loading">loading...</li>';
-        }
-      }
       Xss.sanitizeRender(this.view.S.cached('contacts').find('ul'), ulHtml);
       if (!this.canSearchContacts) {
         if (!contacts.length) {
@@ -674,7 +664,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
       const offsetTop = $('#recipients_row').height()! + offset.top; // both are in the template
       const bottomGap = 10;
       this.view.S.cached('contacts').css({
-        display: this.preventDisplayingContacts ? 'none' : 'block',
+        display: 'none',
         left: leftOffset,
         top: offsetTop,
         maxHeight: `calc(100% - ${offsetTop + bottomGap}px)`,
@@ -770,11 +760,8 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
   }
 
   private renderSearchResultsLoadingDone = () => {
-    this.view.S.cached('contacts').find('ul li.loading').remove();
     if (this.view.S.cached('contacts').find('ul li').length) {
       this.showContacts();
-    } else {
-      this.hideContacts();
     }
   }
 

--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -45,7 +45,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
   private canSearchContacts: boolean;
   private canReadEmails: boolean;
 
-  private preventDisplaying: boolean = false;
+  private preventDisplayingContacts: boolean = false;
 
   constructor(view: ComposeView) {
     super(view);
@@ -633,10 +633,10 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
         }
         ulHtml += '</li>';
       }
-      this.preventDisplaying = false;
+      this.preventDisplayingContacts = false;
       if (this.contactSearchInProgress) {
         if (this.canSearchContacts) {
-          this.preventDisplaying = true;
+          this.preventDisplayingContacts = true;
         } else {
           ulHtml += '<li class="loading" data-test="container-contacts-loading">loading...</li>';
         }
@@ -674,7 +674,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
       const offsetTop = $('#recipients_row').height()! + offset.top; // both are in the template
       const bottomGap = 10;
       this.view.S.cached('contacts').css({
-        display: this.preventDisplaying ? 'none' : 'block',
+        display: this.preventDisplayingContacts ? 'none' : 'block',
         left: leftOffset,
         top: offsetTop,
         maxHeight: `calc(100% - ${offsetTop + bottomGap}px)`,
@@ -773,6 +773,8 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
     this.view.S.cached('contacts').find('ul li.loading').remove();
     if (this.view.S.cached('contacts').find('ul li').length) {
       this.showContacts();
+    } else {
+      this.hideContacts();
     }
   }
 

--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -544,13 +544,13 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
           this.renderSearchRes(input, contacts, { substring });
         });
       }
-      this.renderSearchResultsLoadingDone();
     } catch (e) {
       Ui.toast(`Error searching contacts: ${ApiErr.eli5(e)}`, 5);
       throw e;
     } finally {
       this.view.errModule.debug('searchContacts 7 - finishing');
       this.contactSearchInProgress = false;
+      this.renderSearchResultsLoadingDone();
     }
   }
 
@@ -760,7 +760,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
   }
 
   private renderSearchResultsLoadingDone = () => {
-    if (this.view.S.cached('contacts').find('ul li').length) {
+    if (this.view.S.cached('contacts').find('.select_contact, .allow-google-contact-search').length) {
       this.showContacts();
     }
   }

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -163,6 +163,7 @@ span.gray { color: #b7b7b7; }
 }
 
 .swal2-popup.ui-modal-iframe .swal2-html-container {
+  margin: 0;
   padding: 0;
 }
 

--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -373,6 +373,7 @@ body.cryptup_gmail div.recipients_use_encryption a {
 }
 
 .swal2-popup.ui-modal-iframe .swal2-html-container {
+  margin: 0;
   padding: 0;
 }
 
@@ -401,6 +402,7 @@ body.cryptup_gmail div.recipients_use_encryption a {
 
 .swal2-container.ui-modal-attachment .swal2-html-container {
   height: 100vh;
+  margin: 0;
   padding: 0;
 }
 

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -1292,10 +1292,6 @@ export const expectRecipientElements = async (controllable: ControllablePage, ex
 };
 
 const expectContactsResultEqual = async (composePage: ControllablePage | ControllableFrame, emails: string[]) => {
-  await composePage.waitAny('@container-contacts');
-  await Util.sleep(0.5);
-  await composePage.waitTillGone('@container-contacts-loading');
-  await Util.sleep(0.5);
   const contacts = await composePage.waitAny('@container-contacts');
   const contactsList = await contacts.$$('li');
   for (const index in contactsList) { // tslint:disable-line:forin


### PR DESCRIPTION
This PR prevents showing the contacts suggestion popup which was containing only "loading..." message. It was blinking and unnecessary distracting users when they are typing email addresses into the `#input_to` field:

![CleanShot 2021-07-26 at 22 36 46](https://user-images.githubusercontent.com/6059356/127048248-5478fb17-d884-4b44-af7a-44b1e37452d1.gif)


close #3711

Also, some minor style adjustments for sweetalert2 after the latest update from #3847

----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
