### PR TITLE
issue #4081 Make secure compose popup active when draft is waiting for pass phrase

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -336,18 +336,24 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
   };
 
   private renderPPDialogAndWaitWhenPPEntered = async (longids: string[]) => {
-    const promptText = `<div>Waiting for <a href="#" data-test="action-open-passphrase-dialog" class="action_open_passphrase_dialog">pass phrase</a> to open draft..</div>`;
+    const promptText = `<div style="font-size: 18px">Waiting for pass phrase to open draft...</div>`;
     if (this.view.isReplyBox) {
       Xss.sanitizeRender(this.view.S.cached('prompt'), promptText).css({ display: 'block' });
       this.view.sizeModule.resizeComposeBox();
     } else {
-      Xss.sanitizeRender(this.view.S.cached('prompt'), `${promptText}<br><br><a href="#" class="action_close">close</a>`).css({ display: 'flex', height: '100%' });
+      Xss.sanitizeRender(this.view.S.cached('prompt'), `
+        ${promptText}
+        <div class="mt-20">
+          <button href="#" data-test="action-open-passphrase-dialog" class="button long green action_open_passphrase_dialog">Enter pass phrase</button>
+          <button href="#" class="button gray action_close">close</button>
+        </div>
+      `).css({ display: 'flex', height: '100%' });
       BrowserMsg.send.setActiveWindow(this.view.parentTabId, { frameId: this.view.frameId });
     }
-    this.view.S.cached('prompt').find('a.action_open_passphrase_dialog').click(this.view.setHandler(async () => {
+    this.view.S.cached('prompt').find('.action_open_passphrase_dialog').click(this.view.setHandler(async () => {
       BrowserMsg.send.passphraseDialog(this.view.parentTabId, { type: 'draft', longids });
     }));
-    this.view.S.cached('prompt').find('a.action_close').click(this.view.setHandler(() => this.view.renderModule.closeMsg()));
+    this.view.S.cached('prompt').find('.action_close').click(this.view.setHandler(() => this.view.renderModule.closeMsg()));
     const setActiveWindow = this.view.setHandler(async () => { BrowserMsg.send.setActiveWindow(this.view.parentTabId, { frameId: this.view.frameId }); });
     this.view.S.cached('prompt').on('click', setActiveWindow).trigger('click');
     await PassphraseStore.waitUntilPassphraseChanged(this.view.acctEmail, longids, 1000, this.view.ppChangedPromiseCancellation);

--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -348,6 +348,8 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
       BrowserMsg.send.passphraseDialog(this.view.parentTabId, { type: 'draft', longids });
     }));
     this.view.S.cached('prompt').find('a.action_close').click(this.view.setHandler(() => this.view.renderModule.closeMsg()));
+    const setActiveWindow = this.view.setHandler(async () => { BrowserMsg.send.setActiveWindow(this.view.parentTabId, { frameId: this.view.frameId }); });
+    this.view.S.cached('prompt').on('click', setActiveWindow).trigger('click');
     await PassphraseStore.waitUntilPassphraseChanged(this.view.acctEmail, longids, 1000, this.view.ppChangedPromiseCancellation);
   };
 

--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -352,7 +352,7 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
     }
     this.view.S.cached('prompt').find('.action_open_passphrase_dialog').click(this.view.setHandler(async () => {
       BrowserMsg.send.passphraseDialog(this.view.parentTabId, { type: 'draft', longids });
-    }));
+    })).focus();
     this.view.S.cached('prompt').find('.action_close').click(this.view.setHandler(() => this.view.renderModule.closeMsg()));
     const setActiveWindow = this.view.setHandler(async () => { BrowserMsg.send.setActiveWindow(this.view.parentTabId, { frameId: this.view.frameId }); });
     this.view.S.cached('prompt').on('click', setActiveWindow).trigger('click');


### PR DESCRIPTION
This PR makes secure compose popup active when draft is waiting for pass phrase, previously is wasn't become active on open and looked faded (as default inactive popup).

Also, the buttons are now more obvious to click:

<img width="432" alt="CleanShot 2021-11-30 at 19 37 56@2x" src="https://user-images.githubusercontent.com/6059356/144098963-14d6599b-2d37-458b-a6f2-4a46fc430880.png">

close #4081

----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
