### PR TITLE
improved popup message when sending password protected email

### DIFF
--- a/extension/chrome/elements/compose.htm
+++ b/extension/chrome/elements/compose.htm
@@ -123,7 +123,7 @@
           <div id="expiration_note">
             Recipient will have access to this message <a href="#" id="expiration_note_settings_link">for <span id="expiration_note_message_expire">(loading)</span></a>. You are responsible for sharing this password with them (use other medium to share the password - not email).
             <br /> <br />
-            (messages sent to FlowCrypt users have no limit, and don't need password exchange)
+            (Messages sent to FlowCrypt users have no limit for message expiry and don't need password exchange)
           </div>
           <div>
             <div class="warning_nopgp" data-test="warning-nopgp">emails <span class="grey">in grey</span> don't use encryption </div>

--- a/extension/chrome/elements/compose.htm
+++ b/extension/chrome/elements/compose.htm
@@ -123,7 +123,7 @@
           <div id="expiration_note">
             Recipient will have access to this message <a href="#" id="expiration_note_settings_link">for <span id="expiration_note_message_expire">(loading)</span></a>. You are responsible for sharing this password with them (use other medium to share the password - not email).
             <br /> <br />
-            (Messages sent to FlowCrypt users have no limit for message expiry and don't need password exchange)
+            (Messages sent to FlowCrypt users don't expire this way and don't need password exchange)
           </div>
           <div>
             <div class="warning_nopgp" data-test="warning-nopgp">emails <span class="grey">in grey</span> don't use encryption </div>


### PR DESCRIPTION
This PR rephrases the popup message when sending password-protected email into a clearer one.

close #3449 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
