### PR TITLE
Replace flaky sleep timeouts with robust code

### DIFF
--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -245,7 +245,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       await gmailPage.page.keyboard.type('hey there');
       await Util.sleep(5);
       await gmailPage.page.reload();
-      await Util.sleep(5);
+      await Util.sleep(10);
       const replyBox = await pageHasSecureDraft(t, browser, gmailPage, 'hey there');
       await replyBox.waitAndClick('@action-send');
       await Util.sleep(5);

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -246,7 +246,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       await pubkeyPage.waitForContent('@container-pgp-pubkey', 'Fingerprint: DCB2 74D2 4683 145E B053 BC0B 48E4 74A0 926B AE86');
     }));
 
-    ava.default.only('mail.google.com - secure reply btn, reply draft', testWithBrowser('ci.tests.gmail', async (t, browser) => {
+    ava.default('mail.google.com - secure reply btn, reply draft', testWithBrowser('ci.tests.gmail', async (t, browser) => {
       const gmailPage = await openGmailPage(t, browser, '/FMfcgzGkZZqZQpLXZnzPRFKVrwKNnqrN'); // encrypted convo
       await gmailPage.waitAndClick('@secure-reply-button');
       await createSecureDraft(t, browser, gmailPage, 'hey there');

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -40,8 +40,18 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       }
     };
 
+    const createSecureDraft = async (t: AvaContext, browser: BrowserHandle, gmailPage: ControllablePage, content: string) => {
+      const urls = await gmailPage.getFramesUrls(['/chrome/elements/compose.htm']);
+      expect(urls.length).to.equal(1);
+      const replyBox = await browser.newPage(t, urls[0]);
+      await Util.sleep(3); // the draft isn't being saved if start typing without this delay
+      await replyBox.page.keyboard.type(content);
+      await replyBox.verifyContentIsPresentContinuously('@send-btn-note', 'Saved');
+      await replyBox.close();
+    };
+
     const pageHasSecureDraft = async (t: AvaContext, browser: BrowserHandle, gmailPage: ControllablePage, expectedContent?: string) => {
-      await gmailPage.waitAll('iframe');
+      await gmailPage.waitAll('.reply_message');
       const urls = await gmailPage.getFramesUrls(['/chrome/elements/compose.htm']);
       expect(urls.length).to.equal(1);
       const replyBox = await browser.newPage(t, urls[0]);
@@ -236,19 +246,14 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       await pubkeyPage.waitForContent('@container-pgp-pubkey', 'Fingerprint: DCB2 74D2 4683 145E B053 BC0B 48E4 74A0 926B AE86');
     }));
 
-    ava.default('mail.google.com - secure reply btn, reply draft', testWithBrowser('ci.tests.gmail', async (t, browser) => {
-      const gmailPage = await openGmailPage(t, browser, '/FMfcgxwJXVGtMJwQTZmBDlspVWDvsnnL'); // encrypted convo
-      await Util.sleep(5);
-      await pageHasSecureReplyContainer(t, browser, gmailPage, { isReplyPromptAccepted: false });
+    ava.default.only('mail.google.com - secure reply btn, reply draft', testWithBrowser('ci.tests.gmail', async (t, browser) => {
+      const gmailPage = await openGmailPage(t, browser, '/FMfcgzGkZZqZQpLXZnzPRFKVrwKNnqrN'); // encrypted convo
       await gmailPage.waitAndClick('@secure-reply-button');
-      await Util.sleep(3);
-      await gmailPage.page.keyboard.type('hey there');
-      await Util.sleep(5);
+      await createSecureDraft(t, browser, gmailPage, 'hey there');
       await gmailPage.page.reload();
-      await Util.sleep(10);
       const replyBox = await pageHasSecureDraft(t, browser, gmailPage, 'hey there');
       await replyBox.waitAndClick('@action-send');
-      await Util.sleep(5);
+      await replyBox.waitTillGone('@action-send');
       await replyBox.close();
       await gmailPage.page.reload();
       await gmailPage.waitAndClick('.h7:last-child .ajz', { delay: 1 }); // the small triangle which toggles the message details


### PR DESCRIPTION
This PR (hopefully) fixes the flaky gmail test. Locally I'm not able to make the test fail. Last time I increased the sleep from 3 to 5 seconds, but apparently, that's not enough. Increasing to 10. In other similar places the sleep is also 10 seconds:

- https://github.com/FlowCrypt/flowcrypt-browser/blob/master/test/source/tests/gmail.ts#L181
- https://github.com/FlowCrypt/flowcrypt-browser/blob/master/test/source/tests/gmail.ts#L190

(hopefully) close #3481

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
