### PR TITLE
issue 3672 use FES for web portal when available

### DIFF
--- a/extension/chrome/elements/compose-modules/formatters/encrypted-mail-msg-formatter.ts
+++ b/extension/chrome/elements/compose-modules/formatters/encrypted-mail-msg-formatter.ts
@@ -120,7 +120,7 @@ export class EncryptedMsgMailFormatter extends BaseMailFormatter {
           sender: newMsgData.from,
           recipient: Value.arr.withoutVal(Value.arr.withoutVal(recipients, newMsgData.from), this.acctEmail),
           subject: newMsgData.subject,
-          token: response.token,
+          token: response.replyToken,
         })
       });
       return { 'text/plain': newMsgData.plaintext + '\n\n' + infoDiv, 'text/html': newMsgData.plainhtml + '<br /><br />' + infoDiv };

--- a/extension/chrome/elements/compose-modules/formatters/encrypted-mail-msg-formatter.ts
+++ b/extension/chrome/elements/compose-modules/formatters/encrypted-mail-msg-formatter.ts
@@ -107,9 +107,6 @@ export class EncryptedMsgMailFormatter extends BaseMailFormatter {
   }
 
   private getPwdMsgSendableBodyWithOnlineReplyMsgToken = async (authInfo: FcUuidAuth, newMsgData: NewMsgData): Promise<SendableMsgBody> => {
-    if (!authInfo.uuid) {
-      return { 'text/plain': newMsgData.plaintext, 'text/html': newMsgData.plainhtml };
-    }
     const recipients = Array.prototype.concat.apply([], Object.values(newMsgData.recipients));
     try {
       const response = await this.view.acctServer.messageToken(authInfo);

--- a/extension/chrome/elements/compose-modules/formatters/encrypted-mail-msg-formatter.ts
+++ b/extension/chrome/elements/compose-modules/formatters/encrypted-mail-msg-formatter.ts
@@ -39,12 +39,13 @@ export class EncryptedMsgMailFormatter extends BaseMailFormatter {
   private prepareAndUploadPwdEncryptedMsg = async (newMsg: NewMsgData): Promise<string> => {
     // PGP/MIME + included attachments (encrypted for password only)
     const authInfo = await AcctStore.authInfo(this.acctEmail);
-    const msgBodyWithReplyToken = await this.getPwdMsgSendableBodyWithOnlineReplyMsgToken(authInfo, newMsg);
-    const pgpMimeWithAttachments = await Mime.encode(msgBodyWithReplyToken, { Subject: newMsg.subject }, await this.view.attachmentsModule.attachment.collectAttachments());
+    const { bodyWithReplyToken, replyToken } = await this.getPwdMsgSendableBodyWithOnlineReplyMsgToken(authInfo, newMsg);
+    const pgpMimeWithAttachments = await Mime.encode(bodyWithReplyToken, { Subject: newMsg.subject }, await this.view.attachmentsModule.attachment.collectAttachments());
     const { data: pwdEncryptedWithAttachments } = await this.encryptDataArmor(Buf.fromUtfStr(pgpMimeWithAttachments), newMsg.pwd, []); // encrypted only for pwd, not signed
     const { url } = await this.view.acctServer.messageUpload(
       authInfo.uuid ? authInfo : undefined,
       pwdEncryptedWithAttachments,
+      replyToken,
       (p) => this.view.sendBtnModule.renderUploadProgress(p, 'FIRST-HALF'), // still need to upload to Gmail later, this request represents first half of progress
     );
     return url;
@@ -106,7 +107,9 @@ export class EncryptedMsgMailFormatter extends BaseMailFormatter {
     return await MsgUtil.encryptMessage({ pubkeys: pubsForEncryption, signingPrv, pwd, data, armor: true, date: encryptAsOfDate }) as PgpMsgMethod.EncryptAnyArmorResult;
   }
 
-  private getPwdMsgSendableBodyWithOnlineReplyMsgToken = async (authInfo: FcUuidAuth, newMsgData: NewMsgData): Promise<SendableMsgBody> => {
+  private getPwdMsgSendableBodyWithOnlineReplyMsgToken = async (
+    authInfo: FcUuidAuth, newMsgData: NewMsgData
+  ): Promise<{ bodyWithReplyToken: SendableMsgBody, replyToken: string }> => {
     const recipients = Array.prototype.concat.apply([], Object.values(newMsgData.recipients));
     try {
       const response = await this.view.acctServer.messageToken(authInfo);
@@ -120,7 +123,10 @@ export class EncryptedMsgMailFormatter extends BaseMailFormatter {
           token: response.replyToken,
         })
       });
-      return { 'text/plain': newMsgData.plaintext + '\n\n' + infoDiv, 'text/html': newMsgData.plainhtml + '<br /><br />' + infoDiv };
+      return {
+        bodyWithReplyToken: { 'text/plain': newMsgData.plaintext + '\n\n' + infoDiv, 'text/html': newMsgData.plainhtml + '<br /><br />' + infoDiv },
+        replyToken: response.replyToken
+      };
     } catch (msgTokenErr) {
       if (ApiErr.isAuthErr(msgTokenErr)) {
         Settings.offerToLoginWithPopupShowModalOnErr(this.acctEmail);

--- a/extension/js/common/api/account-server.ts
+++ b/extension/js/common/api/account-server.ts
@@ -44,12 +44,23 @@ export class AccountServer extends Api {
     }
   }
 
-  public messageUpload = async (fcAuth: FcUuidAuth | undefined, encryptedDataBinary: Uint8Array, progressCb: ProgressCb): Promise<BackendRes.FcMsgUpload> => {
-    return await FlowCryptComApi.messageUpload(fcAuth, encryptedDataBinary, progressCb);
+  public messageUpload = async (fcAuth: FcUuidAuth | undefined, encrypted: Uint8Array, progressCb: ProgressCb): Promise<{ url: string }> => {
+    if (await this.isFesUsed()) {
+      const fes = new EnterpriseServer(this.acctEmail);
+      return await fes.webPortalMessageUpload(encrypted, progressCb);
+    } else {
+      return await FlowCryptComApi.messageUpload(fcAuth, encrypted, progressCb);
+    }
   }
 
-  public messageToken = async (fcAuth: FcUuidAuth): Promise<BackendRes.FcMsgToken> => {
-    return await FlowCryptComApi.messageToken(fcAuth);
+  public messageToken = async (fcAuth: FcUuidAuth): Promise<{ replyToken: string }> => {
+    if (await this.isFesUsed()) {
+      const fes = new EnterpriseServer(this.acctEmail);
+      return await fes.webPortalMessageNewReplyToken();
+    } else {
+      const res = await FlowCryptComApi.messageToken(fcAuth);
+      return { replyToken: res.token };
+    }
   }
 
   private isFesUsed = async (): Promise<boolean> => {

--- a/extension/js/common/api/account-server.ts
+++ b/extension/js/common/api/account-server.ts
@@ -44,10 +44,10 @@ export class AccountServer extends Api {
     }
   }
 
-  public messageUpload = async (fcAuth: FcUuidAuth | undefined, encrypted: Uint8Array, progressCb: ProgressCb): Promise<{ url: string }> => {
+  public messageUpload = async (fcAuth: FcUuidAuth | undefined, encrypted: Uint8Array, replyToken: string, progressCb: ProgressCb): Promise<{ url: string }> => {
     if (await this.isFesUsed()) {
       const fes = new EnterpriseServer(this.acctEmail);
-      return await fes.webPortalMessageUpload(encrypted, progressCb);
+      return await fes.webPortalMessageUpload(encrypted, replyToken, progressCb);
     } else {
       return await FlowCryptComApi.messageUpload(fcAuth, encrypted, progressCb);
     }

--- a/extension/js/common/api/account-servers/enterprise-server.ts
+++ b/extension/js/common/api/account-servers/enterprise-server.ts
@@ -102,7 +102,7 @@ export class EnterpriseServer extends Api {
   }
 
   public webPortalMessageNewReplyToken = async (): Promise<FesRes.ReplyToken> => {
-    return await this.request<FesRes.ReplyToken>('POST', `/api/${this.apiVersion}/message/new-reply-token`, await this.authHdr());
+    return await this.request<FesRes.ReplyToken>('POST', `/api/${this.apiVersion}/message/new-reply-token`, await this.authHdr(), {});
   }
 
   public webPortalMessageUpload = async (encrypted: Uint8Array, progressCb: ProgressCb): Promise<FesRes.MessageUpload> => {

--- a/extension/js/common/api/account-servers/enterprise-server.ts
+++ b/extension/js/common/api/account-servers/enterprise-server.ts
@@ -107,7 +107,7 @@ export class EnterpriseServer extends Api {
 
   public webPortalMessageUpload = async (encrypted: Uint8Array, progressCb: ProgressCb): Promise<FesRes.MessageUpload> => {
     const content = new Attachment({ name: 'cryptup_encrypted_message.asc', type: 'text/plain', data: encrypted });
-    return await EnterpriseServer.apiCall<FesRes.MessageUpload>(this.url, `/api/${this.apiVersion}/message/upload`, { content },
+    return await EnterpriseServer.apiCall<FesRes.MessageUpload>(this.url, `/api/${this.apiVersion}/message`, { content },
       'FORM', { upload: progressCb }, await this.authHdr(), 'json', 'POST');
   }
 

--- a/extension/js/common/api/account-servers/enterprise-server.ts
+++ b/extension/js/common/api/account-servers/enterprise-server.ts
@@ -5,19 +5,22 @@
 
 'use strict';
 
-import { Api, ReqMethod } from '../shared/api.js';
+import { Api, ProgressCb, ReqMethod } from '../shared/api.js';
 import { AcctStore } from '../../platform/store/acct-store.js';
-import { BackendRes, FlowCryptComApi, ProfileUpdate } from './flowcrypt-com-api.js';
+import { BackendRes, ProfileUpdate } from './flowcrypt-com-api.js';
 import { Dict } from '../../core/common.js';
 import { ErrorReport, UnreportableError } from '../../platform/catch.js';
 import { ApiErr } from '../shared/api-error.js';
 import { FLAVOR } from '../../core/const.js';
+import { Attachment } from '../../core/attachment.js';
 
 // todo - decide which tags to use
 type EventTag = 'compose' | 'decrypt' | 'setup' | 'settings' | 'import-pub' | 'import-prv';
 
 export namespace FesRes {
   export type AccessToken = { accessToken: string };
+  export type ReplyToken = { replyToken: string };
+  export type MessageUpload = { url: string };
   export type ServiceInfo = { vendor: string, service: string, orgId: string, version: string, apiVersion: string }
 }
 
@@ -98,6 +101,16 @@ export class EnterpriseServer extends Api {
     await this.request<void>('POST', `/api/${this.apiVersion}/log-collector/exception`, await this.authHdr(), { tags, message, details });
   }
 
+  public webPortalMessageNewReplyToken = async (): Promise<FesRes.ReplyToken> => {
+    return await this.request<FesRes.ReplyToken>('POST', `/api/${this.apiVersion}/message/new-reply-token`, await this.authHdr());
+  }
+
+  public webPortalMessageUpload = async (encrypted: Uint8Array, progressCb: ProgressCb): Promise<FesRes.MessageUpload> => {
+    const content = new Attachment({ name: 'cryptup_encrypted_message.asc', type: 'text/plain', data: encrypted });
+    return await EnterpriseServer.apiCall<FesRes.MessageUpload>(this.url, `/api/${this.apiVersion}/message/upload`, { content },
+      'FORM', { upload: progressCb }, await this.authHdr(), 'json', 'POST');
+  }
+
   public accountUpdate = async (profileUpdate: ProfileUpdate): Promise<BackendRes.FcAccountUpdate> => {
     console.log('profile update ignored', profileUpdate);
     throw new UnreportableError('Account update not implemented when using FlowCrypt Enterprise Server');
@@ -109,7 +122,7 @@ export class EnterpriseServer extends Api {
   }
 
   private request = async <RT>(method: ReqMethod, path: string, headers: Dict<string> = {}, vals?: Dict<any>): Promise<RT> => {
-    return await FlowCryptComApi.apiCall(this.url, path, vals, method === 'GET' ? undefined : 'JSON', undefined, headers, 'json', method);
+    return await EnterpriseServer.apiCall(this.url, path, vals, method === 'GET' ? undefined : 'JSON', undefined, headers, 'json', method);
   }
 
 }

--- a/extension/js/common/api/account-servers/enterprise-server.ts
+++ b/extension/js/common/api/account-servers/enterprise-server.ts
@@ -105,10 +105,12 @@ export class EnterpriseServer extends Api {
     return await this.request<FesRes.ReplyToken>('POST', `/api/${this.apiVersion}/message/new-reply-token`, await this.authHdr(), {});
   }
 
-  public webPortalMessageUpload = async (encrypted: Uint8Array, progressCb: ProgressCb): Promise<FesRes.MessageUpload> => {
+  public webPortalMessageUpload = async (encrypted: Uint8Array, replyToken: string, progressCb: ProgressCb): Promise<FesRes.MessageUpload> => {
     const content = new Attachment({ name: 'cryptup_encrypted_message.asc', type: 'text/plain', data: encrypted });
-    return await EnterpriseServer.apiCall<FesRes.MessageUpload>(this.url, `/api/${this.apiVersion}/message`, { content },
-      'FORM', { upload: progressCb }, await this.authHdr(), 'json', 'POST');
+    return await EnterpriseServer.apiCall<FesRes.MessageUpload>(
+      this.url, `/api/${this.apiVersion}/message?associate-reply-token=${replyToken}`,
+      { content }, 'FORM', { upload: progressCb }, await this.authHdr(), 'json', 'POST'
+    );
   }
 
   public accountUpdate = async (profileUpdate: ProfileUpdate): Promise<BackendRes.FcAccountUpdate> => {

--- a/test/source/mock/fes/fes-endpoints.ts
+++ b/test/source/mock/fes/fes-endpoints.ts
@@ -62,13 +62,12 @@ export const mockFesEndpoints: HandlersDefinition = {
     }
     throw new HttpClientErr('Not Found', 404);
   },
-  '/api/v1/message/new-reply-token': async ({ }) => { // why is this not getting called?
-    throw new HttpClientErr('why not getting called?', 400);
-    // if (req.headers.host === standardFesUrl && req.method === 'POST') {
-    //   authenticate(req, 'fes');
-    //   return { 'replyToken': 'mock-fes-reply-token' };
-    // }
-    // throw new HttpClientErr('Not Found', 404);
+  '/api/v1/message/new-reply-token': async ({ }, req) => {
+    if (req.headers.host === standardFesUrl && req.method === 'POST') {
+      authenticate(req, 'fes');
+      return { 'replyToken': 'mock-fes-reply-token' };
+    }
+    throw new HttpClientErr('Not Found', 404);
   },
 };
 

--- a/test/source/mock/fes/fes-endpoints.ts
+++ b/test/source/mock/fes/fes-endpoints.ts
@@ -62,13 +62,14 @@ export const mockFesEndpoints: HandlersDefinition = {
     }
     throw new HttpClientErr('Not Found', 404);
   },
-  // '/api/v1/message/new-access-token': async ({ }, req) => { // why is this not getting called?
-  //   if (req.headers.host === standardFesUrl && req.method === 'POST') {
-  //     authenticate(req, 'fes');
-  //     return { 'replyToken': 'mock-fes-reply-token' };
-  //   }
-  //   throw new HttpClientErr('Not Found', 404);
-  // },
+  '/api/v1/message/new-reply-token': async ({ }) => { // why is this not getting called?
+    throw new HttpClientErr('why not getting called?', 400);
+    // if (req.headers.host === standardFesUrl && req.method === 'POST') {
+    //   authenticate(req, 'fes');
+    //   return { 'replyToken': 'mock-fes-reply-token' };
+    // }
+    // throw new HttpClientErr('Not Found', 404);
+  },
 };
 
 const authenticate = (req: IncomingMessage, type: 'oidc' | 'fes'): string => {

--- a/test/source/mock/fes/fes-endpoints.ts
+++ b/test/source/mock/fes/fes-endpoints.ts
@@ -58,6 +58,9 @@ export const mockFesEndpoints: HandlersDefinition = {
   '/api/v1/message': async ({ }, req) => {
     if (req.headers.host === standardFesUrl && req.method === 'POST') {
       authenticate(req, 'fes');
+      if (!req.url!.includes('?associate-reply-token=mock-fes-reply-token')) {
+        throw new HttpClientErr('Missing ?associate-reply-token=mock-fes-reply-token in URL', 404);
+      }
       return { 'url': `http://${standardFesUrl}/message/FES-MOCK-MESSAGE-ID` };
     }
     throw new HttpClientErr('Not Found', 404);

--- a/test/source/mock/fes/fes-endpoints.ts
+++ b/test/source/mock/fes/fes-endpoints.ts
@@ -55,20 +55,17 @@ export const mockFesEndpoints: HandlersDefinition = {
     }
     throw new HttpClientErr('Not Found', 404);
   },
-  '/api/v1/message': async ({ }, req) => {
-    if (req.headers.host === standardFesUrl && req.method === 'POST') {
-      authenticate(req, 'fes');
-      if (!req.url!.includes('?associate-reply-token=mock-fes-reply-token')) {
-        throw new HttpClientErr('Missing ?associate-reply-token=mock-fes-reply-token in URL', 400);
-      }
-      return { 'url': `http://${standardFesUrl}/message/FES-MOCK-MESSAGE-ID` };
-    }
-    throw new HttpClientErr('Not Found', 404);
-  },
   '/api/v1/message/new-reply-token': async ({ }, req) => {
     if (req.headers.host === standardFesUrl && req.method === 'POST') {
       authenticate(req, 'fes');
       return { 'replyToken': 'mock-fes-reply-token' };
+    }
+    throw new HttpClientErr('Not Found', 404);
+  },
+  '/api/v1/message?associate-reply-token=mock-fes-reply-token': async ({ }, req) => {
+    if (req.headers.host === standardFesUrl && req.method === 'POST') {
+      authenticate(req, 'fes');
+      return { 'url': `http://${standardFesUrl}/message/FES-MOCK-MESSAGE-ID` };
     }
     throw new HttpClientErr('Not Found', 404);
   },

--- a/test/source/mock/fes/fes-endpoints.ts
+++ b/test/source/mock/fes/fes-endpoints.ts
@@ -59,7 +59,7 @@ export const mockFesEndpoints: HandlersDefinition = {
     if (req.headers.host === standardFesUrl && req.method === 'POST') {
       authenticate(req, 'fes');
       if (!req.url!.includes('?associate-reply-token=mock-fes-reply-token')) {
-        throw new HttpClientErr('Missing ?associate-reply-token=mock-fes-reply-token in URL', 404);
+        throw new HttpClientErr('Missing ?associate-reply-token=mock-fes-reply-token in URL', 400);
       }
       return { 'url': `http://${standardFesUrl}/message/FES-MOCK-MESSAGE-ID` };
     }

--- a/test/source/mock/fes/fes-endpoints.ts
+++ b/test/source/mock/fes/fes-endpoints.ts
@@ -55,6 +55,20 @@ export const mockFesEndpoints: HandlersDefinition = {
     }
     throw new HttpClientErr('Not Found', 404);
   },
+  '/api/v1/message': async ({ }, req) => {
+    if (req.headers.host === standardFesUrl && req.method === 'POST') {
+      authenticate(req, 'fes');
+      return { 'url': `http://${standardFesUrl}/message/FES-MOCK-MESSAGE-ID` };
+    }
+    throw new HttpClientErr('Not Found', 404);
+  },
+  // '/api/v1/message/new-access-token': async ({ }, req) => { // why is this not getting called?
+  //   if (req.headers.host === standardFesUrl && req.method === 'POST') {
+  //     authenticate(req, 'fes');
+  //     return { 'replyToken': 'mock-fes-reply-token' };
+  //   }
+  //   throw new HttpClientErr('Not Found', 404);
+  // },
 };
 
 const authenticate = (req: IncomingMessage, type: 'oidc' | 'fes'): string => {

--- a/test/source/mock/google/strategies/send-message-strategy.ts
+++ b/test/source/mock/google/strategies/send-message-strategy.ts
@@ -20,7 +20,19 @@ class SaveMessageInStorageStrategy implements ITestMsgStrategy {
 class PwdEncryptedMessageWithFlowCryptComApiTestStrategy implements ITestMsgStrategy {
   public test = async (mimeMsg: ParsedMail, base64Msg: string) => {
     if (!mimeMsg.text?.match(/https:\/\/flowcrypt.com\/[a-z0-9A-Z]{10}/)) {
-      throw new HttpClientErr(`Error: cannot find pwd encrypted link in:\n\n${mimeMsg.text}`);
+      throw new HttpClientErr(`Error: cannot find pwd encrypted flowcrypt.com/api link in:\n\n${mimeMsg.text}`);
+    }
+    if (!mimeMsg.text?.includes('Follow this link to open it')) {
+      throw new HttpClientErr(`Error: cannot find pwd encrypted open link prompt in ${mimeMsg.text}`);
+    }
+    (await GoogleData.withInitializedData(mimeMsg.from!.value[0].address!)).storeSentMessage(mimeMsg, base64Msg);
+  }
+}
+
+class PwdEncryptedMessageWithFesTestStrategy implements ITestMsgStrategy {
+  public test = async (mimeMsg: ParsedMail, base64Msg: string) => {
+    if (!mimeMsg.text?.includes('http://fes.standardsubdomainfes.test:8001/message/FES-MOCK-MESSAGE-ID')) {
+      throw new HttpClientErr(`Error: cannot find pwd encrypted FES link in:\n\n${mimeMsg.text}`);
     }
     if (!mimeMsg.text?.includes('Follow this link to open it')) {
       throw new HttpClientErr(`Error: cannot find pwd encrypted open link prompt in ${mimeMsg.text}`);
@@ -152,6 +164,8 @@ export class TestBySubjectStrategyContext {
       this.strategy = new MessageWithFooterTestStrategy();
     } else if (subject.includes('PWD encrypted message with flowcrypt.com/api')) {
       this.strategy = new PwdEncryptedMessageWithFlowCryptComApiTestStrategy();
+    } else if (subject.includes('PWD encrypted message with FES')) {
+      this.strategy = new PwdEncryptedMessageWithFesTestStrategy();
     } else if (subject.includes('Message With Image')) {
       this.strategy = new SaveMessageInStorageStrategy();
     } else if (subject.includes('Message With Test Text')) {

--- a/test/source/mock/google/strategies/send-message-strategy.ts
+++ b/test/source/mock/google/strategies/send-message-strategy.ts
@@ -17,7 +17,7 @@ class SaveMessageInStorageStrategy implements ITestMsgStrategy {
   }
 }
 
-class PwdEncryptedMessageTestStrategy implements ITestMsgStrategy {
+class PwdEncryptedMessageWithFlowCryptComApiTestStrategy implements ITestMsgStrategy {
   public test = async (mimeMsg: ParsedMail, base64Msg: string) => {
     if (!mimeMsg.text?.match(/https:\/\/flowcrypt.com\/[a-z0-9A-Z]{10}/)) {
       throw new HttpClientErr(`Error: cannot find pwd encrypted link in:\n\n${mimeMsg.text}`);
@@ -150,8 +150,8 @@ export class TestBySubjectStrategyContext {
       this.strategy = new SignedMessageTestStrategy();
     } else if (subject.includes('Test Footer (Mock Test)')) {
       this.strategy = new MessageWithFooterTestStrategy();
-    } else if (subject.includes('PWD encrypted message')) {
-      this.strategy = new PwdEncryptedMessageTestStrategy();
+    } else if (subject.includes('PWD encrypted message with flowcrypt.com/api')) {
+      this.strategy = new PwdEncryptedMessageWithFlowCryptComApiTestStrategy();
     } else if (subject.includes('Message With Image')) {
       this.strategy = new SaveMessageInStorageStrategy();
     } else if (subject.includes('Message With Test Text')) {

--- a/test/source/mock/google/strategies/send-message-strategy.ts
+++ b/test/source/mock/google/strategies/send-message-strategy.ts
@@ -25,7 +25,6 @@ class PwdEncryptedMessageWithFlowCryptComApiTestStrategy implements ITestMsgStra
     if (!mimeMsg.text?.includes('Follow this link to open it')) {
       throw new HttpClientErr(`Error: cannot find pwd encrypted open link prompt in ${mimeMsg.text}`);
     }
-    (await GoogleData.withInitializedData(mimeMsg.from!.value[0].address!)).storeSentMessage(mimeMsg, base64Msg);
   }
 }
 
@@ -37,7 +36,6 @@ class PwdEncryptedMessageWithFesTestStrategy implements ITestMsgStrategy {
     if (!mimeMsg.text?.includes('Follow this link to open it')) {
       throw new HttpClientErr(`Error: cannot find pwd encrypted open link prompt in ${mimeMsg.text}`);
     }
-    (await GoogleData.withInitializedData(mimeMsg.from!.value[0].address!)).storeSentMessage(mimeMsg, base64Msg);
   }
 }
 

--- a/test/source/mock/google/strategies/send-message-strategy.ts
+++ b/test/source/mock/google/strategies/send-message-strategy.ts
@@ -18,7 +18,7 @@ class SaveMessageInStorageStrategy implements ITestMsgStrategy {
 }
 
 class PwdEncryptedMessageWithFlowCryptComApiTestStrategy implements ITestMsgStrategy {
-  public test = async (mimeMsg: ParsedMail, base64Msg: string) => {
+  public test = async (mimeMsg: ParsedMail) => {
     if (!mimeMsg.text?.match(/https:\/\/flowcrypt.com\/[a-z0-9A-Z]{10}/)) {
       throw new HttpClientErr(`Error: cannot find pwd encrypted flowcrypt.com/api link in:\n\n${mimeMsg.text}`);
     }
@@ -29,7 +29,7 @@ class PwdEncryptedMessageWithFlowCryptComApiTestStrategy implements ITestMsgStra
 }
 
 class PwdEncryptedMessageWithFesTestStrategy implements ITestMsgStrategy {
-  public test = async (mimeMsg: ParsedMail, base64Msg: string) => {
+  public test = async (mimeMsg: ParsedMail) => {
     if (!mimeMsg.text?.includes('http://fes.standardsubdomainfes.test:8001/message/FES-MOCK-MESSAGE-ID')) {
       throw new HttpClientErr(`Error: cannot find pwd encrypted FES link in:\n\n${mimeMsg.text}`);
     }

--- a/test/source/mock/lib/api.ts
+++ b/test/source/mock/lib/api.ts
@@ -210,7 +210,12 @@ export class Api<REQ, RES> {
   protected parseReqBody = (body: Buffer, req: http.IncomingMessage): REQ => {
     let parsedBody: string | undefined;
     if (body.length) {
-      if (req.url!.startsWith('/upload/') || req.url!.startsWith('/api/message/upload') || (req.url!.startsWith('/attester/pub/') && req.method === 'POST')) {
+      if (
+        req.url!.startsWith('/upload/') || // gmail message send
+        req.url!.startsWith('/api/message/upload') || // flowcrypt.com/api pwd msg
+        (req.url!.startsWith('/attester/pub/') && req.method === 'POST') || // attester submit
+        req.url! == '/api/v1/message' // FES pwd msg
+      ) {
         parsedBody = body.toString();
       } else {
         parsedBody = JSON.parse(body.toString());

--- a/test/source/mock/lib/api.ts
+++ b/test/source/mock/lib/api.ts
@@ -214,7 +214,7 @@ export class Api<REQ, RES> {
         req.url!.startsWith('/upload/') || // gmail message send
         req.url!.startsWith('/api/message/upload') || // flowcrypt.com/api pwd msg
         (req.url!.startsWith('/attester/pub/') && req.method === 'POST') || // attester submit
-        req.url! === '/api/v1/message' // FES pwd msg
+        req.url!.startsWith('/api/v1/message') // FES pwd msg
       ) {
         parsedBody = body.toString();
       } else {

--- a/test/source/mock/lib/api.ts
+++ b/test/source/mock/lib/api.ts
@@ -214,7 +214,7 @@ export class Api<REQ, RES> {
         req.url!.startsWith('/upload/') || // gmail message send
         req.url!.startsWith('/api/message/upload') || // flowcrypt.com/api pwd msg
         (req.url!.startsWith('/attester/pub/') && req.method === 'POST') || // attester submit
-        req.url! == '/api/v1/message' // FES pwd msg
+        req.url! === '/api/v1/message' // FES pwd msg
       ) {
         parsedBody = body.toString();
       } else {

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -58,7 +58,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await composeFrame.waitAndClick('@action-send');
       await inboxPage.waitAll('@dialog-passphrase');
       const passphraseDialog = await inboxPage.getFrame(['passphrase.htm']);
-      await passphraseDialog.waitForContent('@lost-pass-phrase','Lost pass phrase?');
+      await passphraseDialog.waitForContent('@lost-pass-phrase', 'Lost pass phrase?');
       await passphraseDialog.waitAndType('@input-pass-phrase', k.passphrase);
       await passphraseDialog.waitAndClick('@action-confirm-pass-phrase-entry');
       await inboxPage.waitTillGone('@dialog-passphrase');
@@ -1167,6 +1167,26 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await composePage.waitAny('@input-to');
       await composePage.waitUntilFocused('@input-to');
       await expectRecipientElements(composePage, { to: [], cc: [], bcc: [] });
+    }));
+
+    /**
+     * You need the following lines in /etc/hosts:
+     * 127.0.0.1    standardsubdomainfes.test
+     * 127.0.0.1    fes.standardsubdomainfes.test
+     */
+    ava.default('compose - user@standardsubdomainfes.test:8001 - PWD encrypted message with FES web portal', testWithBrowser(undefined, async (t, browser) => {
+      const acct = 'user@standardsubdomainfes.test:8001'; // added port to trick extension into calling the mock
+      const settingsPage = await BrowserRecipe.openSettingsLoginApprove(t, browser, acct);
+      await SetupPageRecipe.manualEnter(settingsPage, 'flowcrypt.test.key.used.pgp', { submitPubkey: false, usedPgpBefore: false },
+        { isSavePassphraseChecked: false, isSavePassphraseDisabled: false });
+      const msgPwd = 'super hard password for the message';
+      const subject = 'PWD encrypted message with FES';
+      const composePage = await ComposePageRecipe.openStandalone(t, browser, 'user@standardsubdomainfes.test:8001');
+      await ComposePageRecipe.fillMsg(composePage, { to: 'test@email.com' }, subject);
+      const fileInput = await composePage.target.$('input[type=file]');
+      await fileInput!.uploadFile('test/samples/small.txt');
+      await ComposePageRecipe.sendAndClose(composePage, { password: msgPwd });
+      // this test is using PwdEncryptedMessageWithFesTestStrategy to check sent result based on subject "PWD encrypted message with flowcrypt.com/api"
     }));
 
   }

--- a/test/source/tests/flaky.ts
+++ b/test/source/tests/flaky.ts
@@ -112,26 +112,6 @@ export const defineFlakyTests = (testVariant: TestVariant, testWithBrowser: Test
       // this test is using PwdEncryptedMessageWithFlowCryptComApiTestStrategy to check sent result based on subject "PWD encrypted message with flowcrypt.com/api"
     }));
 
-    /**
-     * You need the following lines in /etc/hosts:
-     * 127.0.0.1    standardsubdomainfes.test
-     * 127.0.0.1    fes.standardsubdomainfes.test
-     */
-    ava.default('compose - user@standardsubdomainfes.test:8001 - PWD encrypted message with FES web portal', testWithBrowser(undefined, async (t, browser) => {
-      const acct = 'user@standardsubdomainfes.test:8001'; // added port to trick extension into calling the mock
-      const settingsPage = await BrowserRecipe.openSettingsLoginApprove(t, browser, acct);
-      await SetupPageRecipe.manualEnter(settingsPage, 'flowcrypt.test.key.used.pgp', { submitPubkey: false, usedPgpBefore: false },
-        { isSavePassphraseChecked: false, isSavePassphraseDisabled: false });
-      const msgPwd = 'super hard password for the message';
-      const subject = 'PWD encrypted message with FES';
-      const composePage = await ComposePageRecipe.openStandalone(t, browser, 'user@standardsubdomainfes.test:8001');
-      await ComposePageRecipe.fillMsg(composePage, { to: 'test@email.com' }, subject);
-      const fileInput = await composePage.target.$('input[type=file]');
-      await fileInput!.uploadFile('test/samples/small.txt');
-      await ComposePageRecipe.sendAndClose(composePage, { password: msgPwd });
-      // this test is using PwdEncryptedMessageWithFesTestStrategy to check sent result based on subject "PWD encrypted message with flowcrypt.com/api"
-    }));
-
     ava.default(`[unit][Stream.readToEnd] efficiently handles multiple chunks`, async t => {
       const stream = new ReadableStream<Uint8Array>({
         start(controller) {

--- a/test/source/tests/flaky.ts
+++ b/test/source/tests/flaky.ts
@@ -101,7 +101,7 @@ export const defineFlakyTests = (testVariant: TestVariant, testWithBrowser: Test
       await ComposePageRecipe.sendAndClose(composePage, { timeout: 60, expectProgress: true });
     }));
 
-    ava.default('compose - send pwd encrypted msg & check on flowcrypt site', testWithBrowser('compatibility', async (t, browser) => {
+    ava.default('compose - PWD encrypted message with flowcrypt.com/api', testWithBrowser('compatibility', async (t, browser) => {
       const msgPwd = 'super hard password for the message';
       const subject = 'PWD encrypted message with flowcrypt.com/api';
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
@@ -110,6 +110,26 @@ export const defineFlakyTests = (testVariant: TestVariant, testWithBrowser: Test
       await fileInput!.uploadFile('test/samples/small.txt');
       await ComposePageRecipe.sendAndClose(composePage, { password: msgPwd });
       // this test is using PwdEncryptedMessageWithFlowCryptComApiTestStrategy to check sent result based on subject "PWD encrypted message with flowcrypt.com/api"
+    }));
+
+    /**
+     * You need the following lines in /etc/hosts:
+     * 127.0.0.1    standardsubdomainfes.test
+     * 127.0.0.1    fes.standardsubdomainfes.test
+     */
+    ava.default('compose - user@standardsubdomainfes.test:8001 - PWD encrypted message with FES web portal', testWithBrowser(undefined, async (t, browser) => {
+      const acct = 'user@standardsubdomainfes.test:8001'; // added port to trick extension into calling the mock
+      const settingsPage = await BrowserRecipe.openSettingsLoginApprove(t, browser, acct);
+      await SetupPageRecipe.manualEnter(settingsPage, 'flowcrypt.test.key.used.pgp', { submitPubkey: false, usedPgpBefore: false },
+        { isSavePassphraseChecked: false, isSavePassphraseDisabled: false });
+      const msgPwd = 'super hard password for the message';
+      const subject = 'PWD encrypted message with FES';
+      const composePage = await ComposePageRecipe.openStandalone(t, browser, 'user@standardsubdomainfes.test:8001');
+      await ComposePageRecipe.fillMsg(composePage, { to: 'test@email.com' }, subject);
+      const fileInput = await composePage.target.$('input[type=file]');
+      await fileInput!.uploadFile('test/samples/small.txt');
+      await ComposePageRecipe.sendAndClose(composePage, { password: msgPwd });
+      // this test is using PwdEncryptedMessageWithFesTestStrategy to check sent result based on subject "PWD encrypted message with flowcrypt.com/api"
     }));
 
     ava.default(`[unit][Stream.readToEnd] efficiently handles multiple chunks`, async t => {

--- a/test/source/tests/flaky.ts
+++ b/test/source/tests/flaky.ts
@@ -117,7 +117,7 @@ export const defineFlakyTests = (testVariant: TestVariant, testWithBrowser: Test
      * 127.0.0.1    standardsubdomainfes.test
      * 127.0.0.1    fes.standardsubdomainfes.test
      */
-    ava.default.only('compose - user@standardsubdomainfes.test:8001 - PWD encrypted message with FES web portal', testWithBrowser(undefined, async (t, browser) => {
+    ava.default('compose - user@standardsubdomainfes.test:8001 - PWD encrypted message with FES web portal', testWithBrowser(undefined, async (t, browser) => {
       const acct = 'user@standardsubdomainfes.test:8001'; // added port to trick extension into calling the mock
       const settingsPage = await BrowserRecipe.openSettingsLoginApprove(t, browser, acct);
       await SetupPageRecipe.manualEnter(settingsPage, 'flowcrypt.test.key.used.pgp', { submitPubkey: false, usedPgpBefore: false },

--- a/test/source/tests/flaky.ts
+++ b/test/source/tests/flaky.ts
@@ -103,12 +103,13 @@ export const defineFlakyTests = (testVariant: TestVariant, testWithBrowser: Test
 
     ava.default('compose - send pwd encrypted msg & check on flowcrypt site', testWithBrowser('compatibility', async (t, browser) => {
       const msgPwd = 'super hard password for the message';
-      const subject = 'PWD encrypted message with attachment';
+      const subject = 'PWD encrypted message with flowcrypt.com/api';
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
       await ComposePageRecipe.fillMsg(composePage, { to: 'test@email.com' }, subject);
       const fileInput = await composePage.target.$('input[type=file]');
       await fileInput!.uploadFile('test/samples/small.txt');
       await ComposePageRecipe.sendAndClose(composePage, { password: msgPwd });
+      // this test is using PwdEncryptedMessageWithFlowCryptComApiTestStrategy to check sent result based on subject "PWD encrypted message with flowcrypt.com/api"
     }));
 
     ava.default(`[unit][Stream.readToEnd] efficiently handles multiple chunks`, async t => {

--- a/test/source/tests/flaky.ts
+++ b/test/source/tests/flaky.ts
@@ -117,7 +117,7 @@ export const defineFlakyTests = (testVariant: TestVariant, testWithBrowser: Test
      * 127.0.0.1    standardsubdomainfes.test
      * 127.0.0.1    fes.standardsubdomainfes.test
      */
-    ava.default('compose - user@standardsubdomainfes.test:8001 - PWD encrypted message with FES web portal', testWithBrowser(undefined, async (t, browser) => {
+    ava.default.only('compose - user@standardsubdomainfes.test:8001 - PWD encrypted message with FES web portal', testWithBrowser(undefined, async (t, browser) => {
       const acct = 'user@standardsubdomainfes.test:8001'; // added port to trick extension into calling the mock
       const settingsPage = await BrowserRecipe.openSettingsLoginApprove(t, browser, acct);
       await SetupPageRecipe.manualEnter(settingsPage, 'flowcrypt.test.key.used.pgp', { submitPubkey: false, usedPgpBefore: false },


### PR DESCRIPTION
This PR will use fes.example.com instance instead of flowcrypt.com/api for sending password-protected messages through the web portal - when FES is available.

close #3672

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
