### PR TITLE
extend searchable entries till the end of email/name

### DIFF
--- a/extension/js/background_page/background_page.ts
+++ b/extension/js/background_page/background_page.ts
@@ -9,7 +9,7 @@ import { Catch } from '../common/platform/catch.js';
 import { GoogleAuth } from '../common/api/email-provider/gmail/google-auth.js';
 import { VERSION } from '../common/core/const.js';
 import { injectFcIntoWebmail } from './inject.js';
-import { migrateGlobal, moveContactsToEmailsAndPubkeys, updateOpgpRevocations, updateX509FingerprintsAndLongids } from './migrations.js';
+import { extendSearchables, migrateGlobal, moveContactsToEmailsAndPubkeys, updateOpgpRevocations, updateX509FingerprintsAndLongids } from './migrations.js';
 import { opgp } from '../common/core/crypto/pgp/openpgpjs-custom.js';
 import { GlobalStoreDict, GlobalStore } from '../common/platform/store/global-store.js';
 import { ContactStore } from '../common/platform/store/contact-store.js';
@@ -46,6 +46,7 @@ opgp.initWorker({ path: '/lib/openpgp.worker.js' });
     db = await ContactStore.dbOpen(); // takes 4-10 ms first time
     await updateOpgpRevocations(db);
     await updateX509FingerprintsAndLongids(db);
+    await extendSearchables(db);
     await moveContactsToEmailsAndPubkeys(db);
   } catch (e) {
     await BgUtils.handleStoreErr(e);

--- a/extension/js/background_page/migrations.ts
+++ b/extension/js/background_page/migrations.ts
@@ -140,6 +140,31 @@ export const updateX509FingerprintsAndLongids = async (db: IDBDatabase): Promise
   console.info('done updating');
 };
 
+export const extendSearchables = async (db: IDBDatabase): Promise<void> => {
+  const globalStore = await GlobalStore.get(['contact_store_searchable_extended']);
+  if (globalStore.contact_store_searchable_extended) {
+    return;
+  }
+  console.info('updating ContactStorage to extend searchable values...');
+  const tx = db.transaction(['emails'], 'readwrite');
+  await new Promise((resolve, reject) => {
+    ContactStore.setTxHandlers(tx, resolve, reject);
+    const emailsStore = tx.objectStore('emails');
+    const search = emailsStore.openCursor();
+    ContactStore.setReqPipe(search,
+      (cursor: IDBCursorWithValue) => {
+        if (cursor) {
+          const email = cursor.value as Email;
+          ContactStore.updateSearchable(email);
+          cursor.update(email);
+          cursor.continue();
+        }
+      });
+  });
+  await GlobalStore.set({ contact_store_searchable_extended: true });
+  console.info('done updating');
+};
+
 export const updateOpgpRevocations = async (db: IDBDatabase): Promise<void> => {
   const globalStore = await GlobalStore.get(['contact_store_opgp_revoked_flags_updated']);
   if (globalStore.contact_store_opgp_revoked_flags_updated) {

--- a/extension/js/common/core/common.ts
+++ b/extension/js/common/core/common.ts
@@ -94,9 +94,10 @@ export class Str {
     return id;
   };
 
-  public static splitExtended = (str: string): string[] => {
+  // splits the string to matches,
+  // each match is extended till the end of the original string
+  public static splitExtended = (str: string, regexp: RegExp): string[] => {
     const result: string[] = [];
-    const regexp = /[a-z0-9]+/g;
     for (; ;) {
       const match = regexp.exec(str);
       if (match === null) {
@@ -105,6 +106,12 @@ export class Str {
       result.push(str.substring(match.index));
     }
     return result;
+  };
+
+  // splits the string to alphanumeric chunks,
+  // each chunk is extended till the end of the original string
+  public static splitAlphanumericExtended = (str: string): string[] => {
+    return Str.splitExtended(str, /[a-z0-9]+/g);
   };
 
   public static regexEscape = (toBeUsedInRegex: string) => {

--- a/extension/js/common/core/common.ts
+++ b/extension/js/common/core/common.ts
@@ -94,6 +94,19 @@ export class Str {
     return id;
   };
 
+  public static splitExtended = (str: string): string[] => {
+    const result: string[] = [];
+    const regexp = /[a-z0-9]+/g;
+    for (; ;) {
+      const match = regexp.exec(str);
+      if (match === null) {
+        break;
+      }
+      result.push(str.substring(match.index));
+    }
+    return result;
+  };
+
   public static regexEscape = (toBeUsedInRegex: string) => {
     return toBeUsedInRegex.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   };

--- a/extension/js/common/core/common.ts
+++ b/extension/js/common/core/common.ts
@@ -98,7 +98,7 @@ export class Str {
   // each match is extended till the end of the original string
   public static splitExtended = (str: string, regexp: RegExp): string[] => {
     const result: string[] = [];
-    for (; ;) {
+    while (true) {
       const match = regexp.exec(str);
       if (match === null) {
         break;

--- a/extension/js/common/platform/store/contact-store.ts
+++ b/extension/js/common/platform/store/contact-store.ts
@@ -669,7 +669,7 @@ export class ContactStore extends AbstractStore {
     const name = emailEntity.name ? emailEntity.name.toLowerCase() : '';
     // we only need the longest word if it starts with a shorter one,
     // e.g. we don't need "flowcrypt" if we have "flowcryptcompatibility"
-    const sortedNormalized = [...email.split(/[^a-z0-9]/), ...name.split(/[^a-z0-9]/)].filter(p => !!p)
+    const sortedNormalized = [...Str.splitExtended(email), ...Str.splitExtended(name)].filter(p => !!p)
       .map(ContactStore.normalizeString).sort((a, b) => b.length - a.length);
     emailEntity.searchable = sortedNormalized.filter((value, index, self) => !self.slice(0, index).find((el) => el.startsWith(value)))
       .map(normalized => ContactStore.dbIndex(emailEntity.fingerprints.length > 0, normalized));

--- a/extension/js/common/platform/store/contact-store.ts
+++ b/extension/js/common/platform/store/contact-store.ts
@@ -453,6 +453,17 @@ export class ContactStore extends AbstractStore {
     });
   };
 
+  public static updateSearchable = (emailEntity: Email) => {
+    const email = emailEntity.email.toLowerCase();
+    const name = emailEntity.name ? emailEntity.name.toLowerCase() : '';
+    // we only need the longest word if it starts with a shorter one,
+    // e.g. we don't need "flowcrypt" if we have "flowcryptcompatibility"
+    const sortedNormalized = [...Str.splitExtended(email), ...Str.splitExtended(name)].filter(p => !!p)
+      .map(ContactStore.normalizeString).sort((a, b) => b.length - a.length);
+    emailEntity.searchable = sortedNormalized.filter((value, index, self) => !self.slice(0, index).find((el) => el.startsWith(value)))
+      .map(normalized => ContactStore.dbIndex(emailEntity.fingerprints.length > 0, normalized));
+  };
+
   private static sortKeys = async (pubkeys: Pubkey[], revocations: Revocation[]): Promise<PubkeyInfo[]> => {
     // parse the keys
     const pubkeyInfos = await Promise.all(pubkeys.map(async (pubkey) => {
@@ -662,17 +673,6 @@ export class ContactStore extends AbstractStore {
     }
     const upperBound = lowerBound.substring(0, copyLength) + String.fromCharCode(lastChar + 1);
     return { lowerBound, upperBound };
-  };
-
-  private static updateSearchable = (emailEntity: Email) => {
-    const email = emailEntity.email.toLowerCase();
-    const name = emailEntity.name ? emailEntity.name.toLowerCase() : '';
-    // we only need the longest word if it starts with a shorter one,
-    // e.g. we don't need "flowcrypt" if we have "flowcryptcompatibility"
-    const sortedNormalized = [...Str.splitExtended(email), ...Str.splitExtended(name)].filter(p => !!p)
-      .map(ContactStore.normalizeString).sort((a, b) => b.length - a.length);
-    emailEntity.searchable = sortedNormalized.filter((value, index, self) => !self.slice(0, index).find((el) => el.startsWith(value)))
-      .map(normalized => ContactStore.dbIndex(emailEntity.fingerprints.length > 0, normalized));
   };
 
   private static dbContactInternalGetOne = async (db: IDBDatabase, email: string): Promise<Contact | undefined> => {

--- a/extension/js/common/platform/store/contact-store.ts
+++ b/extension/js/common/platform/store/contact-store.ts
@@ -458,7 +458,7 @@ export class ContactStore extends AbstractStore {
     const name = emailEntity.name ? emailEntity.name.toLowerCase() : '';
     // we only need the longest word if it starts with a shorter one,
     // e.g. we don't need "flowcrypt" if we have "flowcryptcompatibility"
-    const sortedNormalized = [...Str.splitExtended(email), ...Str.splitExtended(name)].filter(p => !!p)
+    const sortedNormalized = [...Str.splitAlphanumericExtended(email), ...Str.splitAlphanumericExtended(name)].filter(p => !!p)
       .map(ContactStore.normalizeString).sort((a, b) => b.length - a.length);
     emailEntity.searchable = sortedNormalized.filter((value, index, self) => !self.slice(0, index).find((el) => el.startsWith(value)))
       .map(normalized => ContactStore.dbIndex(emailEntity.fingerprints.length > 0, normalized));

--- a/extension/js/common/platform/store/global-store.ts
+++ b/extension/js/common/platform/store/global-store.ts
@@ -22,13 +22,14 @@ export type GlobalStoreDict = {
   key_info_store_fingerprints_added?: boolean;
   contact_store_x509_fingerprints_and_longids_updated?: boolean;
   contact_store_opgp_revoked_flags_updated?: boolean;
+  contact_store_searchable_extended?: boolean;
   local_drafts?: Dict<LocalDraft>;
 };
 
 export type GlobalIndex = 'version' | 'account_emails' | 'settings_seen' | 'hide_pass_phrases' |
   'dev_outlook_allow' | 'install_mobile_app_notification_dismissed' | 'key_info_store_fingerprints_added' |
   'contact_store_x509_fingerprints_and_longids_updated' | 'contact_store_opgp_revoked_flags_updated' |
-  'local_drafts';
+  'contact_store_searchable_extended' | 'local_drafts';
 
 /**
  * Locally stored data that is not associated with any email account

--- a/test/source/tests/browser-unit-tests/unit-ContactStore.js
+++ b/test/source/tests/browser-unit-tests/unit-ContactStore.js
@@ -103,17 +103,16 @@ BROWSER_UNIT_TEST_NAME(`ContactStore is able to search by a chunk spanning acros
 BROWSER_UNIT_TEST_NAME(`ContactStore doesn't store duplicates in searchable`);
 (async () => {
   const db = await ContactStore.dbOpen();
-  const contact = await ContactStore.obj({
-    email: 'this.word.this.word@this.word.this.word', name: 'This Word THIS WORD this word'
-  });
-  await ContactStore.save(db, contact);
+  const email = 'at@this.word';
+  await ContactStore.update(db, email, { name: 'This.Word' });
   // extract the entity from the database to see the actual field
   const entity = await new Promise((resolve, reject) => {
-    const req = db.transaction(['emails'], 'readonly').objectStore('emails').get(contact.email);
+    const req = db.transaction(['emails'], 'readonly').objectStore('emails').get(email);
     ContactStore.setReqPipe(req, resolve, reject);
   });
-  if (entity?.searchable.length !== 2) {
-    throw Error(`Expected 2 entries in 'searchable' but got "${entity?.searchable}"`);
+  if (entity?.searchable.length !== 3 || !entity.searchable.includes('f:at@this.word')
+    || !entity.searchable.includes('f:this.word') || !entity.searchable.includes('f:word')) {
+    throw Error(`Expected ["at@this.word", "this.word", "word"] entries in 'searchable' but got "${entity?.searchable}"`);
   }
   return 'pass';
 })();
@@ -121,18 +120,16 @@ BROWSER_UNIT_TEST_NAME(`ContactStore doesn't store duplicates in searchable`);
 BROWSER_UNIT_TEST_NAME(`ContactStore doesn't store smaller words in searchable when there is a bigger one that starts with it`);
 (async () => {
   const db = await ContactStore.dbOpen();
-  const contact = await ContactStore.obj({
-    email: 'a@big.one', name: 'Bigger'
-  });
-  await ContactStore.save(db, contact);
+  const email = 'com@big.com';
+  await ContactStore.update(db, email, { name: 'Commander' });
   // extract the entity from the database to see the actual field
   const entity = await new Promise((resolve, reject) => {
-    const req = db.transaction(['emails'], 'readonly').objectStore('emails').get(contact.email);
+    const req = db.transaction(['emails'], 'readonly').objectStore('emails').get(email);
     ContactStore.setReqPipe(req, resolve, reject);
   });
-  if (entity?.searchable.length !== 3 || !entity.searchable.includes('f:a')
-    || !entity.searchable.includes('f:bigger') || !entity.searchable.includes('f:one')) {
-    throw Error(`Expected "a bigger one" entries in 'searchable' but got "${entity?.searchable}"`);
+  if (entity?.searchable.length !== 3 || !entity.searchable.includes('f:com@big.com')
+    || !entity.searchable.includes('f:big.com') || !entity.searchable.includes('f:commander')) {
+    throw Error(`Expected ["com@big.com", "big.com", "commander"] in 'searchable' but got "${entity?.searchable}"`);
   }
   return 'pass';
 })();

--- a/test/source/tests/unit-node.ts
+++ b/test/source/tests/unit-node.ts
@@ -22,6 +22,7 @@ import { ExpirationCache } from '../core/expiration-cache';
 import { readFileSync } from 'fs';
 import * as forge from 'node-forge';
 import { ENVELOPED_DATA_OID, SmimeKey } from '../core/crypto/smime/smime-key';
+import { Str } from '../core/common';
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -2168,5 +2169,9 @@ AAAAAAAAAAAAAAAAzzzzzzzzzzzzzzzzzzzzzzzzzzzz.....`)).to.eventually.be.rejectedWi
       t.pass();
     });
 
+    ava.default(`[unit][Str] splitExtended returns all parts extendec till the end of the original string`, async t => {
+      expect(Str.splitExtended('part1.part2@part3.part4')).to.eql(['part1.part2@part3.part4', 'part2@part3.part4', 'part3.part4', 'part4']);
+      t.pass();
+    });
   }
 };

--- a/test/source/tests/unit-node.ts
+++ b/test/source/tests/unit-node.ts
@@ -2169,8 +2169,8 @@ AAAAAAAAAAAAAAAAzzzzzzzzzzzzzzzzzzzzzzzzzzzz.....`)).to.eventually.be.rejectedWi
       t.pass();
     });
 
-    ava.default(`[unit][Str] splitExtended returns all parts extendec till the end of the original string`, async t => {
-      expect(Str.splitExtended('part1.part2@part3.part4')).to.eql(['part1.part2@part3.part4', 'part2@part3.part4', 'part3.part4', 'part4']);
+    ava.default(`[unit][Str] splitAlphanumericExtended returns all parts extendec till the end of the original string`, async t => {
+      expect(Str.splitAlphanumericExtended('part1.part2@part3.part4')).to.eql(['part1.part2@part3.part4', 'part2@part3.part4', 'part3.part4', 'part4']);
       t.pass();
     });
   }


### PR DESCRIPTION
This PR extends each entry in searchable till the end of the original full string,
making it possible to search whole emails etc.

close #3735 

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
