### PR TITLE
issue 4018 generic InMemoryStore

### DIFF
--- a/extension/js/background_page/background_page.ts
+++ b/extension/js/background_page/background_page.ts
@@ -54,8 +54,8 @@ opgp.initWorker({ path: '/lib/openpgp.worker.js' });
 
   // storage related handlers
   BrowserMsg.bgAddListener('db', (r: Bm.Db) => BgHandlers.dbOperationHandler(db, r));
-  BrowserMsg.bgAddListener('inMemoryStoreGet', async (r: Bm.InMemoryStoreSet) => inMemoryStore.set(emailKeyIndex(r.acctEmail, r.key), r.value));
-  BrowserMsg.bgAddListener('inMemoryStoreSet', async (r: Bm.InMemoryStoreGet) => inMemoryStore.get(emailKeyIndex(r.acctEmail, r.key)));
+  BrowserMsg.bgAddListener('inMemoryStoreSet', async (r: Bm.InMemoryStoreSet) => inMemoryStore.set(emailKeyIndex(r.acctEmail, r.key), r.value));
+  BrowserMsg.bgAddListener('inMemoryStoreGet', async (r: Bm.InMemoryStoreGet) => inMemoryStore.get(emailKeyIndex(r.acctEmail, r.key)));
   BrowserMsg.bgAddListener('storeGlobalGet', (r: Bm.StoreGlobalGet) => GlobalStore.get(r.keys));
   BrowserMsg.bgAddListener('storeGlobalSet', (r: Bm.StoreGlobalSet) => GlobalStore.set(r.values));
   BrowserMsg.bgAddListener('storeAcctGet', (r: Bm.StoreAcctGet) => AcctStore.get(r.acctEmail, r.keys));

--- a/extension/js/background_page/background_page.ts
+++ b/extension/js/background_page/background_page.ts
@@ -25,8 +25,8 @@ opgp.initWorker({ path: '/lib/openpgp.worker.js' });
 
   let db: IDBDatabase;
   let storage: GlobalStoreDict;
-  const inMemoryPassPhrases = new ExpirationCache(4 * 60 * 60 * 1000); // 4 hours
-  Catch.setHandledInterval(() => inMemoryPassPhrases.deleteExpired(), 60000); // each minute
+  const inMemoryStore = new ExpirationCache(4 * 60 * 60 * 1000); // 4 hours
+  Catch.setHandledInterval(() => inMemoryStore.deleteExpired(), 60000); // each minute
 
   try {
     await migrateGlobal();
@@ -54,8 +54,8 @@ opgp.initWorker({ path: '/lib/openpgp.worker.js' });
 
   // storage related handlers
   BrowserMsg.bgAddListener('db', (r: Bm.Db) => BgHandlers.dbOperationHandler(db, r));
-  BrowserMsg.bgAddListener('session_passphrase_set', async (r: Bm.StoreSessionSet) => inMemoryPassPhrases.set(emailKeyIndex(r.acctEmail, r.key), r.value));
-  BrowserMsg.bgAddListener('session_passphrase_get', async (r: Bm.StoreSessionGet) => inMemoryPassPhrases.get(emailKeyIndex(r.acctEmail, r.key)));
+  BrowserMsg.bgAddListener('inMemoryStoreGet', async (r: Bm.InMemoryStoreSet) => inMemoryStore.set(emailKeyIndex(r.acctEmail, r.key), r.value));
+  BrowserMsg.bgAddListener('inMemoryStoreSet', async (r: Bm.InMemoryStoreGet) => inMemoryStore.get(emailKeyIndex(r.acctEmail, r.key)));
   BrowserMsg.bgAddListener('storeGlobalGet', (r: Bm.StoreGlobalGet) => GlobalStore.get(r.keys));
   BrowserMsg.bgAddListener('storeGlobalSet', (r: Bm.StoreGlobalSet) => GlobalStore.set(r.values));
   BrowserMsg.bgAddListener('storeAcctGet', (r: Bm.StoreAcctGet) => AcctStore.get(r.acctEmail, r.keys));

--- a/extension/js/common/browser/browser-msg.ts
+++ b/extension/js/common/browser/browser-msg.ts
@@ -49,8 +49,8 @@ export namespace Bm {
   export type StripeResult = { token: string };
   export type PassphraseEntry = { entered: boolean, initiatorFrameId?: string };
   export type Db = { f: string, args: any[] };
-  export type StoreSessionSet = { acctEmail: string, key: string, value: string | undefined };
-  export type StoreSessionGet = { acctEmail: string, key: string };
+  export type InMemoryStoreSet = { acctEmail: string, key: string, value: string | undefined };
+  export type InMemoryStoreGet = { acctEmail: string, key: string };
   export type StoreGlobalGet = { keys: GlobalIndex[]; };
   export type StoreGlobalSet = { values: GlobalStoreDict; };
   export type StoreAcctGet = { acctEmail: string, keys: AccountIndex[]; };
@@ -70,8 +70,8 @@ export namespace Bm {
 
   export namespace Res {
     export type GetActiveTabInfo = { provider: 'gmail' | undefined, acctEmail: string | undefined, sameWorld: boolean | undefined };
-    export type StoreSessionGet = string | null;
-    export type StoreSessionSet = void;
+    export type InMemoryStoreGet = string | null;
+    export type InMemoryStoreSet = void;
     export type StoreGlobalGet = GlobalStoreDict;
     export type StoreGlobalSet = void;
     export type StoreAcctGet = AcctStoreDict;
@@ -91,7 +91,7 @@ export namespace Bm {
 
     export type Any = GetActiveTabInfo | _tab_ | ReconnectAcctAuthPopup
       | PgpMsgDecrypt | PgpMsgDiagnoseMsgPubkeys | PgpMsgVerify | PgpHashChallengeAnswer | PgpMsgType | KeyParse
-      | StoreSessionGet | StoreSessionSet | StoreAcctGet | StoreAcctSet | StoreGlobalGet | StoreGlobalSet
+      | InMemoryStoreGet | InMemoryStoreSet | StoreAcctGet | StoreAcctSet | StoreGlobalGet | StoreGlobalSet
       | AjaxGmailAttachmentGetChunk | KeyMatch;
   }
 
@@ -99,7 +99,7 @@ export namespace Bm {
     AddPubkeyDialog | ReinsertReplyBox | ComposeWindow | ScrollToReplyBox | ScrollToCursorInReplyBox | SubscribeDialog |
     RenderPublicKeys | NotificationShowAuthPopupNeeded |
     NotificationShow | PassphraseDialog | PassphraseDialog | Settings | SetCss | AddOrRemoveClass | ReconnectAcctAuthPopup |
-    Db | StoreSessionSet | StoreSessionGet | StoreGlobalGet | StoreGlobalSet | StoreAcctGet | StoreAcctSet | KeyParse |
+    Db | InMemoryStoreSet | InMemoryStoreGet | StoreGlobalGet | StoreGlobalSet | StoreAcctGet | StoreAcctSet | KeyParse |
     PgpMsgDecrypt | PgpMsgDiagnoseMsgPubkeys | PgpMsgVerifyDetached | PgpHashChallengeAnswer | PgpMsgType | Ajax |
     ShowAttachmentPreview | ReRenderRecipient | KeyMatch;
 
@@ -133,8 +133,8 @@ export class BrowserMsg {
       await: {
         reconnectAcctAuthPopup: (bm: Bm.ReconnectAcctAuthPopup) => BrowserMsg.sendAwait(undefined, 'reconnect_acct_auth_popup', bm, true) as Promise<Bm.Res.ReconnectAcctAuthPopup>,
         getActiveTabInfo: () => BrowserMsg.sendAwait(undefined, 'get_active_tab_info', undefined, true) as Promise<Bm.Res.GetActiveTabInfo>,
-        storeSessionPassphraseGet: (bm: Bm.StoreSessionGet) => BrowserMsg.sendAwait(undefined, 'session_passphrase_get', bm, true) as Promise<Bm.Res.StoreSessionGet>,
-        storeSessionPassphraseSet: (bm: Bm.StoreSessionSet) => BrowserMsg.sendAwait(undefined, 'session_passphrase_set', bm, true) as Promise<Bm.Res.StoreSessionSet>,
+        inMemoryStoreGet: (bm: Bm.InMemoryStoreGet) => BrowserMsg.sendAwait(undefined, 'inMemoryStoreGet', bm, true) as Promise<Bm.Res.InMemoryStoreGet>,
+        inMemoryStoreSet: (bm: Bm.InMemoryStoreSet) => BrowserMsg.sendAwait(undefined, 'inMemoryStoreSet', bm, true) as Promise<Bm.Res.InMemoryStoreSet>,
         storeGlobalGet: (bm: Bm.StoreGlobalGet) => BrowserMsg.sendAwait(undefined, 'storeGlobalGet', bm, true) as Promise<Bm.Res.StoreGlobalGet>,
         storeGlobalSet: (bm: Bm.StoreGlobalSet) => BrowserMsg.sendAwait(undefined, 'storeGlobalSet', bm, true) as Promise<Bm.Res.StoreGlobalSet>,
         storeAcctGet: (bm: Bm.StoreAcctGet) => BrowserMsg.sendAwait(undefined, 'storeAcctGet', bm, true) as Promise<Bm.Res.StoreAcctGet>,

--- a/extension/js/common/platform/store/in-memory-store.ts
+++ b/extension/js/common/platform/store/in-memory-store.ts
@@ -1,0 +1,20 @@
+/* ©️ 2016 - present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com */
+
+import { AbstractStore } from './abstract-store.js';
+import { BrowserMsg } from '../../browser/browser-msg.js';
+
+/**
+ * Temporrary In-Memory store for sensitive values, expiring after 4 hours
+ * see background_page.ts for the other end, also ExpirationCache class
+ */
+export class InMemoryStore extends AbstractStore {
+
+  public static set = async (acctEmail: string, key: string, value: string | undefined) => {
+    return await BrowserMsg.send.bg.await.inMemoryStoreSet({ acctEmail, key, value });
+  }
+
+  public static get = async (acctEmail: string, key: string): Promise<string | undefined> => {
+    return await BrowserMsg.send.bg.await.inMemoryStoreGet({ acctEmail, key }) ?? undefined;
+  }
+
+}

--- a/extension/js/common/platform/store/passphrase-store.ts
+++ b/extension/js/common/platform/store/passphrase-store.ts
@@ -19,7 +19,7 @@ export class PassphraseStore extends AbstractStore {
     const longid = fingerprintOrLongid.length === 40 ? OpenPGPKey.fingerprintToLongid(fingerprintOrLongid) : fingerprintOrLongid;
     const storageIndex = PassphraseStore.getIndex(longid);
     if (storageType === 'session') {
-      return await InMemoryStore.set(acctEmail, longid, passphrase);
+      return await InMemoryStore.set(acctEmail, storageIndex, passphrase);
     } else {
       if (typeof passphrase === 'undefined') {
         await AcctStore.remove(acctEmail, [storageIndex]);
@@ -45,7 +45,7 @@ export class PassphraseStore extends AbstractStore {
     if (ignoreSession) {
       return undefined;
     }
-    return await InMemoryStore.get(acctEmail, longid) ?? undefined;
+    return await InMemoryStore.get(acctEmail, storageIndex) ?? undefined;
   }
 
   /**

--- a/extension/js/common/platform/store/passphrase-store.ts
+++ b/extension/js/common/platform/store/passphrase-store.ts
@@ -5,7 +5,7 @@ import { AccountIndex, AcctStore, AcctStoreDict } from './acct-store.js';
 import { PromiseCancellation, Dict } from '../../core/common.js';
 import { Ui } from '../../browser/ui.js';
 import { OpenPGPKey } from '../../core/crypto/pgp/openpgp-key.js';
-import { BrowserMsg } from '../../browser/browser-msg.js';
+import { InMemoryStore } from './in-memory-store.js';
 
 /**
  * Local or session store of pass phrases
@@ -19,7 +19,7 @@ export class PassphraseStore extends AbstractStore {
     const longid = fingerprintOrLongid.length === 40 ? OpenPGPKey.fingerprintToLongid(fingerprintOrLongid) : fingerprintOrLongid;
     const storageIndex = PassphraseStore.getIndex(longid);
     if (storageType === 'session') {
-      return await BrowserMsg.send.bg.await.storeSessionPassphraseSet({ acctEmail, key: longid, value: passphrase });
+      return await InMemoryStore.set(acctEmail, longid, passphrase);
     } else {
       if (typeof passphrase === 'undefined') {
         await AcctStore.remove(acctEmail, [storageIndex]);
@@ -45,7 +45,7 @@ export class PassphraseStore extends AbstractStore {
     if (ignoreSession) {
       return undefined;
     }
-    return await BrowserMsg.send.bg.await.storeSessionPassphraseGet({ acctEmail, key: longid }) ?? undefined;
+    return await InMemoryStore.get(acctEmail, longid) ?? undefined;
   }
 
   /**


### PR DESCRIPTION
This PR turns pass phrase session store into a more generic InMemoryStore that could be also used for storing other temporary secrets.

close #4018

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
