### PR TITLE
issue #4168 Do not show import warning for unusable keys

### DIFF
--- a/extension/chrome/elements/pgp_pubkey.htm
+++ b/extension/chrome/elements/pgp_pubkey.htm
@@ -22,7 +22,7 @@
       <input class="input_email" data-test="input-email" value="..." />
       <button class="button orange action_add_contact" data-test="action-add-contact"></button>
     </div>
-    <div class="mt-10 orange hide_if_compact" id="manual_import_warning">
+    <div class="mt-10 orange hide_if_compact" id="manual_import_warning" data-test="manual-import-warning">
       Manually importing Public Keys received over email can be dangerous. <br>
       Contact the sender to verify that the fingerprint matches.
     </div>

--- a/extension/chrome/elements/pgp_pubkey.htm
+++ b/extension/chrome/elements/pgp_pubkey.htm
@@ -22,7 +22,7 @@
       <input class="input_email" data-test="input-email" value="..." />
       <button class="button orange action_add_contact" data-test="action-add-contact"></button>
     </div>
-    <div class="mt-10 orange hide_if_compact">
+    <div class="mt-10 orange hide_if_compact" id="manual_import_warning">
       Manually importing Public Keys received over email can be dangerous. <br>
       Contact the sender to verify that the fingerprint matches.
     </div>

--- a/extension/chrome/elements/pgp_pubkey.ts
+++ b/extension/chrome/elements/pgp_pubkey.ts
@@ -133,7 +133,7 @@ View.run(class PgpPubkeyView extends View {
   };
 
   private showKeyNotUsableError = () => {
-    $('.fingerprints, .add_contact').remove();
+    $('.fingerprints, .add_contact, #manual_import_warning').remove();
     $('#pgp_block.pgp_pubkey .result')
       .prepend('<span class="bad">This OpenPGP key is not usable.</span>'); // xss-direct
     $('.pubkey').addClass('bad');

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -1344,7 +1344,6 @@ td {
 #pgp_block.pgp_pubkey .add_contact:not(.line) { text-align: center; }
 
 #pgp_block.pgp_pubkey pre.pubkey {
-  margin-top: 0;
   display: none;
 }
 

--- a/test/source/tests/settings.ts
+++ b/test/source/tests/settings.ts
@@ -196,6 +196,7 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
       await contactsFrame.waitAll('iframe');
       const pubkeyFrame = await contactsFrame.getFrame(['pgp_pubkey.htm']);
       await pubkeyFrame.notPresent('@action-add-contact');
+      await pubkeyFrame.notPresent('@manual-import-warning');
       expect((await pubkeyFrame.read('#pgp_block.pgp_pubkey')).toLowerCase()).to.include('not usable');
       const revocationAfter = await dbPage.page.evaluate(async () => {
         const db = await (window as any).ContactStore.dbOpen();


### PR DESCRIPTION
This PR hides the import warning for unusable keys.

close #4168

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
