### PR TITLE
Fix styles for popups in short frames

### DIFF
--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -2870,7 +2870,7 @@ body#settings div.webmail_notifications div.webmail_notification a:hover { text-
 
   .swal2-popup {
     width: auto !important;
-    grid-template-columns: auto auto;
+    grid-template-columns: auto auto !important;
     align-items: center;
     font-size: 0.75em !important;
     padding: 2px 20px !important;
@@ -2879,6 +2879,7 @@ body#settings div.webmail_notifications div.webmail_notification a:hover { text-
   .swal2-title,
   .swal2-html-container,
   .swal2-actions {
+    margin: 0 !important;
     padding: 0 !important;
   }
 


### PR DESCRIPTION
This PR fixes the styles of popups in short frames so the content and the buttons fit:

<img width="519" alt="CleanShot 2021-08-16 at 11 42 54@2x" src="https://user-images.githubusercontent.com/6059356/129536309-7799e779-f812-4716-a73d-8baa4119480d.png">

close #3908

----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
