### PR TITLE
issue #3992 [Setup] Fix showing error modal when uploading invalid private key

### DIFF
--- a/test/source/tests/page-recipe/settings-page-recipe.ts
+++ b/test/source/tests/page-recipe/settings-page-recipe.ts
@@ -14,7 +14,6 @@ import { KeyUtil } from '../../core/crypto/key';
 export type SavePassphraseChecks = {
   isSavePassphraseHidden?: boolean | undefined,
   isSavePassphraseChecked?: boolean | undefined
-  isInvalidKey?: boolean | undefined
 };
 
 export class SettingsPageRecipe extends PageRecipe {

--- a/test/source/tests/page-recipe/setup-page-recipe.ts
+++ b/test/source/tests/page-recipe/setup-page-recipe.ts
@@ -19,7 +19,8 @@ type ManualEnterOpts = {
   enforceAttesterSubmitOrgRule?: boolean,
   noPubSubmitRule?: boolean,
   fillOnly?: boolean,
-  key?: TestKeyInfoWithFilepath
+  key?: TestKeyInfoWithFilepath,
+  isInvalidKey?: boolean | undefined,
 };
 
 type CreateKeyOpts = {
@@ -101,6 +102,7 @@ export class SetupPageRecipe extends PageRecipe {
       fillOnly = false,
       noPubSubmitRule = false,
       key,
+      isInvalidKey = false,
     }: ManualEnterOpts = {},
     checks: SavePassphraseChecks = {}
   ) {
@@ -123,7 +125,7 @@ export class SetupPageRecipe extends PageRecipe {
         settingsPage.waitAndClick('@input-step2bmanualenter-file', { retryErrs: true })]);
       await fileChooser.accept([key.filePath]);
       await Util.sleep(1);
-      if (checks.isInvalidKey) {
+      if (isInvalidKey) {
         await settingsPage.waitAndRespondToModal('error', 'confirm', 'Not able to read this key. Make sure it is a valid PGP private key.');
         return;
       }

--- a/test/source/tests/setup.ts
+++ b/test/source/tests/setup.ts
@@ -67,7 +67,7 @@ export const defineSetupTests = (testVariant: TestVariant, testWithBrowser: Test
         passphrase: '',
         longid: null // tslint:disable-line:no-null-keyword
       };
-      await SetupPageRecipe.manualEnter(settingsPage, key.title, { key } , { isInvalidKey: true });
+      await SetupPageRecipe.manualEnter(settingsPage, key.title, { key, isInvalidKey: true });
     }));
 
     ava.default('setup - import key - submit - used before', testWithBrowser(undefined, async (t, browser) => {


### PR DESCRIPTION
This PR fixes showing the error modal when user imports invalid key file. The functionality was already there, but it was broken.

close #3992

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
