### PR TITLE
Decrease the height of Secure Compose button

### DIFF
--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -27,6 +27,10 @@
   outline: 0;
 }
 
+.anZ #flowcrypt_secure_compose_button {
+  height: 40px;
+}
+
 #flowcrypt_secure_compose_button::before {
   display: block;
   content: '';


### PR DESCRIPTION
This PR decreases the height of the Secure Compose button in case the Meet is enabled for the account (in Settings)

close #4063

Meet enabled | Meet disabled (larger buttons)
-|-
<img width="276" alt="CleanShot 2021-10-21 at 22 54 51@2x" src="https://user-images.githubusercontent.com/6059356/138347721-23c89e88-ba06-4034-9704-ad3bd90c4e7e.png"> | <img width="257" alt="CleanShot 2021-10-21 at 22 55 19@2x" src="https://user-images.githubusercontent.com/6059356/138347764-970c5679-fe27-43bf-87d8-f48971a547e8.png">


----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
