### PR TITLE
Fix handling Gmail's 'Reply to All' button

### DIFF
--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -46,7 +46,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
   private currentlyEvaluatingStandardComposeBoxRecipients = false;
   private currentlyReplacingAttachments = false;
   private keepNextStandardReplyBox = false;
-  private showSwithToEncryptedReplyWarning = false;
+  private showSwitchToEncryptedReplyWarning = false;
   private removeNextReplyBoxBorders = false;
 
   private sel = { // gmail_variant=standard|new
@@ -218,7 +218,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
           const replyContainerIframe = $('.reply_message_iframe_container > iframe').last();
           if (replyContainerIframe.length && !$('#switch_to_encrypted_reply').length) {
             this.keepNextStandardReplyBox = true;
-            this.showSwithToEncryptedReplyWarning = $(target).closest(this.sel.msgOuter).find('iframe.pgp_block').hasClass('encryptedMsg');
+            this.showSwitchToEncryptedReplyWarning = $(target).closest(this.sel.msgOuter).find('iframe.pgp_block').hasClass('encryptedMsg');
           }
         }));
       }
@@ -626,7 +626,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
         if (this.keepNextStandardReplyBox) {
           for (const replyBoxEl of newReplyBoxes) {
             $(replyBoxEl).addClass('reply_message_evaluated');
-            if (this.showSwithToEncryptedReplyWarning) {
+            if (this.showSwitchToEncryptedReplyWarning) {
               const notification = $('<div class="error_notification">The last message was encrypted, but you are composing a reply without encryption. </div>');
               const swithToEncryptedReply = $('<a href id="switch_to_encrypted_reply">Switch to encrypted reply</a>');
               swithToEncryptedReply.click(Ui.event.handle((el, ev: JQuery.Event) => {
@@ -639,7 +639,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
             }
           }
           this.keepNextStandardReplyBox = false;
-          this.showSwithToEncryptedReplyWarning = false;
+          this.showSwitchToEncryptedReplyWarning = false;
           return;
         }
         for (const replyBoxEl of newReplyBoxes.reverse()) { // looping in reverse


### PR DESCRIPTION
This PR adds the already existed for the "Reply" button handler which keeps the default Gmail's reply block 

close #3926

----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing, there are already live Gmail tests for the "Reply" button, which is btw re-enabled in #3930 

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
