### PR TITLE
Run Gmail tests only for master and branches that contain `live-test` or `gmail-test` + re-enable and fix flaky test

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -12,6 +12,7 @@ auto_cancel: # cancel running CI for older commits on same branch if new commits
 blocks:
 
   - name: Tests
+    dependencies: []
     execution_time_limit:
       minutes: 20
     task:
@@ -52,10 +53,6 @@ blocks:
             - npm run-script test_async_stack
             - npm run-script test_buf
 
-        - name: Live Gmail tests
-          commands:
-            - npm run-script test_ci_chrome_consumer_live_gmail
-
         - name: consumer mock - unit tests
           commands:
             - npm run-script test_local_unit_consumer
@@ -88,3 +85,35 @@ blocks:
                 echo "Uploading debug files as job artifacts..."
                 artifact push job build/test/test/debugArtifacts/debugHtmlAttachment-*.html
               fi
+
+  - name: Live Gmail tests
+    dependencies: []
+    run:
+      when: "branch = 'master' OR branch =~ 'live-test'  OR branch =~ 'gmail-test'"
+    execution_time_limit:
+      minutes: 20
+    task:
+      secrets:
+        - name: flowcrypt-browser-ci-secrets
+      env_vars:
+        - name: SEMAPHORE_GIT_DIR
+          value: /home/semaphore/git/flowcrypt-browser
+      prologue:
+        commands:
+          - nvm use 12
+          - nvm alias default 12
+          - npm install -g npm@6.14.6 && mkdir ~/git && checkout && mv ~/test-secrets.json ~/git/flowcrypt-browser/test/test-secrets.json
+          - cd ~/git/flowcrypt-browser
+          - npm install
+          - echo "NODE=$(node --version), NPM=$(npm --version), TSC=$( ./node_modules/typescript/bin/tsc --version)"
+          - npm run-script pretest
+          - sudo sh -c "echo '209.250.232.81 cron.flowcrypt.com' >> /etc/hosts"
+          - sudo sh -c "echo '127.0.0.1 fes.google.mock.flowcryptlocal.test' >> /etc/hosts"
+          - sudo sh -c "echo '127.0.0.1 google.mock.flowcryptlocal.test' >> /etc/hosts"
+          - sudo sh -c "echo '127.0.0.1 fes.standardsubdomainfes.test' >> /etc/hosts"
+          - sudo sh -c "echo '127.0.0.1 standardsubdomainfes.test' >> /etc/hosts"
+          - sudo sh -c "echo '127.0.0.1 fes.disablefesaccesstoken.test' >> /etc/hosts"
+      jobs:
+        - name: Live Gmail tests
+          commands:
+            - npm run-script test_ci_chrome_consumer_live_gmail

--- a/test/source/browser/test-urls.ts
+++ b/test/source/browser/test-urls.ts
@@ -1,6 +1,7 @@
 /* ©️ 2016 - present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com */
 
 import { Config } from '../util';
+import { GmailCategory } from '../tests/gmail';
 
 export class TestUrls {
 
@@ -16,8 +17,8 @@ export class TestUrls {
     return TestUrls.extension(`chrome/settings/inbox/inbox.htm?acctEmail=${acctEmail}`);
   }
 
-  public static gmail = (acctLoginIndex = 0, urlEnd = '') => {
-    return `https://mail.google.com/mail/u/${acctLoginIndex}/#inbox${urlEnd}`;
+  public static gmail = (acctLoginIndex = 0, urlEnd = '', category: GmailCategory = 'inbox') => {
+    return `https://mail.google.com/mail/u/${acctLoginIndex}/#${category}${urlEnd}`;
   }
 
   public static googleChat = (acctLoginIndex = 0) => {

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -50,7 +50,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
         await (composeBox.target as Page).setOfflineMode(true); // go offline mode
       }
       await Util.sleep(3); // the draft isn't being saved if start typing without this delay
-      await composeBox.type('@input-body', content);
+      await composeBox.type('@input-body', content, true);
       if (params.offline) {
         await ComposePageRecipe.waitWhenDraftIsSavedLocally(composeBox);
       } else {
@@ -291,9 +291,6 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
 
     ava.default('mail.google.com - secure reply btn, reply draft', testWithBrowser('ci.tests.gmail', async (t, browser) => {
       const gmailPage = await openGmailPage(t, browser, '/');
-      const settingsPage = await browser.newPage(t, TestUrls.extensionSettings());
-      await BrowserRecipe.deleteAllDraftsInGmailAccount(settingsPage);
-      await settingsPage.close();
       await gotoGmailPage(gmailPage, '/FMfcgzGkbDRNgcPktjdSxpJVhZlZqpTr'); // to go encrypted convo
       // Gmail has 100 emails per thread limit, so if there are 98 deleted messages + 1 initial message,
       // the draft number 100 won't be saved. Therefore, we need to delete forever trashed messages from this thread.

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -279,7 +279,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       await pageHasSecureDraft(t, browser, urls[0], 'compose draft 1');
     }));
 
-    ava.default.skip('mail.google.com - secure reply btn, reply draft', testWithBrowser('ci.tests.gmail', async (t, browser) => {
+    ava.default('mail.google.com - secure reply btn, reply draft', testWithBrowser('ci.tests.gmail', async (t, browser) => {
       const gmailPage = await openGmailPage(t, browser, '/');
       const settingsPage = await browser.newPage(t, TestUrls.extensionSettings());
       await BrowserRecipe.deleteAllDraftsInGmailAccount(settingsPage);

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -56,6 +56,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       } else {
         await ComposePageRecipe.waitWhenDraftIsSaved(composeBox);
       }
+      await Util.sleep(3); // the draft isn't being saved sometimes in CI without this delay
       await composeBox.close();
     };
 

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -44,7 +44,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
     };
 
     const createSecureDraft = async (t: AvaContext, browser: BrowserHandle, gmailPage: ControllablePage, content: string, params: { offline: boolean } = { offline: false }) => {
-      const urls = await gmailPage.getFramesUrls(['/chrome/elements/compose.htm']);
+      const urls = await gmailPage.getFramesUrls(['/chrome/elements/compose.htm'], { sleep: 1 });
       const composeBox = await browser.newPage(t, urls[0]);
       if (params.offline) {
         await (composeBox.target as Page).setOfflineMode(true); // go offline mode
@@ -56,20 +56,11 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       } else {
         await ComposePageRecipe.waitWhenDraftIsSaved(composeBox);
       }
-      await Util.sleep(3); // the draft isn't being saved sometimes in CI without this delay
       await composeBox.close();
     };
 
     const pageHasSecureDraft = async (t: AvaContext, browser: BrowserHandle, url: string, expectedContent?: string) => {
       const secureDraft = await browser.newPage(t, url);
-      // if (expectedContent === 'reply draft') {
-      //   console.log('reply draft');
-      //   console.log(await secureDraft.page.screenshot({ encoding: "base64" }));
-      // }
-      // if (expectedContent === 'offline reply draft') {
-      //   console.log('offline reply draft');
-      //   console.log(await secureDraft.page.screenshot({ encoding: "base64" }));
-      // }
       if (expectedContent) {
         await secureDraft.waitForContent('@input-body', expectedContent);
       } else {

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -62,14 +62,14 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
 
     const pageHasSecureDraft = async (t: AvaContext, browser: BrowserHandle, url: string, expectedContent?: string) => {
       const secureDraft = await browser.newPage(t, url);
-      if (expectedContent === 'reply draft') {
-        console.log('reply draft');
-        console.log(await secureDraft.page.screenshot({ encoding: "base64" }));
-      }
-      if (expectedContent === 'offline reply draft') {
-        console.log('offline reply draft');
-        console.log(await secureDraft.page.screenshot({ encoding: "base64" }));
-      }
+      // if (expectedContent === 'reply draft') {
+      //   console.log('reply draft');
+      //   console.log(await secureDraft.page.screenshot({ encoding: "base64" }));
+      // }
+      // if (expectedContent === 'offline reply draft') {
+      //   console.log('offline reply draft');
+      //   console.log(await secureDraft.page.screenshot({ encoding: "base64" }));
+      // }
       if (expectedContent) {
         await secureDraft.waitForContent('@input-body', expectedContent);
       } else {

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -320,11 +320,10 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       await gmailPage.waitAndClick('@action-secure-compose', { delay: 1 });
       await gmailPage.waitAndFocus('body');
       await gmailPage.waitAndClick('[data-tooltip="Drafts"]');
-      await gmailPage.waitForInputValue('[aria-label^="Search"]', 'in:draft');
-      await gmailPage.press('Enter');
+      await gmailPage.waitAndClick('//*[text()="Draft"]');
       await gmailPage.waitAndClick('[class^="open_draft_"]');
       // veryfy that there are two compose windows: new compose window and secure draft
-      const urls = await gmailPage.getFramesUrls(['/chrome/elements/compose.htm']);
+      const urls = await gmailPage.getFramesUrls(['/chrome/elements/compose.htm'], { sleep: 1 });
       expect(urls.length).to.equal(2);
       const composeDraft = await pageHasSecureDraft(t, browser, urls[1], 'compose draft');
       await composeDraft.close();

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -49,7 +49,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       if (params.offline) {
         await (composeBox.target as Page).setOfflineMode(true); // go offline mode
       }
-      await Util.sleep(3); // the draft isn't being saved if start typing without this delay
+      await Util.sleep(4); // the draft isn't being saved if start typing without this delay
       await composeBox.type('@input-body', content, true);
       if (params.offline) {
         await ComposePageRecipe.waitWhenDraftIsSavedLocally(composeBox);
@@ -268,7 +268,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       let urls = await gmailPage.getFramesUrls(['/chrome/elements/compose.htm'], { sleep: 1 });
       // compose draft 2 should be first in list as drafts are sorted by date descending
       const draft = await pageHasSecureDraft(t, browser, urls[0], 'compose draft 2');
-      await Util.sleep(3); // the draft isn't being saved if start typing without this delay
+      await Util.sleep(4); // the draft isn't being saved if start typing without this delay
       await draft.type('@input-body', 'trigger saving a draft to the cloud', true);
       await ComposePageRecipe.waitWhenDraftIsSaved(draft);
       await draft.close();

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -318,7 +318,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       // open new compose window and saved draft
       await gmailPage.waitAndClick('@action-secure-compose', { delay: 1 });
       await gmailPage.waitAndClick('//*[text()="Draft"]');
-      await gmailPage.waitAndClick('[class^="open_draft_"]');
+      await gmailPage.waitAndClick('[class^="open_draft_"]', { delay: 1 });
       // veryfy that there are two compose windows: new compose window and secure draft
       const urls = await gmailPage.getFramesUrls(['/chrome/elements/compose.htm'], { sleep: 1 });
       expect(urls.length).to.equal(2);

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -298,10 +298,12 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       await gmailPage.waitAll('.reply_message');
       const urls = await gmailPage.getFramesUrls(['/chrome/elements/compose.htm']);
       expect(urls.length).to.equal(1);
+      console.log('#', await gmailPage.page.screenshot({ encoding: "base64" }));
       let replyBox = await pageHasSecureDraft(t, browser, urls[0], 'reply draft');
       await replyBox.close();
       await createSecureDraft(t, browser, gmailPage, 'offline reply draft', { offline: true });
       await gmailPage.page.reload();
+      console.log('@', await gmailPage.page.screenshot({ encoding: "base64" }));
       replyBox = await pageHasSecureDraft(t, browser, urls[0], 'offline reply draft');
       await replyBox.waitAndClick('@action-send');
       await replyBox.waitTillGone('@action-send');

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -61,6 +61,14 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
 
     const pageHasSecureDraft = async (t: AvaContext, browser: BrowserHandle, url: string, expectedContent?: string) => {
       const secureDraft = await browser.newPage(t, url);
+      if (expectedContent === 'reply draft') {
+        console.log('reply draft');
+        console.log(await secureDraft.page.screenshot({ encoding: "base64" }));
+      }
+      if (expectedContent === 'offline reply draft') {
+        console.log('offline reply draft');
+        console.log(await secureDraft.page.screenshot({ encoding: "base64" }));
+      }
       if (expectedContent) {
         await secureDraft.waitForContent('@input-body', expectedContent);
       } else {
@@ -295,15 +303,12 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       await gmailPage.waitAndClick('@secure-reply-button');
       await createSecureDraft(t, browser, gmailPage, 'reply draft');
       await gmailPage.page.reload();
-      await gmailPage.waitAll('.reply_message');
       const urls = await gmailPage.getFramesUrls(['/chrome/elements/compose.htm']);
       expect(urls.length).to.equal(1);
-      console.log('#', await gmailPage.page.screenshot({ encoding: "base64" }));
       let replyBox = await pageHasSecureDraft(t, browser, urls[0], 'reply draft');
       await replyBox.close();
       await createSecureDraft(t, browser, gmailPage, 'offline reply draft', { offline: true });
       await gmailPage.page.reload();
-      console.log('@', await gmailPage.page.screenshot({ encoding: "base64" }));
       replyBox = await pageHasSecureDraft(t, browser, urls[0], 'offline reply draft');
       await replyBox.waitAndClick('@action-send');
       await replyBox.waitTillGone('@action-send');

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -335,22 +335,19 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
 
     ava.default('mail.google.com - plain reply to encrypted and signed messages', testWithBrowser('ci.tests.gmail', async (t, browser) => {
       const gmailPage = await openGmailPage(t, browser, '/FMfcgzGkbDRNgcQxLmkhBCKVSFwkfdvV'); // plain convo
-      await Util.sleep(1);
-      await gmailPage.waitAndClick('[data-tooltip="Reply"]');
+      await gmailPage.waitAndClick('[data-tooltip="Reply"]', { delay: 1 });
       await gotoGmailPage(gmailPage, '/FMfcgzGkbDRNgcPktjdSxpJVhZlZqpTr'); // to go encrypted convo
-      await Util.sleep(1);
-      await gmailPage.waitAndClick('[data-tooltip="Reply"]');
-      await Util.sleep(5);
-      await pageDoesNotHaveSecureReplyContainer(gmailPage);
+      await gmailPage.waitAndClick('[data-tooltip="Reply"]', { delay: 1 });
+      await gmailPage.waitTillGone('.reply_message');
       await gmailPage.waitAll('[data-tooltip^="Send"]'); // The Send button from the Standard reply box
       await gmailPage.waitForContent('.reply_message_evaluated .error_notification', 'The last message was encrypted, but you are composing a reply without encryption.');
       await gmailPage.waitAndClick('[data-tooltip="Secure Reply"]'); // Switch to encrypted reply
-      await Util.sleep(5);
+      await gmailPage.waitAll('.reply_message');
       await pageHasSecureReplyContainer(t, browser, gmailPage, { isReplyPromptAccepted: false });
       await gotoGmailPage(gmailPage, '/FMfcgzGkbDRNpjDdNvCrwzqvXspZZxvh'); // go to signed convo
-      await Util.sleep(1);
-      await gmailPage.waitAndClick('[data-tooltip="Reply"]');
-      await pageDoesNotHaveSecureReplyContainer(gmailPage);
+      await gmailPage.waitAndClick('[data-tooltip="Reply"]', { delay: 1 });
+      await gmailPage.waitTillGone('.reply_message');
+      await gmailPage.waitAll('[data-tooltip^="Send"]'); // The Send button from the Standard reply box
       await gmailPage.notPresent('.reply_message_evaluated .error_notification'); // should not show the warning about switching to encrypted reply
     }));
 

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -19,6 +19,8 @@ import { OauthPageRecipe } from './page-recipe/oauth-page-recipe';
  * All tests that use mail.google.com or have to operate without a Gmail API mock should go here
  */
 
+export type GmailCategory = 'inbox' | 'sent' | 'drafts' | 'spam' | 'trash';
+
 // tslint:disable:no-blank-lines-func
 
 export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: TestWithBrowser) => {
@@ -82,8 +84,8 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       return gmailPage;
     };
 
-    const gotoGmailPage = async (gmailPage: ControllablePage, path: string) => {
-      const url = TestUrls.gmail(0, path);
+    const gotoGmailPage = async (gmailPage: ControllablePage, path: string, category: GmailCategory = 'inbox') => {
+      const url = TestUrls.gmail(0, path, category);
       await gmailPage.goto(url);
     };
 
@@ -316,10 +318,9 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       await gmailPage.waitAndClick('@action-secure-compose', { delay: 1 });
       await createSecureDraft(t, browser, gmailPage, 'compose draft');
       await gmailPage.page.reload();
+      await gotoGmailPage(gmailPage, '', 'drafts'); // to go drafts section
       // open new compose window and saved draft
       await gmailPage.waitAndClick('@action-secure-compose', { delay: 1 });
-      await gmailPage.waitAndFocus('body');
-      await gmailPage.waitAndClick('[data-tooltip="Drafts"]');
       await gmailPage.waitAndClick('//*[text()="Draft"]');
       await gmailPage.waitAndClick('[class^="open_draft_"]');
       // veryfy that there are two compose windows: new compose window and secure draft


### PR DESCRIPTION
Because it's not possible to make Gmail tests robust when running them in parallel, this PR changes the SemaphoreCI config so that Gmail tests will run only for:

- `master` branch
- branches that contain `live-test` or `gmail-test` in them

Also, stabilized Gmail tests so all of them now pass without retries:

```
  ✔ mail.google.com/chat (34.6s)
    ℹ run time: 28s
  ✔ mail.google.com - setup prompt notif + hides when close clicked + reappears + setup link opens settings (49.4s)
    ℹ run time: 43s
  ✔ mail.google.com - plain reply to encrypted and signed messages (1m 52.6s)
    ℹ run time: 57s
  ✔ mail.google.com - send rich-text encrypted message (1m 52.7s)
    ℹ run time: 72s
  ✔ mail.google.com - success notif after setup, click hides it, does not re-appear + offers to reauth (2m 9.8s)
    ℹ run time: 123s
  ✔ mail.google.com - rendering attachmnents (2m 59.9s)
    ℹ run time: 61s
  ✔ mail.google.com - pubkey gets rendered with new signed and encrypted Thunderbird signature (3m 0.3s)
    ℹ run time: 61s
  ✔ mail.google.com - msg.asc message content renders (4m 8s)
    ℹ run time: 61s
  ✔ mail.google.com - secure reply btn, reply draft (5m 6.4s)
    ℹ run time: 170s
  ✔ mail.google.com - pubkey file gets rendered (5m 6.9s)
    ℹ run time: 53s
  ✔ mail.google.com - saving and rendering compose drafts when offline (6m 4.9s)
    ℹ run time: 179s
  ✔ mail.google.com - Thunderbird signature [plain] is recognized + correct height (6m 35.3s)
    ℹ run time: 82s
  ✔ mail.google.com - decrypt message in offline mode (7m 3.7s)
    ℹ run time: 52s
  ✔ mail.google.com - setup prompt notification shows up + dismiss hides it + does not reappear if dismissed (7m 20s)
    ℹ run time: 38s
  ✔ mail.google.com - multiple compose windows, saving/opening compose draft (7m 32s)
    ℹ run time: 139s
  ✔ mail.google.com - plain reply draft (8m 22.5s)
    ℹ run time: 55s
  ✔ mail.google.com - Thunderbird signature [html] is recognized (8m 33s)
    ℹ run time: 82s
```

close #4020
close #4022

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
