### PR TITLE
Fix injecting the Secure Compose button on the new Gmail look

### DIFF
--- a/extension/js/common/inject.ts
+++ b/extension/js/common/inject.ts
@@ -26,7 +26,7 @@ export class Injector {
   private S: SelCache;
   private container: { [key: string]: Host } = {
     composeBtnSel: {
-      'gmail': 'div.aeN',
+      'gmail': 'div.aeN, div.aBO', // .aeN for normal look, .aBO for new look https://github.com/FlowCrypt/flowcrypt-browser/issues/4099
       'outlook': 'div._fce_b',
       'settings': '#does_not_have',
     },
@@ -75,7 +75,14 @@ export class Injector {
     } else if (this.shouldInject()) {
       if (this.S.now('compose_button').length === 0) {
         const secureComposeButton = $(this.factory.btnCompose(this.webmailName));
-        const container = this.S.now('compose_button_container').first().prepend(secureComposeButton); // xss-safe-factory
+        let target = this.S.now('compose_button_container').first();
+        // gmail new look, https://github.com/FlowCrypt/flowcrypt-browser/issues/4099
+        if (this.webmailName === 'gmail') {
+          if (this.S.now('compose_button_container').find('div.aBO').length === 1) {
+            target = this.S.now('compose_button_container').find('div.aBO').first();
+          }
+        }
+        const container = target.prepend(secureComposeButton); // xss-safe-factory
         if (this.webmailName === 'gmail') {
           if (!$('.aic').length) { // https://github.com/FlowCrypt/flowcrypt-browser/issues/4063
             secureComposeButton.addClass('small');


### PR DESCRIPTION
This PR checks if the new Gmail look is enabled and if so the Secure Compose button will be injected into another `<div>`.

Here's the markup of the new Gmail look:

<img width="467" alt="CleanShot 2021-12-08 at 15 34 18@2x" src="https://user-images.githubusercontent.com/6059356/145221003-0dca4d5d-e01e-4c46-88a5-a4e9fdaa775e.png">

close #4099

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test, I'm still unable to turn on that new look for myself and I can't turn on this new look in the tests. The markup above is from the screensharing session with a customer.

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
