### PR TITLE
issue #4098 Make the FlowCrypt logo in "Secure Compose" button inline

### DIFF
--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -27,7 +27,7 @@
   outline: 0;
 }
 
-.anZ #flowcrypt_secure_compose_button {
+.small #flowcrypt_secure_compose_button {
   height: 40px;
 }
 
@@ -36,7 +36,7 @@
   content: '';
   background-size: 24px;
   min-width: 56px;
-  height: 48px;
+  height: 100%;
 
   /* inline SVG because of https://github.com/FlowCrypt/flowcrypt-browser/issues/4098#issuecomment-984814877 */
   background-image: url('data:image/svg+xml;utf8,<svg width="220" height="142" viewBox="0 0 220 142" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path d="M31.4 80.108l31.438 31.437-21.6 21.6c-5.467 5.468-14.331 5.468-19.799 0l-15.881-15.88a8 8 0 0 1 0-11.315L31.4 80.108z" fill="%234F4F4F"/><path d="M70.775 40.733l70.735 70.735-21.6 21.6c-5.467 5.467-14.332 5.467-19.8 0L39.277 72.233l31.5-31.5z" fill="%2331A217" opacity=".9"/><path d="M115.1 6.308l100.132 100.133a7 7 0 0 1 0 9.899l-16.65 16.65c-5.468 5.468-14.332 5.468-19.8 0L78.65 32.858l26.55-26.55a7 7 0 0 1 9.9 0z" fill="%2331A217"/></g></svg>');
@@ -57,17 +57,17 @@
   padding: 0;
 }
 
-.anZ.bhZ:not(.bym) #flowcrypt_secure_compose_button {
+.bhZ:not(.bym) .small #flowcrypt_secure_compose_button {
   width: 40px;
   height: 40px;
   border-radius: 20px;
 }
 
-.anZ.bhZ:not(.bym) #flowcrypt_secure_compose_button::before {
+.bhZ:not(.bym) .small #flowcrypt_secure_compose_button::before {
   min-width: 42px;
 }
 
-.aeN:not(.anZ) [class*="_destroyable"].z0 {
+[class*="_destroyable"].z0:not(.small) {
   margin-bottom: 0 !important;
 }
 

--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -37,7 +37,9 @@
   background-size: 24px;
   min-width: 56px;
   height: 48px;
-  background-image: url("/img/logo/logo.svg");
+
+  /* inline SVG because of https://github.com/FlowCrypt/flowcrypt-browser/issues/4098#issuecomment-984814877 */
+  background-image: url('data:image/svg+xml;utf8,<svg width="220" height="142" viewBox="0 0 220 142" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path d="M31.4 80.108l31.438 31.437-21.6 21.6c-5.467 5.468-14.331 5.468-19.799 0l-15.881-15.88a8 8 0 0 1 0-11.315L31.4 80.108z" fill="%234F4F4F"/><path d="M70.775 40.733l70.735 70.735-21.6 21.6c-5.467 5.467-14.332 5.467-19.8 0L39.277 72.233l31.5-31.5z" fill="%2331A217" opacity=".9"/><path d="M115.1 6.308l100.132 100.133a7 7 0 0 1 0 9.899l-16.65 16.65c-5.468 5.468-14.332 5.468-19.8 0L78.65 32.858l26.55-26.55a7 7 0 0 1 9.9 0z" fill="%2331A217"/></g></svg>');
   background-position: center;
   background-repeat: no-repeat;
 }

--- a/extension/js/common/inject.ts
+++ b/extension/js/common/inject.ts
@@ -74,7 +74,13 @@ export class Injector {
       (window as unknown as ContentScriptWindow).TrySetDestroyableTimeout(() => this.btns(), 300);
     } else if (this.shouldInject()) {
       if (this.S.now('compose_button').length === 0) {
-        const container = this.S.now('compose_button_container').first().prepend(this.factory.btnCompose(this.webmailName)); // xss-safe-factory
+        const secureComposeButton = $(this.factory.btnCompose(this.webmailName));
+        const container = this.S.now('compose_button_container').first().prepend(secureComposeButton); // xss-safe-factory
+        if (this.webmailName === 'gmail') {
+          if (!$('.aic').length) { // https://github.com/FlowCrypt/flowcrypt-browser/issues/4063
+            secureComposeButton.addClass('small');
+          }
+        }
         container.find(this.S.sel('compose_button')).click(Ui.event.prevent('double', () => { this.openComposeWin(); }));
       }
     }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -72,7 +72,6 @@
   "options_page": "/chrome/settings/index.htm",
   "web_accessible_resources": [
     "/css/webmail.css",
-    "/img/logo/logo.svg",
     "/img/svgs/reply-icon.svg",
     "/img/svgs/spinner-white-small.svg",
     "/img/svgs/spinner-green-small.svg",


### PR DESCRIPTION
This PR converts the FlowCrypt logo image inside the Secure Compose button inline for the sake of compatibility with [Virtru Email Protection](https://chrome.google.com/webstore/detail/virtru-email-protection/nemmanchfojaehgkbgcfmdiidbopakpp/related?hl=en)

close #4098

Also, because Gmail changed the layout a bit, fixed the detection when the Secure Compose button should have smaller height (issue #4063)

----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
