### PR TITLE
issue #3871 Reword setup notification and convert links to buttons

### DIFF
--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -93,6 +93,14 @@ div.webmail_notifications div.webmail_notification {
   margin-left: 50px;
 }
 
+div.webmail_notifications div.webmail_notification .webmail_notification_buttons {
+  margin: 10px 0 5px;
+}
+
+div.webmail_notifications div.webmail_notification .action_open_settings {
+  font-weight: 500;
+}
+
 div.webmail_notifications div.webmail_notification a {
   color: black;
   padding-left: 6px;

--- a/extension/js/common/notifications.ts
+++ b/extension/js/common/notifications.ts
@@ -52,7 +52,7 @@ export class Notifications {
       callbacks.reload = Catch.try(() => window.location.reload());
     }
     for (const name of Object.keys(callbacks)) {
-      $(`.webmail_notifications a.${name}`).click(Ui.event.prevent('double', callbacks[name]));
+      $(`.webmail_notifications .${name}`).click(Ui.event.prevent('double', callbacks[name]));
     }
   }
 

--- a/extension/js/content_scripts/webmail/setup-webmail-content-script.ts
+++ b/extension/js/content_scripts/webmail/setup-webmail-content-script.ts
@@ -40,9 +40,18 @@ const win = window as unknown as ContentScriptWindow;
 export const contentScriptSetupIfVacant = async (webmailSpecific: WebmailSpecificInfo) => {
 
   const setUpNotification = `
-    <a href="#" class="action_open_settings" data-test="notification-setup-action-open-settings">Set up FlowCrypt</a> to send and receive secure email on this account.
-    <a href="#" class="notification_setup_needed_dismiss" data-test="notification-setup-action-dismiss">dismiss</a>
-    <a href="#" class="close" data-test="notification-setup-action-close">remind me later</a>
+    Set up FlowCrypt now for encrypted email?
+    <div class="webmail_notification_buttons">
+      <button class="action_open_settings" data-test="notification-setup-action-open-settings">
+        Yes
+      </button>
+      <button class="close" data-test="notification-setup-action-close">
+        Remind me later
+      </button>
+      <button class="notification_setup_needed_dismiss" data-test="notification-setup-action-dismiss">
+        Don't remind again
+      </button>
+    </div>
   `;
   let wasDestroyed = false;
   class DestroyTrigger extends Error { }


### PR DESCRIPTION
This PR improves setup notification by making it simpler and converting links to buttons:

<img width="327" alt="CleanShot 2021-10-14 at 16 30 20@2x" src="https://user-images.githubusercontent.com/6059356/137327305-47572bf9-4f0d-4f89-bac6-49538a089cc3.png">

close #3871

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
