### PR TITLE
issue #3940 increase number of attachments to 50

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-attachments-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-attachments-module.ts
@@ -37,7 +37,7 @@ export class ComposeAttachmentsModule extends ViewModule<ComposeView> {
     return {
       sizeMb,
       size: sizeMb * 1024 * 1024,
-      count: 10,
+      count: 50,
       oversize: async (combinedSize: number) => {
         await Ui.modal.warning('Combined attachment size is limited to 25 MB. The last file brings it to ' + Math.ceil(combinedSize / (1024 * 1024)) + ' MB.');
       },

--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -435,6 +435,7 @@ body.cryptup_gmail div.recipients_use_encryption a {
   height: 100vh;
   margin: 0;
   padding: 0;
+  overflow: hidden;
 }
 
 .swal2-container.ui-modal-attachment iframe {


### PR DESCRIPTION
This PR increases the limit of attachments to 50. Tested on Mac and Win, no issues with sending / encrypting / decrypting / rendering performance.

close #3940

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
