### PR TITLE
Save pass phrase for all matching keys

### DIFF
--- a/extension/chrome/elements/passphrase.ts
+++ b/extension/chrome/elements/passphrase.ts
@@ -147,7 +147,8 @@ View.run(class PassphraseView extends View {
     const pass = String($('#passphrase').val());
     const storageType: StorageType = ($('.forget-pass-phrase-checkbox').prop('checked') || this.orgRules.forbidStoringPassPhrase()) ? 'session' : 'local';
     let atLeastOneMatched = false;
-    for (const keyinfo of this.keysWeNeedPassPhraseFor!) { // if passphrase matches more keys, it will save the pass phrase for all keys
+    const allPrivateKeys = await KeyStore.get(this.acctEmail);
+    for (const keyinfo of allPrivateKeys) { // if passphrase matches more keys, it will save the pass phrase for all keys
       const prv = await KeyUtil.parse(keyinfo.private);
       try {
         if (await KeyUtil.decrypt(prv, pass) === true) {


### PR DESCRIPTION
This PR unlocks all keys that match the pass phrase and keeps the pass phrase for all keys that matched. 

close #3963

----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
