### PR TITLE
helper methods to send message on behalf of a test page

### DIFF
--- a/test/source/tests/page-recipe/abstract-page-recipe.ts
+++ b/test/source/tests/page-recipe/abstract-page-recipe.ts
@@ -30,6 +30,18 @@ export abstract class PageRecipe {
     }
   }
 
+  public static sendMessage = async (controllable: Controllable, msg: any) => {
+    return await controllable.target.evaluate(async (msg) => await new Promise((resolve) => {
+      chrome.runtime.sendMessage(msg, resolve);
+    }), msg);
+  }
+
+  public static getTabId = async (controllable: Controllable): Promise<string> => {
+    // tslint:disable-next-line:no-null-keyword
+    const result = await PageRecipe.sendMessage(controllable, { name: '_tab_', data: { bm: {}, objUrls: {} }, to: null, uid: '1' });
+    return (result as { result: { tabId: string } }).result.tabId;
+  }
+
   /**
    * responding to modal triggers a new page to be open, eg oauth login page
    */


### PR DESCRIPTION
This PR shows how to send a message on behalfof the page (useful for testing or getting tabId from inside a test)

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
