### PR TITLE
Change the 'keyup' events handlers to 'input' because text content can be changed with the mouse

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -54,7 +54,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
   public setHandlers = (): void => {
     let preventSearchContacts = false;
     const inputs = this.view.S.cached('recipients_inputs');
-    inputs.on('keyup', this.view.setHandlerPrevent('veryslowspree', async (target) => {
+    inputs.on('input', this.view.setHandlerPrevent('veryslowspree', async (target) => {
       if (!preventSearchContacts) {
         await this.searchContacts($(target));
       }

--- a/extension/chrome/elements/compose-modules/compose-render-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-render-module.ts
@@ -281,7 +281,7 @@ export class ComposeRenderModule extends ViewModule<ComposeView> {
   private addComposeTableHandlers = async () => {
     this.view.S.cached('body').keydown(this.view.setHandler((el, ev) => this.onBodyKeydownHandler(el, ev)));
     this.view.S.cached('input_to').bind('paste', this.view.setHandler((el, ev) => this.onRecipientPasteHandler(el, ev)));
-    this.view.inputModule.squire.addEventListener('keyup', () => this.view.S.cached('send_btn_note').text(''));
+    this.view.inputModule.squire.addEventListener('input', () => this.view.S.cached('send_btn_note').text(''));
     this.view.S.cached('input_addresses_container_inner').click(this.view.setHandler(() => this.onRecipientsClickHandler(), this.view.errModule.handle(`focus recipients`)));
     this.view.S.cached('input_addresses_container_inner').children().click(() => false);
     this.view.S.cached('input_subject').bind('input', this.view.setHandler((el: HTMLInputElement) => this.subjectRTLHandler(el))).trigger('input');

--- a/extension/chrome/elements/compose-modules/compose-size-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-size-module.ts
@@ -41,7 +41,7 @@ export class ComposeSizeModule extends ViewModule<ComposeView> {
       // we use veryslowspree for reply box because hand-resizing the main window will cause too many events
       // we use spree (faster) for new messages because rendering of window buttons on top right depend on it, else visible lag shows
       $(window).resize(this.view.setHandlerPrevent(this.view.isReplyBox ? 'veryslowspree' : 'spree', () => { this.windowResized().catch(Catch.reportErr); }));
-      this.view.inputModule.squire.addEventListener('keyup', () => this.view.setHandlerPrevent('slowspree', () => { this.windowResized().catch(Catch.reportErr); }));
+      this.view.inputModule.squire.addEventListener('input', () => this.view.setHandlerPrevent('slowspree', () => { this.windowResized().catch(Catch.reportErr); }));
     }, 1000);
   }
 

--- a/extension/chrome/settings/modules/change_passphrase.ts
+++ b/extension/chrome/settings/modules/change_passphrase.ts
@@ -89,7 +89,7 @@ View.run(class ChangePassPhraseView extends View {
   }
 
   private actionUseAnotherPassPhraseHandler = () => {
-    $('#new_pass_phrase').val('').keyup();
+    $('#new_pass_phrase').val('').trigger('input');
     $('#new_pass_phrase_confirm').val('');
     this.displayBlock('step_1_enter_new');
     $('#new_pass_phrase').focus();

--- a/extension/js/common/ui/key-import-ui.ts
+++ b/extension/js/common/ui/key-import-ui.ts
@@ -195,7 +195,7 @@ export class KeyImportUi {
     input.parent().append(validationElements.progressBarElement); // xss-direct
     input.parent().append(validationElements.passwordResultElement); // xss-direct
     const validation = Ui.event.prevent('spree', validate);
-    input.on('keyup', validation);
+    input.on('input', validation);
     const removeValidationElements = () => {
       validationElements.passwordResultElement.remove();
       validationElements.progressBarElement.remove();

--- a/extension/js/common/ui/key-import-ui.ts
+++ b/extension/js/common/ui/key-import-ui.ts
@@ -75,7 +75,7 @@ export class KeyImportUi {
       }
     });
     $('.line.unprotected_key_create_pass_phrase .action_use_random_pass_phrase').click(Ui.event.handle(() => {
-      $('.source_paste_container .input_passphrase').val(PgpPwd.random()).keyup();
+      $('.source_paste_container .input_passphrase').val(PgpPwd.random()).trigger('input');
       $('.input_passphrase').attr('type', 'text');
       $('#e_rememberPassphrase').prop('checked', true);
     }));


### PR DESCRIPTION
This PR makes sure that the app is reacting to all input changes - with the keyboard or with the mouse (e.g. right click -> paste)

close #4076

----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
