### PR TITLE
Add support for Microsoft Outlook encrypted emails 

### DIFF
--- a/extension/js/common/core/attachment.ts
+++ b/extension/js/common/core/attachment.ts
@@ -120,6 +120,8 @@ export class Attachment {
       return 'publicKey';
     } else if (this.name.match(/\.asc$/) && this.length < 100000 && !this.inline) {
       return 'encryptedMsg';
+    } else if (this.name.match(/ATT[0-9]{5}$/) || this.type === 'application/pgp-encrypted') {
+      return 'encryptedMsg';
     } else {
       return 'plainFile';
     }


### PR DESCRIPTION
This PR will add support for ATTxxxxx emails from Microsoft Outlook and render them to Gmail and FlowCrypt email clients within the browser extension.

close https://github.com/FlowCrypt/flowcrypt-browser/issues/4086

issue #0000 // if it doesn't close the issue yet

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests will be added later (issue #...)
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
