### PR TITLE
Prevent showing contacts popup for empty input

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -170,6 +170,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
 
   public hideContacts = () => {
     this.view.S.cached('contacts').css('display', 'none');
+    this.view.S.cached('contacts').find('ul').empty();
     this.view.S.cached('contacts').children().not('ul').remove();
   }
 

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -95,10 +95,9 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await composePage2.waitAll(['@container-contacts', '@action-select-contact-email(therecipient@theirdomain.com)']);
     }));
 
-    ava.default.only('compose - misc contacts tests', testWithBrowser('ci.tests.gmail', async (t, browser) => {
+    ava.default('compose - should not show contacts for empty #input_to', testWithBrowser('ci.tests.gmail', async (t, browser) => {
       // works on the first search
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compose');
-      debugger;
       await composePage.type('@input-to', 'FirstName'); // test guessing of contacts when the name is not included in email address
       await composePage.waitAll(['@container-contacts', '@action-select-contact-email(therecipient@theirdomain.com)']);
       // submit the first contact by Enter
@@ -106,11 +105,9 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await composePage.waitForContent('@recipient_0', 'therecipient@theirdomain.com');
       // move focus away from #input_to
       await composePage.page.keyboard.press('Tab');
-      // move focus back #input_to
-      await composePage.page.keyboard.down('Shift');
-      await composePage.page.keyboard.press('Tab');
-      await composePage.page.keyboard.up('Shift');
-      // should not show contacts when
+      // move focus back to #input_to
+      await Util.shiftPress(composePage.page.keyboard, 'Tab');
+      // should not show contacts again
       await composePage.notPresent('@container-contacts');
     }));
 

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -58,7 +58,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await composeFrame.waitAndClick('@action-send');
       await inboxPage.waitAll('@dialog-passphrase');
       const passphraseDialog = await inboxPage.getFrame(['passphrase.htm']);
-      await passphraseDialog.waitForContent('@lost-pass-phrase','Lost pass phrase?');
+      await passphraseDialog.waitForContent('@lost-pass-phrase', 'Lost pass phrase?');
       await passphraseDialog.waitAndType('@input-pass-phrase', k.passphrase);
       await passphraseDialog.waitAndClick('@action-confirm-pass-phrase-entry');
       await inboxPage.waitTillGone('@dialog-passphrase');
@@ -93,6 +93,25 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       const composePage2 = await ComposePageRecipe.openStandalone(t, browser, 'compose');
       await composePage2.type('@input-to', 'FirstName'); // test guessing of contacts when the name is not included in email address
       await composePage2.waitAll(['@container-contacts', '@action-select-contact-email(therecipient@theirdomain.com)']);
+    }));
+
+    ava.default.only('compose - misc contacts tests', testWithBrowser('ci.tests.gmail', async (t, browser) => {
+      // works on the first search
+      const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compose');
+      debugger;
+      await composePage.type('@input-to', 'FirstName'); // test guessing of contacts when the name is not included in email address
+      await composePage.waitAll(['@container-contacts', '@action-select-contact-email(therecipient@theirdomain.com)']);
+      // submit the first contact by Enter
+      await composePage.page.keyboard.press('Enter');
+      await composePage.waitForContent('@recipient_0', 'therecipient@theirdomain.com');
+      // move focus away from #input_to
+      await composePage.page.keyboard.press('Tab');
+      // move focus back #input_to
+      await composePage.page.keyboard.down('Shift');
+      await composePage.page.keyboard.press('Tab');
+      await composePage.page.keyboard.up('Shift');
+      // should not show contacts when
+      await composePage.notPresent('@container-contacts');
     }));
 
     ava.default(`compose - can choose found contact`, testWithBrowser('ci.tests.gmail', async (t, browser) => {

--- a/test/source/util/index.ts
+++ b/test/source/util/index.ts
@@ -1,6 +1,7 @@
 /* ©️ 2016 - present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com */
 
 import * as fs from 'fs';
+import { Keyboard, KeyInput } from 'puppeteer';
 
 import { ExtendedKeyInfo, KeyUtil } from '../core/crypto/key.js';
 
@@ -84,6 +85,12 @@ export class Util {
 
   public static sleep = async (seconds: number) => {
     return await new Promise(resolve => setTimeout(resolve, seconds * 1000));
+  }
+
+  public static shiftPress = async (keyboard: Keyboard, key: KeyInput) => {
+    await keyboard.down('Shift');
+    await keyboard.press(key);
+    await keyboard.up('Shift');
   }
 
   public static lousyRandom = () => {


### PR DESCRIPTION
This PR empties the contacts popup when hiding it, so it will not be shown when refocusing `#input_to`

close #3857

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
