### PR TITLE
issue #4097 add warning when manually importing public keys

### DIFF
--- a/extension/chrome/elements/add_pubkey.htm
+++ b/extension/chrome/elements/add_pubkey.htm
@@ -37,8 +37,11 @@
     <div class="line">
       <textarea class="pubkey" placeholder="ASCII Armored Public Key" spellcheck="false" data-test="input-pubkey"></textarea>
     </div>
+    <div class="line orange">
+      Manually importing Public Keys can be dangerous
+    </div>
     <div class="line">
-      <button class="button long green action_ok" data-test="action-add-pubkey">OK</button>
+      <button class="button long orange action_ok" data-test="action-add-pubkey">OK</button>
       <button class="button long gray action_settings">SETTINGS</button>
       <button class="button long gray action_close">CLOSE</button>
     </div>

--- a/extension/chrome/elements/pgp_pubkey.htm
+++ b/extension/chrome/elements/pgp_pubkey.htm
@@ -20,13 +20,11 @@
     <div class="line fingerprints hide_if_compact">Fingerprint: <span class="fingerprint good"></span></div>
     <div class="line add_contact">
       <input class="input_email" data-test="input-email" value="..." />
-      <button class="button green action_add_contact" data-test="action-add-contact"></button>
-      <div class="mt-10">
-        <span class="orange">
-          Manually importing Public Keys received over email can be dangerous. <br>
-          Contact the sender to verify that the fingerprint matches.
-        </span>
-      </div>
+      <button class="button orange action_add_contact" data-test="action-add-contact"></button>
+    </div>
+    <div class="mt-10 orange hide_if_compact">
+      Manually importing Public Keys received over email can be dangerous. <br>
+      Contact the sender to verify that the fingerprint matches.
     </div>
     <pre class="pubkey hide_if_compact"></pre>
   </div>

--- a/extension/chrome/elements/pgp_pubkey.htm
+++ b/extension/chrome/elements/pgp_pubkey.htm
@@ -21,6 +21,12 @@
     <div class="line add_contact">
       <input class="input_email" data-test="input-email" value="..." />
       <button class="button green action_add_contact" data-test="action-add-contact"></button>
+      <div class="mt-10">
+        <span class="orange">
+          Manually importing Public Keys received over email can be dangerous. <br>
+          Contact the sender to verify that the fingerprint matches.
+        </span>
+      </div>
     </div>
     <pre class="pubkey hide_if_compact"></pre>
   </div>

--- a/extension/chrome/settings/modules/contacts.htm
+++ b/extension/chrome/settings/modules/contacts.htm
@@ -43,11 +43,14 @@
     </div>
 
     <div id="bulk_import" style="display: none;">
+      <div class="line orange">
+        Manually importing Public Keys can be dangerous
+      </div>
       <div class="line" id="file_import">
         <a id="fineuploader_button" href="#">Select a file</a> or paste public key(s) below:
         <div id="fineuploader" class="display_none"></div>
       </div>
-      <div id="processed"></div>
+      <div id="processed" class="mt-20"></div>
       <div class="line">
         <textarea class="input_pubkey"
           data-test="input-bulk-public-keys"

--- a/extension/chrome/settings/modules/contacts.ts
+++ b/extension/chrome/settings/modules/contacts.ts
@@ -265,7 +265,7 @@ View.run(class ContactsView extends View {
           }
         }
         container.css('display', 'block');
-        $('#bulk_import .input_pubkey, #bulk_import .action_process, #file_import #fineuploader_button').css('display', 'none');
+        $('#bulk_import .input_pubkey, #bulk_import .action_process, #file_import, #fineuploader_button').css('display', 'none');
       }
     } catch (e) {
       ApiErr.reportIfSignificant(e);

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -51,7 +51,7 @@ td.red,
 b.red,
 span.red { color: #d14836; }
 
-.line.prange,
+.line.orange,
 td.orange,
 b.orange,
 span.orange { color: #c27e23; }
@@ -1334,7 +1334,12 @@ td {
 
 #pgp_block.pgp_pubkey { padding-top: 7px; }
 #pgp_block.pgp_pubkey .line { margin: 0; }
-#pgp_block.pgp_pubkey pre.pubkey { display: none; }
+#pgp_block.pgp_pubkey .add_contact:not(.line) { text-align: center; }
+
+#pgp_block.pgp_pubkey pre.pubkey {
+  margin-top: 0;
+  display: none;
+}
 
 #pgp_block .three_dots {
   text-align: center;
@@ -1900,8 +1905,7 @@ table#compose td.text div#input_text {
 }
 
 table#compose td.text div#input_text,
-#pgp_block,
-#backup_block,
+#pgp_block:not(.pgp_pubkey),
 div#reply_message_successful_container > table div.replied_body {
   white-space: pre-wrap;
   tab-size: 4;
@@ -2824,6 +2828,7 @@ body#select_account .action_add_account::before {
 }
 
 .m-0 { margin: 0 !important; }
+.mt-10 { margin-top: 10px; }
 .mt-20 { margin-top: 20px; }
 .mt-40 { margin-top: 40px; }
 .mb-20 { margin-bottom: 20px; }

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -54,6 +54,7 @@ span.red { color: #d14836; }
 .line.orange,
 td.orange,
 b.orange,
+div.orange,
 span.orange { color: #c27e23; }
 
 .line.green,
@@ -137,6 +138,11 @@ span.gray { color: #b7b7b7; }
 .button.gray {
   background-color: #b7b7b7;
   background-image: linear-gradient(#c5c5c5, #b7b7b7);
+  color: white;
+}
+
+.button.orange {
+  background: #d18826;
   color: white;
 }
 
@@ -1046,8 +1052,8 @@ body#settings > div#content.dialog.add_pubkey select.copy_from_email {
 
 body#settings > div#content.dialog.add_pubkey textarea.pubkey {
   width: 500px;
-  height: 340px;
-  font-size: 10px;
+  height: 300px;
+  font-size: 12px;
   padding: 8px;
 }
 


### PR DESCRIPTION
This PR adds an orange warning when manually importing public keys. It also fixes the broken layout of `chrome/elements/pgp_pubkey.htm`

close #4097
close #4104

<img width="610" alt="CleanShot 2021-11-10 at 18 26 08@2x" src="https://user-images.githubusercontent.com/6059356/141153352-2926d6c9-73da-45fa-b080-98d5349eeab8.png">

<img width="797" alt="CleanShot 2021-11-10 at 18 24 26@2x" src="https://user-images.githubusercontent.com/6059356/141153426-c89a7e55-7212-4365-95d6-0a3b0f94d18f.png">


----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
