### PR TITLE
Remove 'Download all attachments' and 'Add all to Drive' buttons for encrypted messages

### DIFF
--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -67,6 +67,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
     standardComposeRecipient: 'div.az9 span[email][data-hovercard-id]',
     numberOfAttachments: '.aVW',
     numberOfAttachmentsDigit: '.aVW span',
+    attachmentsButtons: '.aZi',
     draftsList: '.ae4',
   };
 
@@ -372,6 +373,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
     let msgEl = this.getMsgBodyEl(msgId); // not a constant because sometimes elements get replaced, then returned by the function that replaced them
     const senderEmail = this.getSenderEmail(msgEl);
     const isOutgoing = !!this.sendAs[senderEmail];
+    $(this.sel.attachmentsButtons).hide();
     attachmentsContainerInner = $(attachmentsContainerInner);
     attachmentsContainerInner.parent().find(this.sel.numberOfAttachments).hide();
     let nRenderedAttachments = attachmentMetas.length;


### PR DESCRIPTION
This PR hides 'Download all attachments' and 'Add all to Drive' buttons for encrypted messages:

![CleanShot 2021-12-28 at 11 08 59@2x](https://user-images.githubusercontent.com/6059356/147549553-20ff63d6-a7ca-424b-b38b-b3ee7ba31bad.png)

drive: no point storing encrypted attachments to drive - not readable
download all: no point getting a zip of encrypted files

close #4200

----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
