### PR TITLE
issue #3801 Store debug files as Sempahore job artifacts

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -84,5 +84,6 @@ blocks:
           commands:
             - |
               if [ -f build/test/test/debugArtifacts/debugHtmlAttachment-0.html ]; then
+                echo "Uploading debug files as job artifacts..."
                 artifact push job build/test/test/debugArtifacts/debugHtmlAttachment-*.html
               fi

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -83,6 +83,6 @@ blocks:
         on_fail:
           commands:
             - |
-              if [ -f test/tmp/debugHtmlAttachment-0.html ]; then
-                artifact push job test/tmp/debugHtmlAttachment-*.html
+              if [ -f build/test/test/debugArtifacts/debugHtmlAttachment-0.html ]; then
+                artifact push job build/test/test/debugArtifacts/debugHtmlAttachment-*.html
               fi

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -78,3 +78,11 @@ blocks:
             - npm run-script test_ci_chrome_enterprise
             - cd ./build && zip -r ~/chrome-enterprise.zip ./chrome-enterprise/* && cd ~
 #            - if [ "$SEMAPHORE_GIT_BRANCH" = master ]; artifact push project chrome-enterprise.zip --force; fi
+
+      epilogue:
+        on_fail:
+          commands:
+            - |
+              if [ -f test/tmp/debugHtmlAttachment-0.html ]; then
+                artifact push job test/tmp/debugHtmlAttachment-*.html
+              fi

--- a/test/source/test.ts
+++ b/test/source/test.ts
@@ -7,7 +7,7 @@ import { BrowserHandle, BrowserPool } from './browser';
 import { Config, Util, getParsedCliParams } from './util';
 
 import { BrowserRecipe } from './tests/tooling/browser-recipe';
-import { FlowCryptApi } from './tests/tooling/api';
+// import { FlowCryptApi } from './tests/tooling/api';
 import { defineComposeTests } from './tests/compose';
 import { defineDecryptTests } from './tests/decrypt';
 import { defineElementTests } from './tests/elements';
@@ -20,7 +20,8 @@ import { defineUnitBrowserTests } from './tests/unit-browser';
 import { mock } from './mock';
 import { mockBackendData } from './mock/backend/backend-endpoints';
 import { TestUrls } from './browser/test-urls';
-import { writeFileSync } from 'fs';
+import { realpathSync, writeFileSync } from 'fs';
+// import fileSize from 'filesize';
 
 export const { testVariant, testGroup, oneIfNotPooled, buildDir, isMock } = getParsedCliParams();
 export const internalTestState = { expectIntentionalErrReport: false }; // updated when a particular test that causes an error is run
@@ -155,9 +156,12 @@ ava.after.always('send debug info if any', async t => {
   if (debugHtmlAttachments.length) {
     console.info(`FAIL ID ${testId}`);
     standaloneTestTimeout(t, consts.TIMEOUT_SHORT, t.title);
+    const debugArtifactDir = realpathSync(`${__dirname}/..`) + "/tmp";
     for (let i = 0; i < debugHtmlAttachments.length; i++) {
-      const subject = `${testId} ${i + 1}/${debugHtmlAttachments.length}`;
-      await FlowCryptApi.hookCiDebugEmail(subject, debugHtmlAttachments[i]);
+      // const subject = `${testId} ${i + 1}/${debugHtmlAttachments.length}`;
+      // await FlowCryptApi.hookCiDebugEmail(subject, debugHtmlAttachments[i]);
+      const filePath = `${debugArtifactDir}/debugHtmlAttachment-${i}.html}`;
+      writeFileSync(filePath, debugHtmlAttachments[i]);
     }
   } else {
     console.info(`no fails to debug`);

--- a/test/source/test.ts
+++ b/test/source/test.ts
@@ -20,7 +20,7 @@ import { defineUnitBrowserTests } from './tests/unit-browser';
 import { mock } from './mock';
 import { mockBackendData } from './mock/backend/backend-endpoints';
 import { TestUrls } from './browser/test-urls';
-import { realpathSync, writeFileSync } from 'fs';
+import { mkdirSync, realpathSync, writeFileSync } from 'fs';
 // import fileSize from 'filesize';
 
 export const { testVariant, testGroup, oneIfNotPooled, buildDir, isMock } = getParsedCliParams();
@@ -156,7 +156,8 @@ ava.after.always('send debug info if any', async t => {
   if (debugHtmlAttachments.length) {
     console.info(`FAIL ID ${testId}`);
     standaloneTestTimeout(t, consts.TIMEOUT_SHORT, t.title);
-    const debugArtifactDir = realpathSync(`${__dirname}/..`) + "/tmp";
+    const debugArtifactDir = realpathSync(`${__dirname}/..`) + "/debugArtifacts";
+    mkdirSync(debugArtifactDir);
     for (let i = 0; i < debugHtmlAttachments.length; i++) {
       // const subject = `${testId} ${i + 1}/${debugHtmlAttachments.length}`;
       // await FlowCryptApi.hookCiDebugEmail(subject, debugHtmlAttachments[i]);

--- a/test/source/test.ts
+++ b/test/source/test.ts
@@ -156,14 +156,18 @@ ava.after.always('send debug info if any', async t => {
   if (debugHtmlAttachments.length) {
     console.info(`FAIL ID ${testId}`);
     standaloneTestTimeout(t, consts.TIMEOUT_SHORT, t.title);
+    console.info(`There are ${debugHtmlAttachments.length} debug files.`);
     const debugArtifactDir = realpathSync(`${__dirname}/..`) + "/debugArtifacts";
     mkdirSync(debugArtifactDir);
     for (let i = 0; i < debugHtmlAttachments.length; i++) {
       // const subject = `${testId} ${i + 1}/${debugHtmlAttachments.length}`;
       // await FlowCryptApi.hookCiDebugEmail(subject, debugHtmlAttachments[i]);
-      const filePath = `${debugArtifactDir}/debugHtmlAttachment-${i}.html}`;
+      const fileName = `debugHtmlAttachment-${i}.html`;
+      const filePath = `${debugArtifactDir}/${fileName}`;
+      console.info(`Writing debug file ${fileName}`);
       writeFileSync(filePath, debugHtmlAttachments[i]);
     }
+    console.info('All debug files written.');
   } else {
     console.info(`no fails to debug`);
   }


### PR DESCRIPTION
This PR updates Semaphore CI workflow to store debug files generated by tests as job artifact.

close #3801

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
