### PR TITLE
[firefox] prevent clickjacking in pages listed in web_accessible_resources

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -76,18 +76,7 @@
     "/img/svgs/spinner-white-small.svg",
     "/img/svgs/spinner-green-small.svg",
     "/img/svgs/unlock.svg",
-    "/img/logo/flowcrypt-logo-19-19.png",
-    "/chrome/elements/compose.htm",
-    "/chrome/elements/pgp_block.htm",
-    "/chrome/elements/setup_dialog.htm",
-    "/chrome/elements/attachment.htm",
-    "/chrome/elements/attachment_preview.htm",
-    "/chrome/elements/passphrase.htm",
-    "/chrome/elements/add_pubkey.htm",
-    "/chrome/elements/pgp_pubkey.htm",
-    "/chrome/elements/backup.htm",
-    "/chrome/elements/verification.htm",
-    "/chrome/elements/shared/footer.htm"
+    "/img/logo/flowcrypt-logo-19-19.png"
   ],
   "minimum_chrome_version": "61",
   "content_security_policy": "upgrade-insecure-requests; script-src 'self'; frame-ancestors https://mail.google.com 'self'; img-src 'self' https://*.googleusercontent.com data: blob:; frame-src 'self' blob:; worker-src 'self'; form-action 'none'; media-src 'none'; font-src 'none'; manifest-src 'none'; object-src 'none'; base-uri 'self'"


### PR DESCRIPTION
This PR will remove pages that shouldn't be accessible outside of the extension listed in web_accessible_resources inside of the manifest.json for firefox

Screenshot:
<img width="1440" alt="Screen Shot 2021-12-10 at 5 20 59 PM" src="https://user-images.githubusercontent.com/46025304/145549789-11750b13-1e0f-4eb9-a4ed-2684306f6d64.png">


close https://github.com/FlowCrypt/flowcrypt-security/issues/183

issue #0000 // if it doesn't close the issue yet

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests will be added later (issue #...)
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
