### PR TITLE
issue 3751 use client-configuration endpoint on FES

### DIFF
--- a/extension/js/common/api/account-servers/enterprise-server.ts
+++ b/extension/js/common/api/account-servers/enterprise-server.ts
@@ -15,6 +15,7 @@ import { FLAVOR } from '../../core/const.js';
 import { Attachment } from '../../core/attachment.js';
 import { Recipients } from '../email-provider/email-provider-api.js';
 import { Buf } from '../../core/buf.js';
+import { DomainRulesJson } from '../../org-rules.js';
 
 // todo - decide which tags to use
 type EventTag = 'compose' | 'decrypt' | 'setup' | 'settings' | 'import-pub' | 'import-prv';
@@ -24,6 +25,7 @@ export namespace FesRes {
   export type ReplyToken = { replyToken: string };
   export type MessageUpload = { url: string };
   export type ServiceInfo = { vendor: string, service: string, orgId: string, version: string, apiVersion: string }
+  export type ClientConfiguration = { clientConfiguration: DomainRulesJson };
 }
 
 /**
@@ -87,10 +89,10 @@ export class EnterpriseServer extends Api {
     await AcctStore.set(this.acctEmail, { fesAccessToken: response.accessToken });
   }
 
-  public getAccountAndUpdateLocalStore = async (): Promise<BackendRes.FcAccountGet> => {
-    const r = await this.request<BackendRes.FcAccountGet>('GET', `/api/${this.apiVersion}/account/`, await this.authHdr());
-    await AcctStore.set(this.acctEmail, { rules: r.domain_org_rules });
-    return r;
+  public fetchAndSaveOrgRules = async (): Promise<DomainRulesJson> => {
+    const r = await this.request<FesRes.ClientConfiguration>('GET', `/api/${this.apiVersion}/client-configuration?domain=${this.domain}`);
+    await AcctStore.set(this.acctEmail, { rules: r.clientConfiguration });
+    return r.clientConfiguration;
   }
 
   public reportException = async (errorReport: ErrorReport): Promise<void> => {

--- a/extension/js/common/api/account-servers/flowcrypt-com-api.ts
+++ b/extension/js/common/api/account-servers/flowcrypt-com-api.ts
@@ -20,7 +20,7 @@ export type SubscriptionInfo = { level?: SubscriptionLevel; expired?: boolean };
 
 export namespace BackendRes {
   export type FcAccountLogin = { registered: boolean, verified: boolean };
-  export type FcAccount$info = { alias: string, email: string, intro: string, name: string, photo: string, default_message_expire: number };
+  export type FcAccount$info = { alias?: string | null, default_message_expire: number };
   export type FcAccountGet = { account: FcAccount$info, subscription: SubscriptionInfo, domain_org_rules: DomainRulesJson };
   export type FcAccountUpdate = { result: FcAccount$info, updated: boolean };
   export type FcAccountSubscribe = { subscription: SubscriptionInfo };

--- a/test/source/mock/fes/fes-endpoints.ts
+++ b/test/source/mock/fes/fes-endpoints.ts
@@ -44,9 +44,11 @@ export const mockFesEndpoints: HandlersDefinition = {
     throw new HttpClientErr('Not Found', 404);
   },
   '/api/v1/client-configuration': async ({ }, req) => {
-    // ?domain=fes.localhost:8001
-    // ?domain=fes.standardsubdomainfes.test:8001
-    // ?domain=fes.google.mock.flowcryptlocal.test:8001
+    // actual individual OrgRules are tested using FlowCrypt backend mock instead,
+    //   see BackendData.getOrgRules
+    if (req.url !== '/api/v1/client-configuration?domain=standardsubdomainfes.test:8001') {
+      throw new HttpClientErr('Unexpected domain, expecting standardsubdomainfes.test:8001', 400);
+    }
     if (req.headers.host === standardFesUrl && req.method === 'GET') {
       return {
         clientConfiguration: { disallow_attester_search_for_domains: ['got.this@fromstandardfes.com'] },

--- a/test/source/mock/fes/fes-endpoints.ts
+++ b/test/source/mock/fes/fes-endpoints.ts
@@ -43,15 +43,13 @@ export const mockFesEndpoints: HandlersDefinition = {
     }
     throw new HttpClientErr('Not Found', 404);
   },
-  '/api/v1/account/': async ({ }, req) => {
+  '/api/v1/client-configuration': async ({ }, req) => {
+    // ?domain=fes.localhost:8001
+    // ?domain=fes.standardsubdomainfes.test:8001
+    // ?domain=fes.google.mock.flowcryptlocal.test:8001
     if (req.headers.host === standardFesUrl && req.method === 'GET') {
-      authenticate(req, 'fes');
       return {
-        account: {
-          default_message_expire: 30
-        },
-        subscription: { level: 'pro', expire: null, method: 'group', expired: 'false' }, // tslint:disable-line:no-null-keyword
-        domain_org_rules: { disallow_attester_search_for_domains: ['got.this@fromstandardfes.com'] },
+        clientConfiguration: { disallow_attester_search_for_domains: ['got.this@fromstandardfes.com'] },
       };
     }
     throw new HttpClientErr('Not Found', 404);


### PR DESCRIPTION
This PR uses this endpoint https://fes.flowcrypt.com/api/v1/client-configuration?domain=flowcrypt.com (or similar depending on customer domain) to fetch client configuration (org rules) from FES, instead of the `/api/v1/account/` endpoint which was authenticated.

This is to avoid relying on a non-OIDC access token, which our customer doesn't prefer.

close #3751

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
