### PR TITLE
issue #3126 Add support for multiple offline compose drafts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,9 @@ module.exports = {
     'no-fallthrough': 0,
     'no-undef': 0,
     'no-control-regex': 0,
+    'prefer-const': ['error', {
+      destructuring: 'all',
+    }],
     'sort-imports': ['off', {
       "ignoreCase": false,
       "ignoreDeclarationSort": false,

--- a/conf/tslint.yaml
+++ b/conf/tslint.yaml
@@ -10,7 +10,7 @@ rules: #
     object-literal-sort-keys: false
     arrow-parens: false
     no-console: false
-    prefer-const: true
+    prefer-const: false
     ban-types:
      - true
      - ["Object", "Avoid using the `Object` type. Did you mean `object`?"]
@@ -25,7 +25,7 @@ rules: #
      - true
      - allow-leading-underscore
     member-access: true
-    member-ordering: 
+    member-ordering:
       - true
       - order:
         - "public-static-field"

--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -246,6 +246,7 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
     storage.local_drafts[draftId] = {
       id: '',
       timestamp: new Date().getTime(),
+      accEmail: this.view.acctEmail,
       message: { id: '', historyId: '', raw: Buf.fromUtfStr(mimeMsg).toBase64UrlStr(), threadId }
     };
     await GlobalStore.set(storage);

--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -174,12 +174,15 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
   }
 
   public getLocalDraftId = () => {
+    // local draft id passed from openComposeWin()
     if (this.view.draftId.startsWith(this.localDraftPrefix)) {
       return this.view.draftId;
     }
+    // reply local draft
     if (this.view.threadId) {
       return `${this.localDraftPrefix}${this.view.threadId}`;
     }
+    // compose local draft
     return `${this.localDraftPrefix}${this.localComposeDraftPrefix}${this.localComposeDraftId}`;
   }
 
@@ -240,7 +243,10 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
       storage.local_drafts = {};
     }
     const draftId = this.getLocalDraftId();
-    storage.local_drafts[draftId] = { id: new Date().getTime().toString(), message: { id: '', historyId: '', raw: Buf.fromUtfStr(mimeMsg).toBase64UrlStr(), threadId } };
+    storage.local_drafts[draftId] = {
+      id: new Date().getTime().toString(), // use timestamp as id for local drafts
+      message: { id: '', historyId: '', raw: Buf.fromUtfStr(mimeMsg).toBase64UrlStr(), threadId }
+    };
     await GlobalStore.set(storage);
     return draftId;
   }

--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -246,7 +246,7 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
     storage.local_drafts[draftId] = {
       id: '',
       timestamp: new Date().getTime(),
-      accEmail: this.view.acctEmail,
+      acctEmail: this.view.acctEmail,
       message: { id: '', historyId: '', raw: Buf.fromUtfStr(mimeMsg).toBase64UrlStr(), threadId }
     };
     await GlobalStore.set(storage);

--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -244,7 +244,8 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
     }
     const draftId = this.getLocalDraftId();
     storage.local_drafts[draftId] = {
-      id: new Date().getTime().toString(), // use timestamp as id for local drafts
+      id: '',
+      timestamp: new Date().getTime(),
       message: { id: '', historyId: '', raw: Buf.fromUtfStr(mimeMsg).toBase64UrlStr(), threadId }
     };
     await GlobalStore.set(storage);

--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -385,6 +385,17 @@ div.reply_message_iframe_container.inserted {
   margin-left: 72px !important;
 }
 
+/* offline drafts */
+#fc_offline_drafts a {
+  display: block;
+  cursor: pointer;
+  background: rgba(242, 245, 245, 0.8);
+  color: #202124;
+  box-shadow: inset 1px 0 0 #dadce0, inset -1px 0 0 #dadce0, 0 1px 2px 0 rgb(60 64 67 / 30%), 0 1px 3px 1px rgb(60 64 67 / 15%);
+  padding: 10px 20px;
+  text-decoration: none;
+}
+
 /* augmented */
 body.cryptup_gmail div.recipients_use_encryption {
   min-height: 0;

--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -386,14 +386,23 @@ div.reply_message_iframe_container.inserted {
 }
 
 /* offline drafts */
+#fc_offline_drafts {
+  margin-top: 3em;
+}
+
 #fc_offline_drafts a {
   display: block;
   cursor: pointer;
   background: rgba(242, 245, 245, 0.8);
   color: #202124;
-  box-shadow: inset 1px 0 0 #dadce0, inset -1px 0 0 #dadce0, 0 1px 2px 0 rgb(60 64 67 / 30%), 0 1px 3px 1px rgb(60 64 67 / 15%);
+  outline: 1px solid rgb(100 121 143 / 12%);
   padding: 10px 20px;
   text-decoration: none;
+  margin-bottom: 1px;
+}
+
+#fc_offline_drafts a:hover {
+  outline: 2px solid rgb(218, 220, 224);
 }
 
 /* augmented */

--- a/extension/js/background_page/migrations.ts
+++ b/extension/js/background_page/migrations.ts
@@ -2,13 +2,12 @@
 
 'use strict';
 
-import { GmailRes } from '../common/api/email-provider/gmail/gmail-parser.js';
 import { storageLocalGetAll, storageLocalRemove } from '../common/browser/chrome.js';
 import { KeyInfo, KeyUtil } from '../common/core/crypto/key.js';
 import { SmimeKey } from '../common/core/crypto/smime/smime-key.js';
 import { Str } from '../common/core/common.js';
 import { ContactStore, ContactUpdate, Email, Pubkey } from '../common/platform/store/contact-store.js';
-import { GlobalStore } from '../common/platform/store/global-store.js';
+import { GlobalStore, LocalDraft } from '../common/platform/store/global-store.js';
 import { KeyStore } from '../common/platform/store/key-store.js';
 
 // contact entity prior to version 4
@@ -57,7 +56,7 @@ export const migrateGlobal = async () => {
     for (const key of Object.keys(storageLocal)) {
       if (key.startsWith('local-draft-')) {
         console.info(`migrating local draft ${key}`);
-        globalStore.local_drafts[key] = storageLocal[key] as GmailRes.GmailDraftGet;
+        globalStore.local_drafts[key] = storageLocal[key] as LocalDraft;
         oldDrafts.push(key);
       }
     }
@@ -72,7 +71,7 @@ export const migrateGlobal = async () => {
     const newComposeDraftId = `local-draft-compose-${Str.sloppyRandom(10)}`;
     console.info(`new local compose draft id: ${newComposeDraftId}`);
     globalStore.local_drafts[newComposeDraftId] = globalStore.local_drafts['local-draft-'];
-    globalStore.local_drafts[newComposeDraftId].id = new Date().getTime().toString();
+    globalStore.local_drafts[newComposeDraftId].timestamp = new Date().getTime();
     delete globalStore.local_drafts['local-draft-'];
     await GlobalStore.set({ local_drafts: globalStore.local_drafts });
   }

--- a/extension/js/common/core/msg-block-parser.ts
+++ b/extension/js/common/core/msg-block-parser.ts
@@ -101,7 +101,7 @@ export class MsgBlockParser {
   }
 
   public static stripPublicKeys = (decryptedContent: string, foundPublicKeys: string[]) => {
-    let { blocks, normalized } = MsgBlockParser.detectBlocks(decryptedContent); // tslint:disable-line:prefer-const
+    let { blocks, normalized } = MsgBlockParser.detectBlocks(decryptedContent);
     for (const block of blocks) {
       if (block.type === 'publicKey') {
         const armored = block.content.toString();

--- a/extension/js/common/platform/store/global-store.ts
+++ b/extension/js/common/platform/store/global-store.ts
@@ -10,6 +10,8 @@ import { Catch } from '../catch.js';
 
 export type StoredAdminCode = { date: number, codes: string[] };
 
+export type LocalDraft = GmailRes.GmailDraftGet & { timestamp: number }
+
 export type GlobalStoreDict = {
   version?: number | null;
   account_emails?: string; // stringified array
@@ -20,7 +22,7 @@ export type GlobalStoreDict = {
   key_info_store_fingerprints_added?: boolean;
   contact_store_x509_fingerprints_and_longids_updated?: boolean;
   contact_store_opgp_revoked_flags_updated?: boolean;
-  local_drafts?: Dict<GmailRes.GmailDraftGet>;
+  local_drafts?: Dict<LocalDraft>;
 };
 
 export type GlobalIndex = 'version' | 'account_emails' | 'settings_seen' | 'hide_pass_phrases' |

--- a/extension/js/common/platform/store/global-store.ts
+++ b/extension/js/common/platform/store/global-store.ts
@@ -10,7 +10,7 @@ import { Catch } from '../catch.js';
 
 export type StoredAdminCode = { date: number, codes: string[] };
 
-export type LocalDraft = GmailRes.GmailDraftGet & { timestamp: number }
+export type LocalDraft = GmailRes.GmailDraftGet & { timestamp: number, accEmail: string }
 
 export type GlobalStoreDict = {
   version?: number | null;

--- a/extension/js/common/platform/store/global-store.ts
+++ b/extension/js/common/platform/store/global-store.ts
@@ -10,7 +10,7 @@ import { Catch } from '../catch.js';
 
 export type StoredAdminCode = { date: number, codes: string[] };
 
-export type LocalDraft = GmailRes.GmailDraftGet & { timestamp: number, accEmail: string }
+export type LocalDraft = GmailRes.GmailDraftGet & { timestamp: number, acctEmail: string }
 
 export type GlobalStoreDict = {
   version?: number | null;

--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -757,7 +757,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
       }
       const offlineComposeDrafts: Dict<LocalDraft> = {};
       for (const draftId in storage.local_drafts) {
-        if (draftId.startsWith('local-draft-compose-')) {
+        if (draftId.startsWith('local-draft-compose-') && storage.local_drafts[draftId].accEmail === this.acctEmail) {
           offlineComposeDrafts[draftId] = storage.local_drafts[draftId];
         }
       }

--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -762,24 +762,22 @@ export class GmailElementReplacer implements WebmailElementReplacer {
         }
       }
       let offlineDraftsContainer = $(this.sel.draftsList).find('#fc_offline_drafts');
-      if (!offlineDraftsContainer.length) {
-        offlineDraftsContainer = $('<div id="fc_offline_drafts"></div>');
-        $(this.sel.draftsList).append(offlineDraftsContainer); // xss-safe-value
-      }
       if (Object.keys(offlineComposeDrafts).length) {
         const offlineComposeDraftIds = Object.keys(offlineComposeDrafts);
         const draftIdsSortedByTimestamp = offlineComposeDraftIds.sort((a, b) => {
-          return offlineComposeDrafts[a].timestamp - offlineComposeDrafts[b].timestamp;
+          return offlineComposeDrafts[b].timestamp - offlineComposeDrafts[a].timestamp;
         });
         if (offlineDraftsContainer.data('rendered-drafts') === draftIdsSortedByTimestamp.join(',')) {
           // already rendered
           return;
         }
+        offlineDraftsContainer = $('<div id="fc_offline_drafts"><h4>FlowCrypt offline drafts:</h4></div>'); // xss-safe-value
         offlineDraftsContainer.data('rendered-drafts', draftIdsSortedByTimestamp.join(','));
-        offlineDraftsContainer.html(`<h4>FlowCrypt offline drafts:</h4>`); // xss-safe-value
+        $(this.sel.draftsList).find('#fc_offline_drafts').remove();
+        $(this.sel.draftsList).append(offlineDraftsContainer); // xss-safe-factory
         for (const draftId of draftIdsSortedByTimestamp) {
           const draft = offlineComposeDrafts[draftId];
-          const draftLink = $(`<a href data-test="offline-draft-link">${new Date(draft.timestamp).toLocaleString()}</a>`);
+          const draftLink = $(`<a href>${new Date(draft.timestamp).toLocaleString()}</a>`);
           draftLink.on('click', (event) => {
             event.preventDefault();
             this.injector.openComposeWin(draftId);
@@ -787,7 +785,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
           offlineDraftsContainer.append(draftLink ); // xss-safe-value
         }
       } else {
-        offlineDraftsContainer.empty();
+        offlineDraftsContainer.remove();
       }
     }
   }

--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -757,7 +757,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
       }
       const offlineComposeDrafts: Dict<LocalDraft> = {};
       for (const draftId in storage.local_drafts) {
-        if (draftId.startsWith('local-draft-compose-') && storage.local_drafts[draftId].accEmail === this.acctEmail) {
+        if (draftId.startsWith('local-draft-compose-') && storage.local_drafts[draftId].acctEmail === this.acctEmail) {
           offlineComposeDrafts[draftId] = storage.local_drafts[draftId];
         }
       }

--- a/extension/js/content_scripts/webmail/webmail.ts
+++ b/extension/js/content_scripts/webmail/webmail.ts
@@ -23,7 +23,6 @@ Catch.try(async () => {
   const gmailWebmailStartup = async () => {
     let replacePgpElsInterval: number;
     let replacer: GmailElementReplacer;
-    let hostPageInfo: WebmailVariantObject;
 
     const getUserAccountEmail = (): undefined | string => {
       if (window.location.search.indexOf('&view=btop&') === -1) {  // when view=btop present, FlowCrypt should not be activated
@@ -122,7 +121,7 @@ Catch.try(async () => {
       });
     };
 
-    hostPageInfo = getInsightsFromHostVariables();
+    const hostPageInfo = getInsightsFromHostVariables();
     await contentScriptSetupIfVacant({
       name: 'gmail',
       variant: hostPageInfo.gmailVariant,

--- a/test/source/browser/controllable.ts
+++ b/test/source/browser/controllable.ts
@@ -399,7 +399,7 @@ abstract class ControllableBase {
   }
 
   public ensureElementsCount = async (selector: string, count: number) => {
-    let elements = await this.target.$$(selector);
+    const elements = await this.target.$$(selector);
     expect(elements.length).to.equal(count);
   }
 

--- a/test/source/browser/controllable.ts
+++ b/test/source/browser/controllable.ts
@@ -398,6 +398,11 @@ abstract class ControllableBase {
     throw new Error(`Could not find any frame in ${appearIn}s that matches ${urlMatchables.join(' ')}`);
   }
 
+  public ensureElementsCount = async (selector: string, count: number) => {
+    let elements = await this.target.$$(selector);
+    expect(elements.length).to.equal(count);
+  }
+
   public getFrame = async (urlMatchables: string[], { sleep = 1, timeout = 10 } = { sleep: 1, timeout: 10 }): Promise<ControllableFrame> => {
     if (sleep) {
       await Util.sleep(sleep);

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -1,7 +1,6 @@
 /* ©️ 2016 - present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com */
 
 import * as ava from 'ava';
-import { Page } from 'puppeteer';
 
 import { BrowserHandle, Controllable, ControllablePage, ControllableFrame } from './../browser';
 import { Config, Util } from './../util';
@@ -835,19 +834,6 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       const body = await composePage.waitAny('@input-body');
       await composePage.waitAll('#input_text img');
       expect(await body.$eval('#input_text img', el => el.getAttribute('src'))).to.eq(imgBase64);
-    }));
-
-    ava.default('compose - saving and rendering a draft when offline', testWithBrowser('compatibility', async (t, browser) => {
-      let composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
-      await (composePage.target as Page).setOfflineMode(true); // go offline mode
-      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'offline test', {});
-      expect(await composePage.read('@action-send')).to.eq('Re-enter recipient..'); // ensure offline mode
-      await composePage.type('@input-body', `This is a test of saving a draft when offline`);
-      await ComposePageRecipe.waitWhenDraftIsSavedLocally(composePage);
-      await composePage.close();
-      composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
-      expect(await composePage.value('@input-subject')).to.match(/offline test/);
-      await composePage.waitForContent('@input-body', 'This is a test of saving a draft when offline');
     }));
 
     ava.default('compose - RTL subject', testWithBrowser('compatibility', async (t, browser) => {

--- a/test/source/tests/elements.ts
+++ b/test/source/tests/elements.ts
@@ -7,7 +7,7 @@ import { TestWithBrowser } from '../test';
 
 // tslint:disable:no-blank-lines-func
 
-export let defineElementTests = (testVariant: TestVariant, testWithBrowser: TestWithBrowser) => {
+export const defineElementTests = (testVariant: TestVariant, testWithBrowser: TestWithBrowser) => {
 
   if (testVariant !== 'CONSUMER-LIVE-GMAIL') {
 

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -253,6 +253,19 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       await pubkeyPage.waitForContent('@container-pgp-pubkey', 'Fingerprint: 50B7 A032 B5E1 FBAB 24BA B205 B362 45FD AC2F BF3D');
     }));
 
+    ava.default('mail.google.com - saving and rendering a compose draft when offline', testWithBrowser('ci.tests.gmail', async (t, browser) => {
+      const gmailPage = await openGmailPage(t, browser, '/');
+      // create compose draft
+      await gmailPage.waitAndClick('@action-secure-compose', { delay: 1 });
+      await createSecureDraft(t, browser, gmailPage, 'compose draft', true);
+      await gmailPage.page.reload();
+      await gmailPage.waitAndClick('[data-tooltip="Drafts"]');
+      await gmailPage.waitAndClick('@offline-draft-link');
+      const urls = await gmailPage.getFramesUrls(['/chrome/elements/compose.htm']);
+      expect(urls.length).to.equal(1);
+      await pageHasSecureDraft(t, browser, urls[0], 'compose draft');
+    }));
+
     ava.default.skip('mail.google.com - secure reply btn, reply draft', testWithBrowser('ci.tests.gmail', async (t, browser) => {
       const gmailPage = await openGmailPage(t, browser, '/');
       const settingsPage = await browser.newPage(t, TestUrls.extensionSettings());

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -272,8 +272,8 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       await draft.close();
       // after draft 2 is saved to the cloud, it should be removed from offline drafts
       await gmailPage.page.reload();
-      await gmailPage.ensureElementsCount('#fc_offline_drafts a', 1);
       await gmailPage.waitForContent('#fc_offline_drafts', 'FlowCrypt offline drafts:');
+      await gmailPage.ensureElementsCount('#fc_offline_drafts a', 1);
       await gmailPage.waitAndClick('#fc_offline_drafts a');
       urls = await gmailPage.getFramesUrls(['/chrome/elements/compose.htm'], { sleep: 1 });
       await pageHasSecureDraft(t, browser, urls[0], 'compose draft 1');

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -263,18 +263,19 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       await gmailPage.waitForContent('#fc_offline_drafts', 'FlowCrypt offline drafts:');
       await gmailPage.ensureElementsCount('#fc_offline_drafts a', 2);
       await gmailPage.waitAndClick('#fc_offline_drafts a');
-      let urls = await gmailPage.getFramesUrls(['/chrome/elements/compose.htm']);
+      let urls = await gmailPage.getFramesUrls(['/chrome/elements/compose.htm'], { sleep: 1 });
       // compose draft 2 should be first in list as drafts are sorted by date descending
       const draft = await pageHasSecureDraft(t, browser, urls[0], 'compose draft 2');
       await Util.sleep(3); // the draft isn't being saved if start typing without this delay
-      await draft.type('@input-body', 'trigger saving to the clound');
+      await draft.type('@input-body', 'trigger saving to the clound', true);
       await ComposePageRecipe.waitWhenDraftIsSaved(draft);
+      await draft.close();
       // after draft 2 is saved to the cloud, it should be removed from offline drafts
       await gmailPage.page.reload();
       await gmailPage.ensureElementsCount('#fc_offline_drafts a', 1);
       await gmailPage.waitForContent('#fc_offline_drafts', 'FlowCrypt offline drafts:');
       await gmailPage.waitAndClick('#fc_offline_drafts a');
-      urls = await gmailPage.getFramesUrls(['/chrome/elements/compose.htm']);
+      urls = await gmailPage.getFramesUrls(['/chrome/elements/compose.htm'], { sleep: 1 });
       await pageHasSecureDraft(t, browser, urls[0], 'compose draft 1');
     }));
 

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -267,7 +267,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       // compose draft 2 should be first in list as drafts are sorted by date descending
       const draft = await pageHasSecureDraft(t, browser, urls[0], 'compose draft 2');
       await Util.sleep(3); // the draft isn't being saved if start typing without this delay
-      await draft.type('@input-body', 'trigger saving to the clound', true);
+      await draft.type('@input-body', 'trigger saving a draft to the cloud', true);
       await ComposePageRecipe.waitWhenDraftIsSaved(draft);
       await draft.close();
       // after draft 2 is saved to the cloud, it should be removed from offline drafts

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -41,16 +41,16 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       }
     };
 
-    const createSecureDraft = async (t: AvaContext, browser: BrowserHandle, gmailPage: ControllablePage, content: string, offline = false) => {
+    const createSecureDraft = async (t: AvaContext, browser: BrowserHandle, gmailPage: ControllablePage, content: string, params: { offline: boolean } = { offline: false }) => {
       const urls = await gmailPage.getFramesUrls(['/chrome/elements/compose.htm']);
       expect(urls.length).to.equal(1);
       const composeBox = await browser.newPage(t, urls[0]);
-      if (offline) {
+      if (params.offline) {
         await (composeBox.target as Page).setOfflineMode(true); // go offline mode
       }
       await Util.sleep(3); // the draft isn't being saved if start typing without this delay
       await composeBox.type('@input-body', content);
-      if (offline) {
+      if (params.offline) {
         await ComposePageRecipe.waitWhenDraftIsSavedLocally(composeBox);
         await (composeBox.target as Page).setOfflineMode(true); // go offline mode
       } else {
@@ -257,7 +257,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       const gmailPage = await openGmailPage(t, browser, '/');
       // create compose draft
       await gmailPage.waitAndClick('@action-secure-compose', { delay: 1 });
-      await createSecureDraft(t, browser, gmailPage, 'compose draft', true);
+      await createSecureDraft(t, browser, gmailPage, 'compose draft', { offline: true });
       await gmailPage.page.reload();
       await gmailPage.waitAndClick('[data-tooltip="Drafts"]');
       await gmailPage.waitAndClick('@offline-draft-link');
@@ -285,7 +285,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       expect(urls.length).to.equal(1);
       let replyBox = await pageHasSecureDraft(t, browser, urls[0], 'reply draft');
       await replyBox.close();
-      await createSecureDraft(t, browser, gmailPage, 'offline reply draft', true);
+      await createSecureDraft(t, browser, gmailPage, 'offline reply draft', { offline: true });
       await gmailPage.page.reload();
       replyBox = await pageHasSecureDraft(t, browser, urls[0], 'offline reply draft');
       await replyBox.waitAndClick('@action-send');

--- a/test/source/tests/settings.ts
+++ b/test/source/tests/settings.ts
@@ -22,7 +22,7 @@ import { KeyInfo } from '../core/crypto/key';
 
 // tslint:disable:no-blank-lines-func
 
-export let defineSettingsTests = (testVariant: TestVariant, testWithBrowser: TestWithBrowser) => {
+export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: TestWithBrowser) => {
 
   if (testVariant !== 'CONSUMER-LIVE-GMAIL') {
 

--- a/test/source/tests/unit-browser.ts
+++ b/test/source/tests/unit-browser.ts
@@ -14,7 +14,7 @@ import { testConstants } from './tooling/consts';
 
 type UnitTest = { title: string, code: string, only: boolean };
 
-export let defineUnitBrowserTests = (testVariant: TestVariant, testWithBrowser: TestWithBrowser) => {
+export const defineUnitBrowserTests = (testVariant: TestVariant, testWithBrowser: TestWithBrowser) => {
 
   if (testVariant !== 'CONSUMER-LIVE-GMAIL') {
 

--- a/test/source/tests/unit-node.ts
+++ b/test/source/tests/unit-node.ts
@@ -45,7 +45,7 @@ export const equals = (a: string | Uint8Array, b: string | Uint8Array) => {
 };
 
 
-export let defineUnitNodeTests = (testVariant: TestVariant) => {
+export const defineUnitNodeTests = (testVariant: TestVariant) => {
 
   if (testVariant !== 'CONSUMER-LIVE-GMAIL') {
 


### PR DESCRIPTION
This PR allows users to create several offline compose drafts. It also takes care of migrating the existed compose offline drafts, so nothing will be lost for users.

close #3126

<img width="617" alt="CleanShot 2021-09-30 at 11 20 41@2x" src="https://user-images.githubusercontent.com/6059356/135415198-077be682-e23c-46e1-b508-5c053fd5287b.png">

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
