### PR TITLE
Remove toast modal when invalid email is detected

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,7 +40,8 @@ module.exports = {
       "ignoreDeclarationSort": false,
       "ignoreMemberSort": false,
       "memberSyntaxSortOrder": ["none", "all", "multiple", "single"]
-    }]
+    }],
+    'space-before-blocks': ['error', 'always'],
   },
   overrides: [
     {

--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -164,7 +164,7 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
         } else {
           Catch.reportErr(e);
           this.view.S.cached('send_btn_note').text('Not saved (error)');
-          Ui.toast(`Draft not saved: ${Xss.htmlSanitizeAndStripAllTags(e,'\n')}`, 5); // xss-escaped
+          Ui.toast(`Draft not saved: ${Xss.htmlSanitizeAndStripAllTags(String(e), '\n')}`, 5); // xss-escaped
         }
       }
       this.currentlySavingDraft = false;

--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -162,7 +162,7 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
           this.view.threadId = ''; // forget there was a threadId
           await this.draftSave(true); // forceSave=true to not skip
         } else if (e instanceof InvalidRecipientError) {
-          this.view.S.cached('send_btn_note').text('Not saved (invalid recepients)');
+          this.view.S.cached('send_btn_note').text('Not saved (invalid recipients)');
         } else {
           Catch.reportErr(e);
           this.view.S.cached('send_btn_note').text('Not saved (error)');

--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -162,9 +162,7 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
           this.view.threadId = ''; // forget there was a threadId
           await this.draftSave(true); // forceSave=true to not skip
         } else {
-          Catch.reportErr(e);
           this.view.S.cached('send_btn_note').text('Not saved (error)');
-          Ui.toast(`Draft not saved: ${Xss.htmlSanitizeAndStripAllTags(String(e), '\n')}`, 5); // xss-escaped
         }
       }
       this.currentlySavingDraft = false;

--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -161,11 +161,12 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
           // not found - creating draft on a thread that does not exist
           this.view.threadId = ''; // forget there was a threadId
           await this.draftSave(true); // forceSave=true to not skip
-        } else if (e instanceof InvalidRecipientError){
-          this.view.S.cached('send_btn_note').text('Not saved (error)');
+        } else if (e instanceof InvalidRecipientError) {
+          this.view.S.cached('send_btn_note').text('Not saved (invalid recepients)');
         } else {
           Catch.reportErr(e);
-          Ui.toast(`Draft not saved: ${Xss.htmlSanitizeAndStripAllTags(String(e), '\n')}`, 5); // xss-escaped
+          Ui.toast(`Draft not saved: ${e}`, false, 5);
+          this.view.S.cached('send_btn_note').text('Not saved (error)');
         }
       }
       this.currentlySavingDraft = false;

--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -4,7 +4,7 @@
 
 import { Mime, MimeContent, MimeProccesedMsg } from '../../../js/common/core/mime.js';
 import { AjaxErr } from '../../../js/common/api/shared/api-error.js';
-import { ApiErr } from '../../../js/common/api/shared/api-error.js';
+import { ApiErr, InvalidRecipientError } from '../../../js/common/api/shared/api-error.js';
 import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
 import { Buf } from '../../../js/common/core/buf.js';
 import { Catch } from '../../../js/common/platform/catch.js';
@@ -161,8 +161,11 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
           // not found - creating draft on a thread that does not exist
           this.view.threadId = ''; // forget there was a threadId
           await this.draftSave(true); // forceSave=true to not skip
-        } else {
+        } else if (e instanceof InvalidRecipientError){
           this.view.S.cached('send_btn_note').text('Not saved (error)');
+        } else {
+          Catch.reportErr(e);
+          Ui.toast(`Draft not saved: ${Xss.htmlSanitizeAndStripAllTags(String(e), '\n')}`, 5); // xss-escaped
         }
       }
       this.currentlySavingDraft = false;

--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -165,8 +165,8 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
           this.view.S.cached('send_btn_note').text('Not saved (invalid recepients)');
         } else {
           Catch.reportErr(e);
-          Ui.toast(`Draft not saved: ${e}`, false, 5);
           this.view.S.cached('send_btn_note').text('Not saved (error)');
+          Ui.toast(`Draft not saved: ${e}`, false, 5);
         }
       }
       this.currentlySavingDraft = false;

--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -162,9 +162,7 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
           this.view.threadId = ''; // forget there was a threadId
           await this.draftSave(true); // forceSave=true to not skip
         } else {
-          Catch.reportErr(e);
           this.view.S.cached('send_btn_note').text('Not saved (error)');
-          Ui.toast(`Draft not saved: ${e}`, 5);
         }
       }
       this.currentlySavingDraft = false;

--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -162,7 +162,9 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
           this.view.threadId = ''; // forget there was a threadId
           await this.draftSave(true); // forceSave=true to not skip
         } else {
+          Catch.reportErr(e);
           this.view.S.cached('send_btn_note').text('Not saved (error)');
+          Ui.toast(`Draft not saved: ${Xss.htmlSanitizeAndStripAllTags(e,'\n')}`, 5); // xss-escaped
         }
       }
       this.currentlySavingDraft = false;

--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -4,7 +4,7 @@
 
 import { Mime, MimeContent, MimeProccesedMsg } from '../../../js/common/core/mime.js';
 import { AjaxErr } from '../../../js/common/api/shared/api-error.js';
-import { ApiErr, InvalidRecipientError } from '../../../js/common/api/shared/api-error.js';
+import { ApiErr } from '../../../js/common/api/shared/api-error.js';
 import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
 import { Buf } from '../../../js/common/core/buf.js';
 import { Catch } from '../../../js/common/platform/catch.js';
@@ -22,7 +22,7 @@ import { ViewModule } from '../../../js/common/view-module.js';
 import { ComposeView } from '../compose.js';
 import { KeyStore } from '../../../js/common/platform/store/key-store.js';
 import { KeyUtil } from '../../../js/common/core/crypto/key.js';
-import { SendableMsg } from '../../../js/common/api/email-provider/sendable-msg.js';
+import { SendableMsg, InvalidRecipientError } from '../../../js/common/api/email-provider/sendable-msg.js';
 
 export class ComposeDraftModule extends ViewModule<ComposeView> {
 

--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -546,7 +546,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
         });
       }
     } catch (e) {
-      Ui.toast(`Error searching contacts: ${ApiErr.eli5(e)}`, 5);
+      Ui.toast(`Error searching contacts: ${ApiErr.eli5(e)}`, false, 5);
       throw e;
     } finally {
       this.view.errModule.debug('searchContacts 7 - finishing');

--- a/extension/chrome/elements/compose-modules/compose-storage-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-storage-module.ts
@@ -132,7 +132,7 @@ export class ComposeStorageModule extends ViewModule<ComposeView> {
           const key = await KeyUtil.parse(pubkey);
           if (!key.usableForEncryption && !key.revoked && !KeyUtil.expired(key)) { // Not to skip expired and revoked keys
             console.info('Dropping found+parsed key because getEncryptionKeyPacket===null', { for: email, fingerprint: key.id });
-            Ui.toast(`Public Key retrieved for email ${email} with id ${key.id} was ignored because it's not usable for encryption.`, 5);
+            Ui.toast(`Public Key retrieved for email ${email} with id ${key.id} was ignored because it's not usable for encryption.`, false, 5);
           } else {
             pubkeys.push(key);
           }

--- a/extension/js/common/api/email-provider/sendable-msg.ts
+++ b/extension/js/common/api/email-provider/sendable-msg.ts
@@ -8,6 +8,8 @@ import { Attachment } from '../../core/attachment.js';
 import { Buf } from '../../core/buf.js';
 import { RecipientType } from '../shared/api.js';
 import { KeyStore } from '../../platform/store/key-store.js';
+import { InvalidRecipientError } from '../../api/shared/api-error.js';
+
 
 type Recipients = { to?: string[], cc?: string[], bcc?: string[] };
 
@@ -122,7 +124,7 @@ export class SendableMsg {
     }
     const invalidEmails = allEmails.filter(email => !Str.isEmailValid(email));
     if (invalidEmails.length) {
-      throw new Error(`The To: field contains invalid emails: ${invalidEmails.join(', ')}\n\nPlease check recipients and try again.`);
+      throw new InvalidRecipientError(`The To: field contains invalid emails: ${invalidEmails.join(', ')}\n\nPlease check recipients and try again.`);
     }
   }
 

--- a/extension/js/common/api/email-provider/sendable-msg.ts
+++ b/extension/js/common/api/email-provider/sendable-msg.ts
@@ -8,7 +8,6 @@ import { Attachment } from '../../core/attachment.js';
 import { Buf } from '../../core/buf.js';
 import { RecipientType } from '../shared/api.js';
 import { KeyStore } from '../../platform/store/key-store.js';
-import { InvalidRecipientError } from '../../api/shared/api-error.js';
 
 
 type Recipients = { to?: string[], cc?: string[], bcc?: string[] };
@@ -34,6 +33,8 @@ type SendableMsgDefinition = SendableMsgHeaders
     body?: SendableMsgBody;
     attachments?: Attachment[];
   };
+
+export class InvalidRecipientError extends Error { }
 
 export class SendableMsg {
 

--- a/extension/js/common/api/email-provider/sendable-msg.ts
+++ b/extension/js/common/api/email-provider/sendable-msg.ts
@@ -9,7 +9,6 @@ import { Buf } from '../../core/buf.js';
 import { RecipientType } from '../shared/api.js';
 import { KeyStore } from '../../platform/store/key-store.js';
 
-
 type Recipients = { to?: string[], cc?: string[], bcc?: string[] };
 
 type SendableMsgHeaders = {

--- a/extension/js/common/api/shared/api-error.ts
+++ b/extension/js/common/api/shared/api-error.ts
@@ -20,7 +20,6 @@ interface RawAjaxErr {
 abstract class AuthErr extends Error { }
 export class GoogleAuthErr extends AuthErr { }
 export class BackendAuthErr extends AuthErr { }
-export class InvalidRecipientError extends Error { }
 
 abstract class ApiCallErr extends Error {
 

--- a/extension/js/common/api/shared/api-error.ts
+++ b/extension/js/common/api/shared/api-error.ts
@@ -20,6 +20,7 @@ interface RawAjaxErr {
 abstract class AuthErr extends Error { }
 export class GoogleAuthErr extends AuthErr { }
 export class BackendAuthErr extends AuthErr { }
+export class InvalidRecipientError extends Error { }
 
 abstract class ApiCallErr extends Error {
 

--- a/extension/js/common/browser/ui.ts
+++ b/extension/js/common/browser/ui.ts
@@ -442,11 +442,12 @@ export class Ui {
     return $(`<${name}/>`, attrs)[0].outerHTML; // xss-tested: jquery escapes attributes
   }
 
-  public static toast = (msg: string, seconds = 2, position: SweetAlertPosition = 'bottom', icon?: SweetAlertIcon) => {
+  public static toast = (text: string, isHTML: boolean = false, seconds = 2, position: SweetAlertPosition = 'bottom', icon?: SweetAlertIcon) => {
+    text = isHTML ? Xss.htmlSanitize(text) : Xss.escape(text).replace(/\n/g, '<br>');
     // tslint:disable-next-line:no-floating-promises
     Ui.swal().fire({
       toast: true,
-      title: msg,
+      title: text,
       icon,
       showConfirmButton: false,
       position,

--- a/extension/js/common/inject.ts
+++ b/extension/js/common/inject.ts
@@ -64,7 +64,7 @@ export class Injector {
       this.S.cached('body').append(composeWin); // xss-safe-factory
       return true;
     } else {
-      Ui.toast('Only 3 FlowCrypt windows can be opened at a time', 3, 'top', 'error');
+      Ui.toast('Only 3 FlowCrypt windows can be opened at a time', false, 3, 'top', 'error');
       return false;
     }
   }


### PR DESCRIPTION
This PR will remove the toast and the reported error in the console when an invalid email was detected.

close #3932 // if this PR closes an issue
close #3557 


----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)


--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
