### PR TITLE
Change the storage path for local/offline drafts

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -90,7 +90,6 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
   public draftDelete = async () => {
     clearInterval(this.saveDraftInterval);
     await Ui.time.wait(() => !this.currentlySavingDraft ? true : undefined);
-    console.log(this.view.draftId);
     if (this.view.draftId) {
       try {
         if (this.isLocalDraftId(this.view.draftId)) {

--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -175,6 +175,19 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
     return `${this.localDraftPrefix}${this.view.threadId}`;
   }
 
+  public localDraftGet = async (): Promise<GmailRes.GmailDraftGet | undefined> => {
+    const draftId = this.getLocalDraftId();
+    const storage = await GlobalStore.get(['local_drafts']);
+    if (typeof storage.local_drafts === 'undefined') {
+      return undefined;
+    }
+    const localDraft = storage.local_drafts[draftId];
+    if (this.isValidLocalDraft(localDraft)) {
+      return localDraft;
+    }
+    return undefined;
+  }
+
   private draftSetPrefixIntoBody = (sendable: SendableMsg) => {
     let prefix: string;
     if (this.view.threadId) { // reply draft
@@ -222,19 +235,6 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
     storage.local_drafts[draftId] = { id: '', message: { id: '', historyId: '', raw: Buf.fromUtfStr(mimeMsg).toBase64UrlStr(), threadId } };
     await GlobalStore.set(storage);
     return draftId;
-  }
-
-  private localDraftGet = async (): Promise<GmailRes.GmailDraftGet | undefined> => {
-    const draftId = this.getLocalDraftId();
-    const storage = await GlobalStore.get(['local_drafts']);
-    if (typeof storage.local_drafts === 'undefined') {
-      return undefined;
-    }
-    const localDraft = storage.local_drafts[draftId];
-    if (this.isValidLocalDraft(localDraft)) {
-      return localDraft;
-    }
-    return undefined;
   }
 
   private localDraftRemove = async () => {

--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -10,10 +10,10 @@ import { Buf } from '../../../js/common/core/buf.js';
 import { Catch } from '../../../js/common/platform/catch.js';
 import { EncryptedMsgMailFormatter } from './formatters/encrypted-mail-msg-formatter.js';
 import { Env } from '../../../js/common/browser/env.js';
+import { GlobalStore } from '../../../js/common/platform/store/global-store.js';
 import { GmailRes } from '../../../js/common/api/email-provider/gmail/gmail-parser.js';
 import { MsgBlockParser } from '../../../js/common/core/msg-block-parser.js';
 import { MsgUtil } from '../../../js/common/core/crypto/pgp/msg-util.js';
-import { storageLocalGet, storageLocalSet, storageLocalRemove } from '../../../js/common/browser/chrome.js';
 import { Ui } from '../../../js/common/browser/ui.js';
 import { Url } from '../../../js/common/core/common.js';
 import { Xss } from '../../../js/common/platform/xss.js';
@@ -90,10 +90,14 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
   public draftDelete = async () => {
     clearInterval(this.saveDraftInterval);
     await Ui.time.wait(() => !this.currentlySavingDraft ? true : undefined);
+    console.log(this.view.draftId);
     if (this.view.draftId) {
       try {
-        await this.view.emailProvider.draftDelete(this.view.draftId);
-        await this.localDraftRemove();
+        if (this.isLocalDraftId(this.view.draftId)) {
+          await this.localDraftRemove();
+        } else {
+          await this.view.emailProvider.draftDelete(this.view.draftId);
+        }
         this.view.draftId = '';
       } catch (e) {
         if (ApiErr.isAuthErr(e)) {
@@ -125,11 +129,10 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
         const mimeMsg = await sendable.toMime();
         // If a draft was loaded from the local storage, once a user is back online, the local draft will be moved to the email provider
         if (!this.view.draftId || this.isLocalDraftId(this.view.draftId)) {
-          const draftId = await this.doUploadDraftWithLocalStorageFallback(mimeMsg, async () => {
+          this.view.draftId = await this.doUploadDraftWithLocalStorageFallback(mimeMsg, async () => {
             const { id } = await this.view.emailProvider.draftCreate(mimeMsg, this.view.threadId);
             return id;
           });
-          this.view.draftId = draftId;
           // recursing one more time, because we need the draftId we get from this reply in the message itself
           // essentially everytime we save draft for the first time, we have to save it twice
           // currentlySavingDraft will remain true for now
@@ -137,7 +140,7 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
             await this.draftSave(true); // forceSave = true
           }
         } else {
-          await this.doUploadDraftWithLocalStorageFallback(mimeMsg, async () => {
+          this.view.draftId = await this.doUploadDraftWithLocalStorageFallback(mimeMsg, async () => {
             await this.view.emailProvider.draftUpdate(this.view.draftId, mimeMsg, this.view.threadId);
             return this.view.draftId;
           });
@@ -212,14 +215,23 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
   }
 
   private localDraftCreate = async (mimeMsg: string, threadId: string) => {
+    const storage = await GlobalStore.get(['local_drafts']);
+    if (typeof storage.local_drafts === 'undefined') {
+      storage.local_drafts = {};
+    }
     const draftId = this.getLocalDraftId();
-    await storageLocalSet({ [draftId]: { message: { raw: Buf.fromUtfStr(mimeMsg).toBase64UrlStr(), threadId } } });
+    storage.local_drafts[draftId] = { id: '', message: { id: '', historyId: '', raw: Buf.fromUtfStr(mimeMsg).toBase64UrlStr(), threadId } };
+    await GlobalStore.set(storage);
     return draftId;
   }
 
   private localDraftGet = async (): Promise<GmailRes.GmailDraftGet | undefined> => {
     const draftId = this.getLocalDraftId();
-    const { [draftId]: localDraft } = await storageLocalGet([draftId]);
+    const storage = await GlobalStore.get(['local_drafts']);
+    if (typeof storage.local_drafts === 'undefined') {
+      return undefined;
+    }
+    const localDraft = storage.local_drafts[draftId];
     if (this.isValidLocalDraft(localDraft)) {
       return localDraft;
     }
@@ -228,7 +240,11 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
 
   private localDraftRemove = async () => {
     const draftId = this.getLocalDraftId();
-    await storageLocalRemove([draftId]);
+    const storage = await GlobalStore.get(['local_drafts']);
+    if (typeof storage.local_drafts !== 'undefined') {
+      delete storage.local_drafts[draftId];
+      await GlobalStore.set(storage);
+    }
   }
 
   private isValidLocalDraft = (localDraft: unknown): localDraft is GmailRes.GmailDraftGet => {

--- a/extension/chrome/elements/compose-modules/compose-render-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-render-module.ts
@@ -29,12 +29,11 @@ export class ComposeRenderModule extends ViewModule<ComposeView> {
   public initComposeBox = async () => {
     if (this.view.isReplyBox) {
       this.responseMethod = 'reply';
-    } else { // compose
-      if (!this.view.draftId) {
-        this.view.draftId = this.view.draftModule.getLocalDraftId();
-      }
     }
     this.initComposeBoxStyles();
+    if (!this.view.draftId && await this.view.draftModule.localDraftGet()) {
+      this.view.draftId = this.view.draftModule.getLocalDraftId();
+    }
     if (this.view.draftId) {
       const draftLoaded = await this.view.draftModule.initialDraftLoad();
       if (draftLoaded) {

--- a/extension/js/background_page/migrations.ts
+++ b/extension/js/background_page/migrations.ts
@@ -48,21 +48,22 @@ export const migrateGlobal = async () => {
     console.info('done migrating');
   }
   // migrate local drafts (#3337)
-  const storageLocal = await storageLocalGetAll();
   if (typeof globalStore.local_drafts === 'undefined') {
+    console.info('migrating local drafts in old format...');
     globalStore.local_drafts = {};
-  }
-  const oldDrafts = [];
-  for (const key of Object.keys(storageLocal)) {
-    if (key.startsWith('local-draft-')) {
-      console.info(`migrating local draft ${key}`);
-      globalStore.local_drafts[key] = storageLocal[key] as GmailRes.GmailDraftGet;
-      oldDrafts.push(key);
+    const storageLocal = await storageLocalGetAll();
+    const oldDrafts = [];
+    for (const key of Object.keys(storageLocal)) {
+      if (key.startsWith('local-draft-')) {
+        console.info(`migrating local draft ${key}`);
+        globalStore.local_drafts[key] = storageLocal[key] as GmailRes.GmailDraftGet;
+        oldDrafts.push(key);
+      }
     }
-  }
-  if (oldDrafts.length) {
-    await GlobalStore.set({ local_drafts: globalStore.local_drafts });
-    await storageLocalRemove(oldDrafts);
+    if (oldDrafts.length) {
+      await GlobalStore.set({ local_drafts: globalStore.local_drafts });
+      await storageLocalRemove(oldDrafts);
+    }
   }
 };
 

--- a/extension/js/background_page/migrations.ts
+++ b/extension/js/background_page/migrations.ts
@@ -52,15 +52,18 @@ export const migrateGlobal = async () => {
   if (typeof globalStore.local_drafts === 'undefined') {
     globalStore.local_drafts = {};
   }
+  const oldDrafts = [];
   for (const key of Object.keys(storageLocal)) {
     if (key.startsWith('local-draft-')) {
-      console.log(key);
       console.info(`migrating local draft ${key}`);
       globalStore.local_drafts[key] = storageLocal[key] as GmailRes.GmailDraftGet;
-      await storageLocalRemove([key]);
+      oldDrafts.push(key);
     }
   }
-  await GlobalStore.set({ local_drafts: globalStore.local_drafts });
+  if (oldDrafts.length) {
+    await GlobalStore.set({ local_drafts: globalStore.local_drafts });
+    await storageLocalRemove(oldDrafts);
+  }
 };
 
 const processSmimeKey = (pubkey: Pubkey, tx: IDBTransaction, data: PubkeyMigrationData, next: () => void) => {

--- a/extension/js/background_page/migrations.ts
+++ b/extension/js/background_page/migrations.ts
@@ -2,6 +2,8 @@
 
 'use strict';
 
+import { GmailRes } from '../common/api/email-provider/gmail/gmail-parser.js';
+import { storageLocalGetAll, storageLocalRemove } from '../common/browser/chrome.js';
 import { KeyInfo, KeyUtil } from '../common/core/crypto/key.js';
 import { SmimeKey } from '../common/core/crypto/smime/smime-key.js';
 import { ContactStore, ContactUpdate, Email, Pubkey } from '../common/platform/store/contact-store.js';
@@ -38,13 +40,27 @@ const addKeyInfoFingerprints = async () => {
 };
 
 export const migrateGlobal = async () => {
-  const globalStore = await GlobalStore.get(['key_info_store_fingerprints_added']);
+  const globalStore = await GlobalStore.get(['key_info_store_fingerprints_added', 'local_drafts']);
   if (!globalStore.key_info_store_fingerprints_added) {
     console.info('migrating KeyStorage to add fingerprints and emails of each key...');
     await addKeyInfoFingerprints();
     await GlobalStore.set({ key_info_store_fingerprints_added: true });
     console.info('done migrating');
   }
+  // migrate local drafts (#3337)
+  const storageLocal = await storageLocalGetAll();
+  if (typeof globalStore.local_drafts === 'undefined') {
+    globalStore.local_drafts = {};
+  }
+  for (const key of Object.keys(storageLocal)) {
+    if (key.startsWith('local-draft-')) {
+      console.log(key);
+      console.info(`migrating local draft ${key}`);
+      globalStore.local_drafts[key] = storageLocal[key] as GmailRes.GmailDraftGet;
+      await storageLocalRemove([key]);
+    }
+  }
+  await GlobalStore.set({ local_drafts: globalStore.local_drafts });
 };
 
 const processSmimeKey = (pubkey: Pubkey, tx: IDBTransaction, data: PubkeyMigrationData, next: () => void) => {

--- a/extension/js/common/platform/store/global-store.ts
+++ b/extension/js/common/platform/store/global-store.ts
@@ -2,8 +2,9 @@
 
 import { BrowserMsg } from '../../browser/browser-msg.js';
 import { Env } from '../../browser/env.js';
+import { GmailRes } from '../../../common/api/email-provider/gmail/gmail-parser.js';
 import { RawStore, AbstractStore } from './abstract-store.js';
-import { Value } from '../../core/common.js';
+import { Dict, Value } from '../../core/common.js';
 import { storageLocalSet, storageLocalGet, storageLocalRemove } from '../../browser/chrome.js';
 import { Catch } from '../catch.js';
 
@@ -19,11 +20,13 @@ export type GlobalStoreDict = {
   key_info_store_fingerprints_added?: boolean;
   contact_store_x509_fingerprints_and_longids_updated?: boolean;
   contact_store_opgp_revoked_flags_updated?: boolean;
+  local_drafts?: Dict<GmailRes.GmailDraftGet>;
 };
 
 export type GlobalIndex = 'version' | 'account_emails' | 'settings_seen' | 'hide_pass_phrases' |
   'dev_outlook_allow' | 'install_mobile_app_notification_dismissed' | 'key_info_store_fingerprints_added' |
-  'contact_store_x509_fingerprints_and_longids_updated' | 'contact_store_opgp_revoked_flags_updated';
+  'contact_store_x509_fingerprints_and_longids_updated' | 'contact_store_opgp_revoked_flags_updated' |
+  'local_drafts';
 
 /**
  * Locally stored data that is not associated with any email account


### PR DESCRIPTION
This PR puts all local drafts into 1 place in storage, under the `local_drafts` key. Also, it adds the migration, so users will not lose their local drafts which were saved in the old format.

close #3337

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
