### PR TITLE
issue #3925 Allow leading whitespaces generally (do not trim messages) + allow tabs when pasting tab-intended text

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-input-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-input-module.ts
@@ -53,7 +53,7 @@ export class ComposeInputModule extends ViewModule<ComposeView> {
     if (type === 'html') {
       return Xss.htmlSanitizeKeepBasicTags(html, 'IMG-KEEP');
     }
-    return Xss.htmlUnescape(Xss.htmlSanitizeAndStripAllTags(html, '\n')).trim();
+    return Xss.htmlUnescape(Xss.htmlSanitizeAndStripAllTags(html, '\n', false));
   }
 
   public extractAttachments = () => {

--- a/extension/chrome/elements/compose-modules/compose-input-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-input-module.ts
@@ -81,7 +81,7 @@ export class ComposeInputModule extends ViewModule<ComposeView> {
       const div = document.createElement('div');
       div.appendChild(e.fragment);
       const html = div.innerHTML;
-      const sanitized = this.isRichText() ? Xss.htmlSanitizeKeepBasicTags(html, 'IMG-KEEP') : Xss.htmlSanitizeAndStripAllTags(html, '<br>');
+      const sanitized = this.isRichText() ? Xss.htmlSanitizeKeepBasicTags(html, 'IMG-KEEP') : Xss.htmlSanitizeAndStripAllTags(html, '<br>', false);
       Xss.setElementContentDANGEROUSLY(div, sanitized); // xss-sanitized
       e.fragment.appendChild(div);
     });

--- a/extension/chrome/elements/compose-modules/compose-quote-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-quote-module.ts
@@ -179,11 +179,11 @@ export class ComposeQuoteModule extends ViewModule<ComposeView> {
   }
 
   private quoteText = (text: string) => {
-    return text.split('\n').map(l => '<br>&gt; ' + l).join('\n');
+    return text.split('\n').map(line => `&gt; ${line}`.trim()).join('\n');
   }
 
   private generateHtmlPreviousMsgQuote = (text: string, date: Date, from: string) => {
-    let onDateUserWrote = `On ${Str.fromDate(date).replace(' ', ' at ')}, ${from} wrote:`;
+    let onDateUserWrote = `On ${Str.fromDate(date).replace(' ', ' at ')}, ${from} wrote:\n`;
     const rtl = text.match(new RegExp('[' + Str.rtlChars + ']'));
     if (rtl) {
       onDateUserWrote = `<div dir="ltr">${onDateUserWrote}</div>`;

--- a/extension/chrome/elements/compose-modules/compose-quote-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-quote-module.ts
@@ -179,11 +179,11 @@ export class ComposeQuoteModule extends ViewModule<ComposeView> {
   }
 
   private quoteText = (text: string) => {
-    return text.split('\n').map(line => `<br>&gt; ${line}`.trim()).join('\n');
+    return text.split('\n').map(line => `<br>&gt; ${line}`.trim()).join('');
   }
 
   private generateHtmlPreviousMsgQuote = (text: string, date: Date, from: string) => {
-    let onDateUserWrote = `On ${Str.fromDate(date).replace(' ', ' at ')}, ${from} wrote:\n`;
+    let onDateUserWrote = `On ${Str.fromDate(date).replace(' ', ' at ')}, ${from} wrote:`;
     const rtl = text.match(new RegExp('[' + Str.rtlChars + ']'));
     if (rtl) {
       onDateUserWrote = `<div dir="ltr">${onDateUserWrote}</div>`;

--- a/extension/chrome/elements/compose-modules/compose-quote-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-quote-module.ts
@@ -179,7 +179,7 @@ export class ComposeQuoteModule extends ViewModule<ComposeView> {
   }
 
   private quoteText = (text: string) => {
-    return text.split('\n').map(line => `&gt; ${line}`.trim()).join('\n');
+    return text.split('\n').map(line => `<br>&gt; ${line}`.trim()).join('\n');
   }
 
   private generateHtmlPreviousMsgQuote = (text: string, date: Date, from: string) => {

--- a/extension/chrome/elements/compose-modules/compose-quote-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-quote-module.ts
@@ -114,10 +114,10 @@ export class ComposeQuoteModule extends ViewModule<ComposeView> {
       for (const block of readableBlocks) {
         const stringContent = block.content.toString();
         if (block.type === 'decryptedHtml') {
-          const htmlParsed = Xss.htmlSanitizeAndStripAllTags(block ? block.content.toString() : 'No Content', '\n');
+          const htmlParsed = Xss.htmlSanitizeAndStripAllTags(block ? block.content.toString() : 'No Content', '\n', false);
           decryptedAndFormatedContent.push(Xss.htmlUnescape(htmlParsed));
         } else if (block.type === 'plainHtml') {
-          decryptedAndFormatedContent.push(Xss.htmlUnescape(Xss.htmlSanitizeAndStripAllTags(stringContent, '\n')));
+          decryptedAndFormatedContent.push(Xss.htmlUnescape(Xss.htmlSanitizeAndStripAllTags(stringContent, '\n', false)));
         } else if (['encryptedAttachment', 'decryptedAttachment', 'plainAttachment'].includes(block.type)) {
           if (block.attachmentMeta?.data) {
             let attachmentMeta: { content: Buf, filename?: string } | undefined;
@@ -141,7 +141,7 @@ export class ComposeQuoteModule extends ViewModule<ComposeView> {
       }
       return {
         headers,
-        text: decryptedAndFormatedContent.join('\n').trim(),
+        text: decryptedAndFormatedContent.join('\n'),
         isOnlySigned: !!(decoded.rawSignedContent || (message.blocks.length > 0 && message.blocks[0].type === 'signedMsg')),
         decryptedFiles
       };

--- a/extension/chrome/elements/compose.htm
+++ b/extension/chrome/elements/compose.htm
@@ -93,7 +93,7 @@
       <tr id="section_subject">
         <td class="input">
           <!-- subject -->
-          <input id="input_subject" spellcheck="true" tabindex="2" placeholder="Subject" data-test="input-subject" />
+          <input id="input_subject" autocomplete="off" spellcheck="true" tabindex="2" placeholder="Subject" data-test="input-subject" />
         </td>
       </tr>
       <tr class="intro_container">

--- a/extension/chrome/elements/pgp_block_modules/pgp-block-quote-module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp-block-quote-module.ts
@@ -59,7 +59,7 @@ export class PgpBlockViewQuoteModule {
         lines.push(...linesQuotedPart.splice(0, linesQuotedPart.length));
       }
       await this.view.renderModule.renderContent(Str.escapeTextAsRenderableHtml(lines.join('\n')), false);
-      if (linesQuotedPart.length) {
+      if (linesQuotedPart.join('').trim()) {
         this.appendCollapsedQuotedContentButton(linesQuotedPart.join('\n'));
       }
     }

--- a/extension/chrome/elements/pgp_block_modules/pgp-block-quote-module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp-block-quote-module.ts
@@ -40,7 +40,7 @@ export class PgpBlockViewQuoteModule {
         await this.view.renderModule.renderContent(decryptedContent, false);
       }
     } else {
-      const lines = decryptedContent.trim().split(/\r?\n/);
+      const lines = decryptedContent.split(/\r?\n/);
       const linesQuotedPart: string[] = [];
       while (lines.length) {
         const lastLine = lines.pop()!; // lines.length above ensures there is a line

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -1900,6 +1900,8 @@ table#compose td.text div#input_text {
   max-width: 525px;
   overflow-y: auto;
   min-height: 140px;
+  white-space: pre-wrap;
+  tab-size: 4;
 }
 
 table#compose td.text div#input_text img {

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -1900,6 +1900,12 @@ table#compose td.text div#input_text {
   max-width: 525px;
   overflow-y: auto;
   min-height: 140px;
+}
+
+table#compose td.text div#input_text,
+#pgp_block,
+#backup_block,
+div#reply_message_successful_container > table div.replied_body {
   white-space: pre-wrap;
   tab-size: 4;
 }

--- a/extension/js/common/core/common.ts
+++ b/extension/js/common/core/common.ts
@@ -104,7 +104,6 @@ export class Str {
       .replace(rtlRegexp, '<div dir="rtl">$1</div>') // RTL lines
       .replace(/\n/g, '<br>\n') // leave newline so that following replaces work
       .replace(/^ +/gm, spaces => spaces.replace(/ /g, '&nbsp;'))
-      .replace(/^\t+/gm, tabs => tabs.replace(/\t/g, '&#9;'))
       .replace(/\n/g, ''); // strip newlines, already have <br>
   }
 

--- a/extension/js/common/platform/xss.ts
+++ b/extension/js/common/platform/xss.ts
@@ -126,7 +126,7 @@ export class Xss {
    *
    * Will be used when generating a text/plain alternative to outgoing rich text email, or when quoting previous email in a reply.
    */
-  public static htmlSanitizeAndStripAllTags = (dirtyHtml: string, outputNl: string): string => {
+  public static htmlSanitizeAndStripAllTags = (dirtyHtml: string, outputNl: string, trim = true): string => {
     Xss.throwIfNotSupported();
     let html = Xss.htmlSanitizeKeepBasicTags(dirtyHtml, 'IMG-DEL');
     const random = Str.sloppyRandom(5);
@@ -143,7 +143,9 @@ export class Xss {
     text = text.replace(/\n{2,}/g, '\n\n');
     // not all tags were removed above. Remove all remaining tags
     text = DOMPurify.sanitize(text, { ALLOWED_TAGS: [] });
-    text = text.trim();
+    if (trim) {
+      text = text.trim();
+    }
     if (outputNl !== '\n') {
       text = text.replace(/\n/g, outputNl);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,8 @@
         "jquery": "3.6.0",
         "node-forge": "0.10.0",
         "openpgp": "4.10.10",
-        "squire-rte": "1.11.1",
-        "sweetalert2": "^11.1.7",
+        "squire-rte": "1.11.3",
+        "sweetalert2": "11.1.7",
         "zxcvbn": "4.4.2"
       },
       "devDependencies": {
@@ -9027,9 +9027,9 @@
       "dev": true
     },
     "node_modules/squire-rte": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/squire-rte/-/squire-rte-1.11.1.tgz",
-      "integrity": "sha512-Hn86dYJBNnE9oCghPNnuTgXC93iIvtq6n1EEaEqJT6oearBcL6x8lMACY05PXxeq2BF1LhhHsPGpcG+eIrZKhg=="
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/squire-rte/-/squire-rte-1.11.3.tgz",
+      "integrity": "sha512-obFbkQU7UlDVTIjgCrnKW9bEX/C8DKRl9tz6F5txnIMb0c4eZF0Ma/ajTEGz2l+LzQVRdyVmw5uhbshV02Wa2w=="
     },
     "node_modules/sshpk": {
       "version": "1.16.1",
@@ -18065,9 +18065,9 @@
       "dev": true
     },
     "squire-rte": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/squire-rte/-/squire-rte-1.11.1.tgz",
-      "integrity": "sha512-Hn86dYJBNnE9oCghPNnuTgXC93iIvtq6n1EEaEqJT6oearBcL6x8lMACY05PXxeq2BF1LhhHsPGpcG+eIrZKhg=="
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/squire-rte/-/squire-rte-1.11.3.tgz",
+      "integrity": "sha512-obFbkQU7UlDVTIjgCrnKW9bEX/C8DKRl9tz6F5txnIMb0c4eZF0Ma/ajTEGz2l+LzQVRdyVmw5uhbshV02Wa2w=="
     },
     "sshpk": {
       "version": "1.16.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "jquery": "3.6.0",
     "node-forge": "0.10.0",
     "openpgp": "4.10.10",
-    "squire-rte": "1.11.1",
+    "squire-rte": "1.11.3",
     "sweetalert2": "11.1.7",
     "zxcvbn": "4.4.2"
   },

--- a/test/source/mock/google/strategies/send-message-strategy.ts
+++ b/test/source/mock/google/strategies/send-message-strategy.ts
@@ -126,9 +126,9 @@ class IncludeQuotedPartTestStrategy implements ITestMsgStrategy {
   private readonly quotedContent: string = [
     'On 2019-06-14 at 23:24, flowcrypt.compatibility@gmail.com wrote:',
     '> This is some message',
-    '> ',
+    '>',
     '> and below is the quote',
-    '> ',
+    '>',
     '> > this is the quote',
     '> > still the quote',
     '> > third line',

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -801,9 +801,10 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       const appendUrl = 'threadId=16b584ed95837510&skipClickPrompt=___cu_false___&ignoreDraft=___cu_false___&replyMsgId=16b584ed95837510';
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility', { appendUrl, hasReplyPrompt: true });
       await composePage.waitAndClick('@encrypted-reply', { delay: 5 });
-      await ComposePageRecipe.fillMsg(composePage, {}, undefined, '\tline 1\n\t\tline 2');
+      const bodyWithLeadingTabs = '\tline 1\n\t\tline 2';
+      await ComposePageRecipe.fillMsg(composePage, {}, undefined, bodyWithLeadingTabs);
       await composePage.click('@action-send');
-      await composePage.waitForContent('@container-reply-msg-successful', '\tline 1\n\t\tline 2');
+      await composePage.waitForContent('@container-reply-msg-successful', bodyWithLeadingTabs);
     }));
 
     ava.default('compose - RTL subject', testWithBrowser('compatibility', async (t, browser) => {

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -83,7 +83,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await SettingsPageRecipe.forgetAllPassPhrasesInStorage(settingsPage, k.passphrase);
       const inboxPage = await browser.newPage(t, TestUrls.extensionInbox('ci.tests.gmail@flowcrypt.test'));
       const composeFrame = await InboxPageRecipe.openAndGetComposeFrame(inboxPage);
-      await ComposePageRecipe.fillMsg(composeFrame, { to: 'human@flowcrypt.com' }, 'sign with entered pass phrase', { encrypt: false });
+      await ComposePageRecipe.fillMsg(composeFrame, { to: 'human@flowcrypt.com' }, 'sign with entered pass phrase', '', { encrypt: false });
       await composeFrame.waitAndClick('@action-send');
       await inboxPage.waitAll('@dialog-passphrase');
       const passphraseDialog = await inboxPage.getFrame(['passphrase.htm']);
@@ -94,7 +94,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await inboxPage.waitTillGone('@container-new-message'); // confirming pass phrase will auto-send the message
       // signed - done, now try to see if it remembered pp in session
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compose');
-      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'signed message pp in session', { encrypt: false });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'signed message pp in session', '', { encrypt: false });
       await ComposePageRecipe.sendAndClose(composePage);
       await settingsPage.close();
       await inboxPage.close();
@@ -232,7 +232,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
 
     ava.default('compose - signed message', testWithBrowser('ci.tests.gmail', async (t, browser) => {
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compose');
-      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'signed message', { encrypt: false });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'signed message', '', { encrypt: false });
       await ComposePageRecipe.sendAndClose(composePage);
     }));
 
@@ -424,7 +424,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await composePage.waitAndClick('@action-show-options-popover');
       await composePage.waitAll(['@action-toggle-sign', '@action-toggle-encrypt', '@icon-toggle-sign-tick']);
       await composePage.notPresent(['@icon-toggle-encrypt-tick']); // response to signed message should not be auto-encrypted
-      await ComposePageRecipe.fillMsg(composePage, {}, undefined, {}, 'reply');
+      await ComposePageRecipe.fillMsg(composePage, {}, undefined, '', {}, 'reply');
       await ComposePageRecipe.sendAndClose(composePage);
     }));
 
@@ -439,7 +439,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
 
     ava.default('compose - standalone- hide/show btns after signing', testWithBrowser('ci.tests.gmail', async (t, browser) => {
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compose');
-      await ComposePageRecipe.fillMsg(composePage, { to: 'test.no.pgp@test.com' }, 'Signed Message', { encrypt: false });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'test.no.pgp@test.com' }, 'Signed Message', '', { encrypt: false });
       expect(await composePage.isElementPresent('@add-intro')).to.be.true;
       expect(await composePage.isElementPresent('@password-or-pubkey-container')).to.be.true;
       await composePage.notPresent('@add-intro');
@@ -456,7 +456,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       const appendUrl = 'threadId=16ce2c965c75e5a6&skipClickPrompt=___cu_false___&ignoreDraft=___cu_false___&replyMsgId=16ce2c965c75e5a6';
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility', { appendUrl, hasReplyPrompt: true });
       await composePage.waitAndClick('@action-accept-reply-all-prompt', { delay: 2 });
-      await ComposePageRecipe.fillMsg(composePage, { bcc: "test@email.com" }, undefined, undefined, 'reply');
+      await ComposePageRecipe.fillMsg(composePage, { bcc: "test@email.com" }, undefined, undefined, undefined, 'reply');
       await expectRecipientElements(composePage, { to: ['censored@email.com'], cc: ['censored@email.com'], bcc: ['test@email.com'] });
       await Util.sleep(3);
       await ComposePageRecipe.sendAndClose(composePage, { password: 'test-pass' });
@@ -639,7 +639,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
 
     ava.default('compose - send new plain message', testWithBrowser('ci.tests.gmail', async (t, browser) => {
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compose');
-      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'New Plain Message', { encrypt: false, sign: false });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'New Plain Message', '', { encrypt: false, sign: false });
       await ComposePageRecipe.sendAndClose(composePage);
     }));
 
@@ -752,7 +752,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
 
     ava.default('compose - new message, Footer Mock Test', testWithBrowser('compatibility', async (t, browser) => {
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
-      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'Test Footer (Mock Test)', {}, 'new');
+      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'Test Footer (Mock Test)', '', {}, 'new');
       await ComposePageRecipe.sendAndClose(composePage);
     }));
 
@@ -787,7 +787,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       const imgBase64 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAAnElEQVR42u3RAQ0AAAgDIE1u9FvDOahAVzLFGS1ECEKEIEQIQoQgRIgQIQgRghAhCBGCECEIQYgQhAhBiBCECEEIQoQgRAhChCBECEIQIgQhQhAiBCFCEIIQIQgRghAhCBGCEIQIQYgQhAhBiBCEIEQIQoQgRAhChCAEIUIQIgQhQhAiBCEIEYIQIQgRghAhCBEiRAhChCBECEK+W3uw+TnWoJc/AAAAAElFTkSuQmCC';
       let composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
       const subject = `saving and rendering a draft with image ${Util.lousyRandom()}`;
-      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, { 'richtext': true });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, '', { 'richtext': true });
       await composePage.page.evaluate((src: string) => { $('[data-test=action-insert-image]').val(src).click(); }, imgBase64);
       await ComposePageRecipe.waitWhenDraftIsSaved(composePage);
       await composePage.close();
@@ -795,6 +795,15 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       const body = await composePage.waitAny('@input-body');
       await composePage.waitAll('#input_text img');
       expect(await body.$eval('#input_text img', el => el.getAttribute('src'))).to.eq(imgBase64);
+    }));
+
+    ava.default('compose - leading tabs', testWithBrowser('compatibility', async (t, browser) => {
+      const appendUrl = 'threadId=16b584ed95837510&skipClickPrompt=___cu_false___&ignoreDraft=___cu_false___&replyMsgId=16b584ed95837510';
+      const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility', { appendUrl, hasReplyPrompt: true });
+      await composePage.waitAndClick('@encrypted-reply', { delay: 5 });
+      await ComposePageRecipe.fillMsg(composePage, {}, undefined, '\tline 1\n\t\tline 2');
+      await composePage.click('@action-send');
+      await composePage.waitForContent('@container-reply-msg-successful', '\tline 1\n\t\tline 2');
     }));
 
     ava.default('compose - RTL subject', testWithBrowser('compatibility', async (t, browser) => {
@@ -810,7 +819,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
     ava.default('compose - saving and rendering a draft with RTL text (plain text)', testWithBrowser('compatibility', async (t, browser) => {
       let composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
       const subject = `مرحبا RTL plain text`;
-      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, { richtext: false });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, '', { richtext: false });
       await ComposePageRecipe.waitWhenDraftIsSaved(composePage);
       await composePage.close();
       composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility', { appendUrl: 'draftId=draft_with_rtl_text_plain' });
@@ -821,7 +830,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
     ava.default('compose - saving and rendering a draft with RTL text (rich text)', testWithBrowser('compatibility', async (t, browser) => {
       let composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
       const subject = `مرحبا RTL rich text`;
-      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, { richtext: true });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, '', { richtext: true });
       await ComposePageRecipe.waitWhenDraftIsSaved(composePage);
       await composePage.close();
       composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility', { appendUrl: 'draftId=draft_with_rtl_text_rich' });
@@ -844,7 +853,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       const text = 'This message is encrypted with 2 keys of flowcrypt.compatibility';
       const subject = `Test Sending Multi-Encrypted Message With Test Text ${Util.lousyRandom()}`;
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
-      await ComposePageRecipe.fillMsg(composePage, { to: 'flowcrypt.compatibility@gmail.com' }, subject, { sign: true, encrypt: true });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'flowcrypt.compatibility@gmail.com' }, subject, '', { sign: true, encrypt: true });
       await composePage.waitAndType('@input-body', text, { delay: 1 });
       expect(await composePage.read('@input-body')).to.include(text);
       await ComposePageRecipe.sendAndClose(composePage);
@@ -878,7 +887,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
         { isSavePassphraseChecked: false, isSavePassphraseHidden: false });
       const subject = `Test Sending Message With Test Text and HIDE_ARMOR_META OrgRule ${Util.lousyRandom()}`;
       const composePage = await ComposePageRecipe.openStandalone(t, browser, acct);
-      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, { sign: true });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, '', { sign: true });
       await composePage.waitAndType('@input-body', 'any text', { delay: 1 });
       await ComposePageRecipe.sendAndClose(composePage);
       // get sent msg from mock
@@ -1004,7 +1013,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       });
       await settingsPage.close();
       const composePage = await ComposePageRecipe.openStandalone(t, browser, acctEmail);
-      await ComposePageRecipe.fillMsg(composePage, { to: 'smime@recipient.com' }, 'send signed S/MIME without attachment', { encrypt: false, sign: true });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'smime@recipient.com' }, 'send signed S/MIME without attachment', '', { encrypt: false, sign: true });
       await composePage.waitAndClick('@action-send', { delay: 2 });
     }));
 
@@ -1277,7 +1286,7 @@ const sendImgAndVerifyPresentInSentMsg = async (t: AvaContext, browser: BrowserH
   const sendingTypeForHumans = sendingType === 'encrypt' ? 'Encrypted' : (sendingType === 'sign' ? 'Signed' : 'Plain');
   const subject = `Test Sending ${sendingTypeForHumans} Message With Image ${Util.lousyRandom()}`;
   const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
-  await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, { richtext: true, sign: sendingType === 'sign', encrypt: sendingType === 'encrypt' });
+  await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, '', { richtext: true, sign: sendingType === 'sign', encrypt: sendingType === 'encrypt' });
   // the following is a temporary hack - currently not able to directly paste an image with puppeteer
   // instead we should find a way to load the image into clipboard, and paste it into textbox
   await composePage.page.evaluate((src: string) => { $('[data-test=action-insert-image]').val(src).click(); }, imgBase64);
@@ -1312,7 +1321,7 @@ const sendTextAndVerifyPresentInSentMsg = async (t: AvaContext,
 ) => {
   const subject = `Test Sending ${sendingOpt.sign ? 'Signed' : ''} ${sendingOpt.encrypt ? 'Encrypted' : ''} Message With Test Text ${text} ${Util.lousyRandom()}`;
   const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
-  await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, sendingOpt);
+  await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, '', sendingOpt);
   await composePage.waitAndType('@input-body', text, { delay: 1 });
   expect(await composePage.read('@input-body')).to.include(text);
   await ComposePageRecipe.sendAndClose(composePage);

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -833,7 +833,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
     ava.default('compose - saving and rendering a draft with RTL text (rich text)', testWithBrowser('compatibility', async (t, browser) => {
       let composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
       const subject = `مرحبا RTL rich text`;
-      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, undefined, { richtext: true });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, 'مرحبا', { richtext: true });
       await ComposePageRecipe.waitWhenDraftIsSaved(composePage);
       await composePage.close();
       composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility', { appendUrl: 'draftId=draft_with_rtl_text_rich' });

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -346,7 +346,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
         '> From: Mozilla <Mozilla@e.mozilla.org>',
         '> Date: Thu, 6 Jun 2019, 17:22',
         '> Subject: Your misinformation questions ... answered.',
-        '> To: <tom@cryptup.org>'
+        '> To:  <tom@cryptup.org>'
       ].join('\n'));
     }));
 
@@ -358,7 +358,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
         'On 2018-10-03 at 14:47, henry.electrum@gmail.com wrote:',
         '> The following text is bold: this is bold',
         '>',
-        '> The following text is red: this text is red'
+        '> The following text is red: this text is        red'
       ].join('\n'));
     }));
 

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -356,6 +356,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await composePage.waitAndClick('@encrypted-reply', { delay: 1 });
       await clickTripleDotAndExpectQuoteToLoad(composePage, [
         'On 2018-10-03 at 14:47, henry.electrum@gmail.com wrote:',
+        '>',
         '> The following text is bold: this is bold',
         '>',
         '> The following text is red: this text is        red'
@@ -408,6 +409,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
         expect(inputBody.trim()).to.be.empty;
         await clickTripleDotAndExpectQuoteToLoad(replyFrame, [
           'On 2019-06-14 at 23:24, flowcrypt.compatibility@gmail.com wrote:',
+          '>',
           '> (Skipping previous message quote)'
         ].join('\n'));
       }));

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -856,9 +856,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       const text = 'This message is encrypted with 2 keys of flowcrypt.compatibility';
       const subject = `Test Sending Multi-Encrypted Message With Test Text ${Util.lousyRandom()}`;
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
-      await ComposePageRecipe.fillMsg(composePage, { to: 'flowcrypt.compatibility@gmail.com' }, subject, undefined, { sign: true, encrypt: true });
-      await composePage.waitAndType('@input-body', text, { delay: 1 });
-      expect(await composePage.read('@input-body')).to.include(text);
+      await ComposePageRecipe.fillMsg(composePage, { to: 'flowcrypt.compatibility@gmail.com' }, subject, text, { sign: true, encrypt: true });
       await ComposePageRecipe.sendAndClose(composePage);
       // get sent msg from mock
       const sentMsg = (await GoogleData.withInitializedData('flowcrypt.compatibility@gmail.com')).getMessageBySubject(subject)!;

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -83,7 +83,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await SettingsPageRecipe.forgetAllPassPhrasesInStorage(settingsPage, k.passphrase);
       const inboxPage = await browser.newPage(t, TestUrls.extensionInbox('ci.tests.gmail@flowcrypt.test'));
       const composeFrame = await InboxPageRecipe.openAndGetComposeFrame(inboxPage);
-      await ComposePageRecipe.fillMsg(composeFrame, { to: 'human@flowcrypt.com' }, 'sign with entered pass phrase', '', { encrypt: false });
+      await ComposePageRecipe.fillMsg(composeFrame, { to: 'human@flowcrypt.com' }, 'sign with entered pass phrase', undefined, { encrypt: false });
       await composeFrame.waitAndClick('@action-send');
       await inboxPage.waitAll('@dialog-passphrase');
       const passphraseDialog = await inboxPage.getFrame(['passphrase.htm']);
@@ -94,7 +94,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await inboxPage.waitTillGone('@container-new-message'); // confirming pass phrase will auto-send the message
       // signed - done, now try to see if it remembered pp in session
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compose');
-      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'signed message pp in session', '', { encrypt: false });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'signed message pp in session', undefined, { encrypt: false });
       await ComposePageRecipe.sendAndClose(composePage);
       await settingsPage.close();
       await inboxPage.close();
@@ -232,7 +232,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
 
     ava.default('compose - signed message', testWithBrowser('ci.tests.gmail', async (t, browser) => {
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compose');
-      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'signed message', '', { encrypt: false });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'signed message', undefined, { encrypt: false });
       await ComposePageRecipe.sendAndClose(composePage);
     }));
 
@@ -426,7 +426,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await composePage.waitAndClick('@action-show-options-popover');
       await composePage.waitAll(['@action-toggle-sign', '@action-toggle-encrypt', '@icon-toggle-sign-tick']);
       await composePage.notPresent(['@icon-toggle-encrypt-tick']); // response to signed message should not be auto-encrypted
-      await ComposePageRecipe.fillMsg(composePage, {}, undefined, '', {}, 'reply');
+      await ComposePageRecipe.fillMsg(composePage, {}, undefined, undefined, {}, 'reply');
       await ComposePageRecipe.sendAndClose(composePage);
     }));
 
@@ -441,7 +441,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
 
     ava.default('compose - standalone- hide/show btns after signing', testWithBrowser('ci.tests.gmail', async (t, browser) => {
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compose');
-      await ComposePageRecipe.fillMsg(composePage, { to: 'test.no.pgp@test.com' }, 'Signed Message', '', { encrypt: false });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'test.no.pgp@test.com' }, 'Signed Message', undefined, { encrypt: false });
       expect(await composePage.isElementPresent('@add-intro')).to.be.true;
       expect(await composePage.isElementPresent('@password-or-pubkey-container')).to.be.true;
       await composePage.notPresent('@add-intro');
@@ -641,7 +641,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
 
     ava.default('compose - send new plain message', testWithBrowser('ci.tests.gmail', async (t, browser) => {
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compose');
-      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'New Plain Message', '', { encrypt: false, sign: false });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'New Plain Message', undefined, { encrypt: false, sign: false });
       await ComposePageRecipe.sendAndClose(composePage);
     }));
 
@@ -670,7 +670,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
 
     ava.default('compose - send btn should be disabled while encrypting/sending', testWithBrowser('ci.tests.gmail', async (t, browser) => {
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compose');
-      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, '');
+      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, undefined);
       await composePage.waitAndClick('@action-send', { delay: 1 });
       expect(await composePage.isDisabled('#send_btn')).to.be.true;
       expect(await composePage.isDisabled('#toggle_send_options')).to.be.true;
@@ -754,7 +754,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
 
     ava.default('compose - new message, Footer Mock Test', testWithBrowser('compatibility', async (t, browser) => {
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
-      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'Test Footer (Mock Test)', '', {}, 'new');
+      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'Test Footer (Mock Test)', undefined, {}, 'new');
       await ComposePageRecipe.sendAndClose(composePage);
     }));
 
@@ -789,7 +789,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       const imgBase64 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAAnElEQVR42u3RAQ0AAAgDIE1u9FvDOahAVzLFGS1ECEKEIEQIQoQgRIgQIQgRghAhCBGCECEIQYgQhAhBiBCECEEIQoQgRAhChCBECEIQIgQhQhAiBCFCEIIQIQgRghAhCBGCEIQIQYgQhAhBiBCEIEQIQoQgRAhChCAEIUIQIgQhQhAiBCEIEYIQIQgRghAhCBEiRAhChCBECEK+W3uw+TnWoJc/AAAAAElFTkSuQmCC';
       let composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
       const subject = `saving and rendering a draft with image ${Util.lousyRandom()}`;
-      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, '', { 'richtext': true });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, undefined, { 'richtext': true });
       await composePage.page.evaluate((src: string) => { $('[data-test=action-insert-image]').val(src).click(); }, imgBase64);
       await ComposePageRecipe.waitWhenDraftIsSaved(composePage);
       await composePage.close();
@@ -822,7 +822,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
     ava.default('compose - saving and rendering a draft with RTL text (plain text)', testWithBrowser('compatibility', async (t, browser) => {
       let composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
       const subject = `مرحبا RTL plain text`;
-      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, '', { richtext: false });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, 'مرحبا', { richtext: false });
       await ComposePageRecipe.waitWhenDraftIsSaved(composePage);
       await composePage.close();
       composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility', { appendUrl: 'draftId=draft_with_rtl_text_plain' });
@@ -833,7 +833,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
     ava.default('compose - saving and rendering a draft with RTL text (rich text)', testWithBrowser('compatibility', async (t, browser) => {
       let composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
       const subject = `مرحبا RTL rich text`;
-      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, '', { richtext: true });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, undefined, { richtext: true });
       await ComposePageRecipe.waitWhenDraftIsSaved(composePage);
       await composePage.close();
       composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility', { appendUrl: 'draftId=draft_with_rtl_text_rich' });
@@ -856,7 +856,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       const text = 'This message is encrypted with 2 keys of flowcrypt.compatibility';
       const subject = `Test Sending Multi-Encrypted Message With Test Text ${Util.lousyRandom()}`;
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
-      await ComposePageRecipe.fillMsg(composePage, { to: 'flowcrypt.compatibility@gmail.com' }, subject, '', { sign: true, encrypt: true });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'flowcrypt.compatibility@gmail.com' }, subject, undefined, { sign: true, encrypt: true });
       await composePage.waitAndType('@input-body', text, { delay: 1 });
       expect(await composePage.read('@input-body')).to.include(text);
       await ComposePageRecipe.sendAndClose(composePage);
@@ -890,7 +890,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
         { isSavePassphraseChecked: false, isSavePassphraseHidden: false });
       const subject = `Test Sending Message With Test Text and HIDE_ARMOR_META OrgRule ${Util.lousyRandom()}`;
       const composePage = await ComposePageRecipe.openStandalone(t, browser, acct);
-      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, '', { sign: true });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, undefined, { sign: true });
       await composePage.waitAndType('@input-body', 'any text', { delay: 1 });
       await ComposePageRecipe.sendAndClose(composePage);
       // get sent msg from mock
@@ -1016,7 +1016,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       });
       await settingsPage.close();
       const composePage = await ComposePageRecipe.openStandalone(t, browser, acctEmail);
-      await ComposePageRecipe.fillMsg(composePage, { to: 'smime@recipient.com' }, 'send signed S/MIME without attachment', '', { encrypt: false, sign: true });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'smime@recipient.com' }, 'send signed S/MIME without attachment', undefined, { encrypt: false, sign: true });
       await composePage.waitAndClick('@action-send', { delay: 2 });
     }));
 
@@ -1288,8 +1288,9 @@ const sendImgAndVerifyPresentInSentMsg = async (t: AvaContext, browser: BrowserH
   const imgBase64 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAAnElEQVR42u3RAQ0AAAgDIE1u9FvDOahAVzLFGS1ECEKEIEQIQoQgRIgQIQgRghAhCBGCECEIQYgQhAhBiBCECEEIQoQgRAhChCBECEIQIgQhQhAiBCFCEIIQIQgRghAhCBGCEIQIQYgQhAhBiBCEIEQIQoQgRAhChCAEIUIQIgQhQhAiBCEIEYIQIQgRghAhCBEiRAhChCBECEK+W3uw+TnWoJc/AAAAAElFTkSuQmCC';
   const sendingTypeForHumans = sendingType === 'encrypt' ? 'Encrypted' : (sendingType === 'sign' ? 'Signed' : 'Plain');
   const subject = `Test Sending ${sendingTypeForHumans} Message With Image ${Util.lousyRandom()}`;
+  const body = `Test Sending ${sendingTypeForHumans} Message With Image ${Util.lousyRandom()}`;
   const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
-  await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, '', { richtext: true, sign: sendingType === 'sign', encrypt: sendingType === 'encrypt' });
+  await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, body, { richtext: true, sign: sendingType === 'sign', encrypt: sendingType === 'encrypt' });
   // the following is a temporary hack - currently not able to directly paste an image with puppeteer
   // instead we should find a way to load the image into clipboard, and paste it into textbox
   await composePage.page.evaluate((src: string) => { $('[data-test=action-insert-image]').val(src).click(); }, imgBase64);
@@ -1297,7 +1298,7 @@ const sendImgAndVerifyPresentInSentMsg = async (t: AvaContext, browser: BrowserH
   // get sent msg id from mock
   const sentMsg = (await GoogleData.withInitializedData('flowcrypt.compatibility@gmail.com')).getMessageBySubject(subject)!;
   if (sendingType === 'plain') {
-    expect(sentMsg.payload?.body?.data).to.match(/<img src="cid:(.+)@flowcrypt">This is an automated puppeteer test: Test Sending Plain Message With Image/);
+    expect(sentMsg.payload?.body?.data).to.match(/<img src="cid:(.+)@flowcrypt">Test Sending Plain Message With Image/);
     return;
     // todo - this test case is a stop-gap. We need to implement rendering of such messages below,
     //   then let test plain messages with images in them (referenced by cid) just like other types of messages below
@@ -1324,7 +1325,7 @@ const sendTextAndVerifyPresentInSentMsg = async (t: AvaContext,
 ) => {
   const subject = `Test Sending ${sendingOpt.sign ? 'Signed' : ''} ${sendingOpt.encrypt ? 'Encrypted' : ''} Message With Test Text ${text} ${Util.lousyRandom()}`;
   const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
-  await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, '', sendingOpt);
+  await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, undefined, sendingOpt);
   await composePage.waitAndType('@input-body', text, { delay: 1 });
   expect(await composePage.read('@input-body')).to.include(text);
   await ComposePageRecipe.sendAndClose(composePage);

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -889,7 +889,6 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       const subject = `Test Sending Message With Test Text and HIDE_ARMOR_META OrgRule ${Util.lousyRandom()}`;
       const composePage = await ComposePageRecipe.openStandalone(t, browser, acct);
       await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, undefined, { sign: true });
-      await composePage.waitAndType('@input-body', 'any text', { delay: 1 });
       await ComposePageRecipe.sendAndClose(composePage);
       // get sent msg from mock
       const sentMsg = (await GoogleData.withInitializedData(acct)).getMessageBySubject(subject)!;
@@ -1323,9 +1322,7 @@ const sendTextAndVerifyPresentInSentMsg = async (t: AvaContext,
 ) => {
   const subject = `Test Sending ${sendingOpt.sign ? 'Signed' : ''} ${sendingOpt.encrypt ? 'Encrypted' : ''} Message With Test Text ${text} ${Util.lousyRandom()}`;
   const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
-  await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, undefined, sendingOpt);
-  await composePage.waitAndType('@input-body', text, { delay: 1 });
-  expect(await composePage.read('@input-body')).to.include(text);
+  await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, subject, text, sendingOpt);
   await ComposePageRecipe.sendAndClose(composePage);
   // get sent msg from mock
   const sentMsg = (await GoogleData.withInitializedData('flowcrypt.compatibility@gmail.com')).getMessageBySubject(subject)!;

--- a/test/source/tests/flaky.ts
+++ b/test/source/tests/flaky.ts
@@ -84,7 +84,7 @@ export const defineFlakyTests = (testVariant: TestVariant, testWithBrowser: Test
         { isSavePassphraseChecked: true, isSavePassphraseHidden: false });
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
       await composePage.selectOption('@input-from', 'flowcryptcompatibility@gmail.com');
-      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'New Signed Message (Mock Test)', { encrypt: false });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'New Signed Message (Mock Test)', '', { encrypt: false });
       await ComposePageRecipe.sendAndClose(composePage);
     }));
 

--- a/test/source/tests/flaky.ts
+++ b/test/source/tests/flaky.ts
@@ -84,7 +84,7 @@ export const defineFlakyTests = (testVariant: TestVariant, testWithBrowser: Test
         { isSavePassphraseChecked: true, isSavePassphraseHidden: false });
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility');
       await composePage.selectOption('@input-from', 'flowcryptcompatibility@gmail.com');
-      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'New Signed Message (Mock Test)', '', { encrypt: false });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'human@flowcrypt.com' }, 'New Signed Message (Mock Test)', undefined, { encrypt: false });
       await ComposePageRecipe.sendAndClose(composePage);
     }));
 

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -163,7 +163,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       const gmailPage = await BrowserRecipe.openGmailPageAndVerifyComposeBtnPresent(t, browser);
       const composePage = await GmailPageRecipe.openSecureCompose(t, gmailPage, browser);
       const subject = `New Rich Text Message ${Util.lousyRandom()}`;
-      await ComposePageRecipe.fillMsg(composePage, { to: 'ci.tests.gmail@flowcrypt.dev' }, subject, '', { richtext: true });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'ci.tests.gmail@flowcrypt.dev' }, subject, undefined, { richtext: true });
       await ComposePageRecipe.sendAndClose(composePage);
       await gmailPage.waitAndClick('[aria-label^="Inbox"]');
       await gmailPage.waitAndClick('[role="row"]'); // click the first message

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -163,7 +163,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       const gmailPage = await BrowserRecipe.openGmailPageAndVerifyComposeBtnPresent(t, browser);
       const composePage = await GmailPageRecipe.openSecureCompose(t, gmailPage, browser);
       const subject = `New Rich Text Message ${Util.lousyRandom()}`;
-      await ComposePageRecipe.fillMsg(composePage, { to: 'ci.tests.gmail@flowcrypt.dev' }, subject, { richtext: true });
+      await ComposePageRecipe.fillMsg(composePage, { to: 'ci.tests.gmail@flowcrypt.dev' }, subject, '', { richtext: true });
       await ComposePageRecipe.sendAndClose(composePage);
       await gmailPage.waitAndClick('[aria-label^="Inbox"]');
       await gmailPage.waitAndClick('[role="row"]'); // click the first message

--- a/test/source/tests/page-recipe/compose-page-recipe.ts
+++ b/test/source/tests/page-recipe/compose-page-recipe.ts
@@ -69,7 +69,7 @@ export class ComposePageRecipe extends PageRecipe {
         await ComposePageRecipe.setPopoverToggle(composePageOrFrame, opt as PopoverOpt, shouldBeTicked);
       }
     }
-    await composePageOrFrame.type('@input-body', body || 'Body placeholder');
+    await composePageOrFrame.type('@input-body', body || subject || ''); // fall back to subject if body is not provided
     return { subject, body };
   }
 

--- a/test/source/tests/page-recipe/compose-page-recipe.ts
+++ b/test/source/tests/page-recipe/compose-page-recipe.ts
@@ -69,10 +69,7 @@ export class ComposePageRecipe extends PageRecipe {
         await ComposePageRecipe.setPopoverToggle(composePageOrFrame, opt as PopoverOpt, shouldBeTicked);
       }
     }
-    if (!body) {
-      body = subject?.match(/RTL/) ? 'مرحبا' : `This is an automated puppeteer test: ${subject || '(no-subject)'}`;
-    }
-    await composePageOrFrame.type('@input-body', body);
+    await composePageOrFrame.type('@input-body', body || 'Body placeholder');
     return { subject, body };
   }
 

--- a/test/source/tests/page-recipe/compose-page-recipe.ts
+++ b/test/source/tests/page-recipe/compose-page-recipe.ts
@@ -51,6 +51,7 @@ export class ComposePageRecipe extends PageRecipe {
     composePageOrFrame: Controllable,
     recipients: Recipients,
     subject?: string | undefined,
+    body?: string | undefined,
     sendingOpt: { encrypt?: boolean, sign?: boolean, richtext?: boolean } = {}, // undefined means leave default
     windowType: 'new' | 'reply' = 'new'
   ) {
@@ -68,7 +69,9 @@ export class ComposePageRecipe extends PageRecipe {
         await ComposePageRecipe.setPopoverToggle(composePageOrFrame, opt as PopoverOpt, shouldBeTicked);
       }
     }
-    const body = subject?.match(/RTL/) ? 'مرحبا' : `This is an automated puppeteer test: ${subject || '(no-subject)'}`;
+    if (!body) {
+      body = subject?.match(/RTL/) ? 'مرحبا' : `This is an automated puppeteer test: ${subject || '(no-subject)'}`;
+    }
     await composePageOrFrame.type('@input-body', body);
     return { subject, body };
   }

--- a/test/source/tests/setup.ts
+++ b/test/source/tests/setup.ts
@@ -479,7 +479,7 @@ AN8G3r5Htj8olot+jm9mIa5XLXWzMNUZgg==
       const inboxPage = await browser.newPage(t, TestUrls.extensionInbox(acctEmail));
       await InboxPageRecipe.finishSessionOnInboxPage(inboxPage);
       const composeFrame = await InboxPageRecipe.openAndGetComposeFrame(inboxPage);
-      await ComposePageRecipe.fillMsg(composeFrame, { to: 'human@flowcrypt.com' }, 'should not send as pass phrase is not known', '', { encrypt: false });
+      await ComposePageRecipe.fillMsg(composeFrame, { to: 'human@flowcrypt.com' }, 'should not send as pass phrase is not known', undefined, { encrypt: false });
       await composeFrame.waitAndClick('@action-send');
       await inboxPage.waitAll('@dialog-passphrase');
       const passphraseDialog = await inboxPage.getFrame(['passphrase.htm']);

--- a/test/source/tests/setup.ts
+++ b/test/source/tests/setup.ts
@@ -479,7 +479,7 @@ AN8G3r5Htj8olot+jm9mIa5XLXWzMNUZgg==
       const inboxPage = await browser.newPage(t, TestUrls.extensionInbox(acctEmail));
       await InboxPageRecipe.finishSessionOnInboxPage(inboxPage);
       const composeFrame = await InboxPageRecipe.openAndGetComposeFrame(inboxPage);
-      await ComposePageRecipe.fillMsg(composeFrame, { to: 'human@flowcrypt.com' }, 'should not send as pass phrase is not known', { encrypt: false });
+      await ComposePageRecipe.fillMsg(composeFrame, { to: 'human@flowcrypt.com' }, 'should not send as pass phrase is not known', '', { encrypt: false });
       await composeFrame.waitAndClick('@action-send');
       await inboxPage.waitAll('@dialog-passphrase');
       const passphraseDialog = await inboxPage.getFrame(['passphrase.htm']);


### PR DESCRIPTION
This PR:

- allows leading and trailing whitespaces in general (users should be able to start and end their messages with spaces or tabs, e.g. for formatting purposes)
- preserves leading tabs when pasting tab-intended text (related PR in Squire repo https://github.com/neilj/Squire/pull/417)

close #3925

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests are added

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
