### PR TITLE
Ask dependabot not to bother about iso-8859-2 and openpgp deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/"
+    open-pull-requests-limit: 1
     schedule:
       interval: "daily"
     ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
       # ignore all bootstrap major updates
       - dependency-name: "bootstrap"
         update-types: ["version-update:semver-major"]
+      # TODO: upgrade iso-8859-2 when ava will have ESM support: https://github.com/orgs/avajs/projects/2
+      # https://github.com/FlowCrypt/flowcrypt-browser/pull/3961#issuecomment-921335748
+      - dependency-name: "iso-8859-2"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "openpgp"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
This PR configures dependabot not to bother about these deps:

- `iso-8859-2`, because it's ESM and ava doesn't have ESM support for now, https://github.com/FlowCrypt/flowcrypt-browser/pull/3961#issuecomment-921335748
- `openpgp`, because the upgrade isn't easy and will be done in #3324

Also, 1 PR by dependabot per time to avoid parallel CI builds, rebasing and git conflicts.

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
