### PR TITLE
Throw an error if keys more than one found.

### DIFF
--- a/extension/js/common/core/crypto/key.ts
+++ b/extension/js/common/core/crypto/key.ts
@@ -125,10 +125,6 @@ export class KeyUtil {
   }
 
   public static parse = async (text: string): Promise<Key> => {
-    const keyLength = (await KeyUtil.parseMany(text)).length;
-    if (keyLength > 1) {
-      throw new Error(`There are ${keyLength} keys found, expecting 1 x509 key`);
-    }
     return (await KeyUtil.parseMany(text))[0];
   }
 

--- a/extension/js/common/core/crypto/key.ts
+++ b/extension/js/common/core/crypto/key.ts
@@ -125,7 +125,12 @@ export class KeyUtil {
   }
 
   public static parse = async (text: string): Promise<Key> => {
-    return (await KeyUtil.parseMany(text))[0];
+    const keys = await KeyUtil.parseMany(text);
+    const keysLength = keys.length;
+    if (keysLength > 1) {
+      throw new Error(`Found ${keysLength} keys, expected one`);
+    }
+    return keys[0];
   }
 
   public static parseMany = async (text: string): Promise<Key[]> => {

--- a/extension/js/common/core/crypto/key.ts
+++ b/extension/js/common/core/crypto/key.ts
@@ -125,6 +125,10 @@ export class KeyUtil {
   }
 
   public static parse = async (text: string): Promise<Key> => {
+    const keyLength = (await KeyUtil.parseMany(text)).length;
+    if (keyLength > 1) {
+      throw new Error(`There are ${keyLength} keys found, expecting 1 x509 key`);
+    }
     return (await KeyUtil.parseMany(text))[0];
   }
 

--- a/extension/js/common/core/crypto/pgp/openpgp-key.ts
+++ b/extension/js/common/core/crypto/pgp/openpgp-key.ts
@@ -20,6 +20,10 @@ export class OpenPGPKey {
 
   public static parse = async (text: string): Promise<Key> => {
     // TODO: Should we throw if more keys are in the armor?
+    const keyLength = (await OpenPGPKey.parseMany(text)).length;
+    if (keyLength > 1) {
+      throw new Error(`There are ${keyLength} keys found, expecting 1 OpenPGP key`);
+    }
     return (await OpenPGPKey.parseMany(text))[0];
   }
 

--- a/extension/js/common/core/crypto/pgp/openpgp-key.ts
+++ b/extension/js/common/core/crypto/pgp/openpgp-key.ts
@@ -19,8 +19,12 @@ export class OpenPGPKey {
   private static minimumBitsByAlgo: { [key: string]: number };
 
   public static parse = async (text: string): Promise<Key> => {
-    // TODO: Should we throw if more keys are in the armor?
-    return (await OpenPGPKey.parseMany(text))[0];
+    const keys = await OpenPGPKey.parseMany(text);
+    const keysLength = keys.length;
+    if (keysLength > 1) {
+      throw new Error(`Found ${keysLength} OpenPGP keys, expected one`);
+    }
+    return keys[0];
   }
 
   public static parseMany = async (text: string): Promise<Key[]> => {

--- a/extension/js/common/core/crypto/pgp/openpgp-key.ts
+++ b/extension/js/common/core/crypto/pgp/openpgp-key.ts
@@ -20,10 +20,6 @@ export class OpenPGPKey {
 
   public static parse = async (text: string): Promise<Key> => {
     // TODO: Should we throw if more keys are in the armor?
-    const keyLength = (await OpenPGPKey.parseMany(text)).length;
-    if (keyLength > 1) {
-      throw new Error(`There are ${keyLength} keys found, expecting 1 OpenPGP key`);
-    }
     return (await OpenPGPKey.parseMany(text))[0];
   }
 

--- a/test/source/tests/unit-node.ts
+++ b/test/source/tests/unit-node.ts
@@ -47,14 +47,15 @@ export let defineUnitNodeTests = (testVariant: TestVariant) => {
 
   if (testVariant !== 'CONSUMER-LIVE-GMAIL') {
 
-    ava.default(`[unit][KeyUtil.parse] throw if read methods expecting exactly one key find more than one`, async t => {
-      const keys = [testConstants.testkey715EDCDC7939A8F7, testConstants.pubkey2864E326A5BE488A].join('\r\n');
-      const returnedKeys = await KeyUtil.parseMany(keys);
-      const keyLength = returnedKeys.length;
-      console.log(keyLength);
-      console.log(typeof(returnedKeys));
-      console.log(returnedKeys);
-      //await expect(await KeyUtil.parse(keys)).to.eventually.be.rejectedWith('There are 2 OpenPGP keys found, expected just one');
+    ava.default(`[unit][KeyUtil.parse] throw if parse methods expecting exactly one key find more than one`, async t => {
+      const unarmoredKeys = Buffer.from([
+        ...(await PgpArmor.dearmor(testConstants.flowcryptcompatibilityPublicKey7FDE685548AEA788)).data,
+        ...(await PgpArmor.dearmor(testConstants.pubkey2864E326A5BE488A)).data
+      ]);
+      const armoredKeys = PgpArmor.armor(opgp.enums.armor.public_key, unarmoredKeys);
+      expect((await KeyUtil.parseMany(armoredKeys)).length).to.equal(2);
+      await t.throwsAsync(() => OpenPGPKey.parse(armoredKeys), { instanceOf: Error, message: 'Found 2 OpenPGP keys, expected one' });
+      await t.throwsAsync(() => KeyUtil.parse(armoredKeys), { instanceOf: Error, message: 'Found 2 keys, expected one' });
       t.pass();
     });
 

--- a/test/source/tests/unit-node.ts
+++ b/test/source/tests/unit-node.ts
@@ -47,6 +47,17 @@ export let defineUnitNodeTests = (testVariant: TestVariant) => {
 
   if (testVariant !== 'CONSUMER-LIVE-GMAIL') {
 
+    ava.default(`[unit][KeyUtil.parse] throw if read methods expecting exactly one key find more than one`, async t => {
+      const keys = [testConstants.testkey715EDCDC7939A8F7, testConstants.pubkey2864E326A5BE488A].join('\r\n');
+      const returnedKeys = await KeyUtil.parseMany(keys);
+      const keyLength = returnedKeys.length;
+      console.log(keyLength);
+      console.log(typeof(returnedKeys));
+      console.log(returnedKeys);
+      //await expect(await KeyUtil.parse(keys)).to.eventually.be.rejectedWith('There are 2 OpenPGP keys found, expected just one');
+      t.pass();
+    });
+
     ava.default(`[unit][MsgBlockParser.detectBlocks] does not get tripped on blocks with unknown headers`, async t => {
       expect(MsgBlockParser.detectBlocks("This text breaks email and Gmail web app.\n\n-----BEGIN FOO-----\n\nEven though it's not a vaild PGP m\n\nMuhahah")).to.deep.equal({
         "blocks": [


### PR DESCRIPTION
This PR will:
* throws an error if the (x509 and OpenPGP) keys found are more than one.

close #2799 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests will be added later (issue #...)
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
