### PR TITLE
issue #4087 Do dot turn off all click handlers on body when closing send btn popover

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-send-btn-popover-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-send-btn-popover-module.ts
@@ -82,14 +82,15 @@ export class ComposeSendBtnPopoverModule extends ViewModule<ComposeView> {
     event.stopPropagation();
     const sendingContainer = $('.sending-container');
     sendingContainer.toggleClass('popover-opened');
+    const popoverClickHandler = this.view.setHandler((elem, event) => {
+      if (!this.view.S.cached('sending_options_container')[0].contains(event.relatedTarget)) {
+        sendingContainer.removeClass('popover-opened');
+        $('body').off('click', popoverClickHandler);
+        this.view.S.cached('toggle_send_options').off('keydown');
+      }
+    });
     if (sendingContainer.hasClass('popover-opened')) {
-      $('body').click(this.view.setHandler((elem, event) => {
-        if (!this.view.S.cached('sending_options_container')[0].contains(event.relatedTarget)) {
-          sendingContainer.removeClass('popover-opened');
-          $('body').off('click');
-          this.view.S.cached('toggle_send_options').off('keydown');
-        }
-      }));
+      $('body').on('click', popoverClickHandler);
       this.view.S.cached('toggle_send_options').on('keydown', this.view.setHandler(async (target, e) => this.keydownHandler(e)));
       const sendingOptions = this.view.S.cached('sending_options_container').find('.sending-option');
       sendingOptions.hover(function () {
@@ -97,7 +98,7 @@ export class ComposeSendBtnPopoverModule extends ViewModule<ComposeView> {
         $(this).addClass('active');
       });
     } else {
-      $('body').off('click');
+      $('body').off('click', popoverClickHandler);
       this.view.S.cached('toggle_send_options').off('keydown');
     }
   };

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -1213,12 +1213,11 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await ComposePageRecipe.pastePublicKeyManually(composeFrame, inboxPage, 'smime.attachment@recipient.com', testConstants.testCertificateMultipleSmimeCEA2D53BB9D24871);
       const fileInput = await composeFrame.target.$('input[type=file]');
       await fileInput!.uploadFile('test/samples/small.txt', 'test/samples/small.png', 'test/samples/small.pdf');
-      /* todo: #4087 attachments in composer can be downloaded
+      // attachments in composer can be downloaded
       const fileText = await inboxPage.awaitDownloadTriggeredByClicking(async () => {
         await composeFrame.click('.qq-file-id-0');
       });
       expect(fileText.toString()).to.equal(`small text file\nnot much here\nthis worked\n`);
-      */
       await composeFrame.waitAndClick('@action-send', { delay: 2 });
       await inboxPage.waitTillGone('@container-new-message');
     }));


### PR DESCRIPTION
This PR turns off only the handler for send btn popover, not all click handlers on body.

close #4087

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
