### PR TITLE
issue #4073 Better title for the 'Attach Pubkey' button

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-my-pubkey-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-my-pubkey-module.ts
@@ -76,9 +76,9 @@ export class ComposeMyPubkeyModule extends ViewModule<ComposeView> {
 
   private setAttachPreference = (includePubkey: boolean) => {
     if (includePubkey) {
-      this.view.S.cached('icon_pubkey').addClass('active').attr('title', Lang.compose.includePubkeyIconTitleActive);
+      this.view.S.cached('icon_pubkey').addClass('active');
     } else {
-      this.view.S.cached('icon_pubkey').removeClass('active').attr('title', Lang.compose.includePubkeyIconTitle);
+      this.view.S.cached('icon_pubkey').removeClass('active');
     }
   };
 

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -1853,6 +1853,7 @@ table#compose .bottom .icon {
   display: inline-block;
   border: 1px solid #f5f5f5;
   border-radius: 2px;
+  cursor: pointer;
   opacity: 0.35;
   background: none;
   vertical-align: middle;

--- a/extension/js/common/lang.ts
+++ b/extension/js/common/lang.ts
@@ -69,8 +69,7 @@ export const Lang = { // tslint:disable-line:variable-name
     msgEncryptedText: (lang: string, senderEmail: string) => (lang === 'DE') ? `${senderEmail} hat Ihnen eine passwortverschlüsselte E-Mail gesendet. Folgen Sie diesem Link, um es zu öffnen: ` : `${senderEmail} has sent you a password-encrypted email. Follow this link to open it: `,
     alternativelyCopyPaste: { EN: 'Alternatively copy and paste the following link: ', DE: 'Alternativ kopieren Sie folgenden Link und fügen ihn in die Adresszeile Ihres Browsers ein: ' },
     openMsg: { EN: 'Click here to Open Message', DE: 'Klicken Sie hier, um die Nachricht zu öffnen' },
-    includePubkeyIconTitle: 'Include your Public Key with this message.\n\nThis allows people using non-FlowCrypt encryption to reply to you.',
-    includePubkeyIconTitleActive: 'Your Public Key will be included with this message.\n\nThis allows people using non-FlowCrypt encryption to reply to you.',
+    includePubkeyIconTitle: 'Include your Public Key with this message.\n\nIf enabled, your Public Key will be included with this message.\n\nThis allows people using non-FlowCrypt encryption to reply to you.',
     headers: {
       encrypted: 'New Secure Message',
       encryptedAndSigned: 'New Signed Secure Message',


### PR DESCRIPTION
This PR makes the title for the 'Attach Pubkey' button a bit more detailed. Also, it adds the `cursor: pointer` to buttons to let users know that they are clickable.

<img width="274" alt="CleanShot 2021-12-06 at 14 20 54@2x" src="https://user-images.githubusercontent.com/6059356/144845339-b02bd55a-0df5-4c40-985d-d60fb1e307b8.png">

close #4073

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
