### PR TITLE
issue #4039 Set compose window active when PP is required

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -324,12 +324,13 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
   }
 
   private renderPPDialogAndWaitWhenPPEntered = async () => {
-    const promptText = `Waiting for <a href="#" class="action_open_passphrase_dialog">pass phrase</a> to open draft..`;
+    const promptText = `<div>Waiting for <a href="#" class="action_open_passphrase_dialog">pass phrase</a> to open draft..</div>`;
     if (this.view.isReplyBox) {
       Xss.sanitizeRender(this.view.S.cached('prompt'), promptText).css({ display: 'block' });
       this.view.sizeModule.resizeComposeBox();
     } else {
-      Xss.sanitizeRender(this.view.S.cached('prompt'), `${promptText}<br><br><a href="#" class="action_close">close</a>`).css({ display: 'block', height: '100%' });
+      Xss.sanitizeRender(this.view.S.cached('prompt'), `${promptText}<br><br><a href="#" class="action_close">close</a>`).css({ display: 'flex', height: '100%' });
+      BrowserMsg.send.setActiveWindow(this.view.parentTabId, { frameId: this.view.frameId });
     }
     this.view.S.cached('prompt').find('a.action_open_passphrase_dialog').click(this.view.setHandler(async () => {
       const primaryKi = await KeyStore.getFirstRequired(this.view.acctEmail);

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -2262,6 +2262,13 @@ body#new_message #loader {
   align-items: center;
 }
 
+body#new_message #initial_prompt {
+  background: white;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
 body#new_message.full_window {
   background-color: rgba(0, 0, 0, 0.5);
   padding: 20px 150px;
@@ -2278,7 +2285,7 @@ div#initial_prompt a {
   height: 36px;
   padding: 0 16px;
   box-shadow: inset 0 0 0 1px #dadce0;
-  margin: 0 12px 6px 0;
+  margin: 6px;
   text-decoration: none;
   outline: none;
 }


### PR DESCRIPTION
This PR sets the compose window active when user is required to enter their PP

close #4039 


https://user-images.githubusercontent.com/6059356/135986885-535a95ee-b3c4-4c1e-b302-e0bc781a4b2a.mp4


----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
