### PR TITLE
exclude searching for backups from Gmail trash

### DIFF
--- a/extension/js/common/core/const.ts
+++ b/extension/js/common/core/const.ts
@@ -31,5 +31,6 @@ export const gmailBackupSearchQuery = (acctEmail: string) => {
     'to:' + acctEmail,
     '(subject:"' + GMAIL_RECOVERY_EMAIL_SUBJECTS.join('" OR subject: "') + '")',
     '-is:spam',
+    '-is:trash'
   ].join(' ');
 };


### PR DESCRIPTION
This PR excludes searching backups from the Gmail trash when recovering an account.

close #3968 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests will be added later (issue #...)
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
