### PR TITLE
Support click back on submitted attachments

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-attachments-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-attachments-module.ts
@@ -3,9 +3,10 @@
 'use strict';
 
 import { AttachmentLimits, AttachmentUI } from '../../../js/common/ui/attachment-ui.js';
+import { Browser } from '../../../js/common/browser/browser.js';
+import { ComposeView } from '../compose.js';
 import { Ui } from '../../../js/common/browser/ui.js';
 import { ViewModule } from '../../../js/common/view-module.js';
-import { ComposeView } from '../compose.js';
 
 export class ComposeAttachmentsModule extends ViewModule<ComposeView> {
 
@@ -23,6 +24,11 @@ export class ComposeAttachmentsModule extends ViewModule<ComposeView> {
         this.view.sizeModule.setInputTextHeightManuallyIfNeeded();
         this.view.sizeModule.resizeComposeBox();
       }
+    });
+    this.view.S.cached('body').on('click', '#attachment_list li', async (e: JQuery.Event) => {
+      const fileId = $(e.currentTarget).attr('qq-file-id') as string;
+      const attachment = await this.attachment.collectAttachment(fileId);
+      Browser.saveToDownloads(attachment);
     });
   }
 

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -2049,6 +2049,7 @@ table#compose #fineuploader .qq-upload-list [class^="qq-file-id"] {
   background-size: 9px;
   background-position-x: 8px;
   background-position-y: center;
+  cursor: pointer;
 }
 
 table#compose #fineuploader .qq-upload-list .not-encrypted {

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -1043,6 +1043,11 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await pastePublicKeyManually(composeFrame, inboxPage, 'smime.attachment@recipient.com', testConstants.smimeCert);
       const fileInput = await composeFrame.target.$('input[type=file]');
       await fileInput!.uploadFile('test/samples/small.txt', 'test/samples/small.png', 'test/samples/small.pdf');
+      // attachments in composer can be downloaded
+      const fileText = await inboxPage.awaitDownloadTriggeredByClicking(async () => {
+        await composeFrame.click('.qq-file-id-0');
+      });
+      expect(fileText.toString()).to.equal(`small text file\nnot much here\nthis worked\n`);
       await composeFrame.waitAndClick('@action-send', { delay: 2 });
       await inboxPage.waitTillGone('@container-new-message');
     }));


### PR DESCRIPTION
This PR adds the ability to download submitted attachments back when composing encrypted emails

close #3896

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
