### PR TITLE
Show badge on pgp block's renderErr

### DIFF
--- a/extension/chrome/elements/pgp_block_modules/pgp-block-decrypt-module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp-block-decrypt-module.ts
@@ -36,7 +36,8 @@ export class PgpBlockViewDecryptModule {
           this.view.signature.parsedSignature = parsed.signature;
           await this.decryptAndRender(Buf.fromUtfStr(parsed.rawSignedContent), verificationPubs);
         } else {
-          await this.view.errorModule.renderErr('Error: could not properly parse signed message', parsed.rawSignedContent || parsed.text || parsed.html || mimeMsg.toUtfStr());
+          await this.view.errorModule.renderErr('Error: could not properly parse signed message',
+            parsed.rawSignedContent || parsed.text || parsed.html || mimeMsg.toUtfStr(), true);
         }
       } else if (this.view.encryptedMsgUrlParam && !forcePullMsgFromApi) { // ascii armored message supplied
         this.view.renderModule.renderText(this.view.signature ? 'Verifying..' : 'Decrypting...');

--- a/extension/chrome/elements/pgp_block_modules/pgp-block-error-module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp-block-error-module.ts
@@ -17,8 +17,13 @@ export class PgpBlockViewErrorModule {
   constructor(private view: PgpBlockView) {
   }
 
-  public renderErr = async (errBoxContent: string, renderRawMsg: string | undefined) => {
+  public renderErr = async (errBoxContent: string, renderRawMsg: string | undefined, isParseError = false) => {
     this.view.renderModule.setFrameColor('red');
+    if (isParseError) {
+      this.view.renderModule.renderSignatureStatus('parse error');
+    } else {
+      this.view.renderModule.renderEncryptionStatus('decrypt error');
+    }
     const showRawMsgPrompt = renderRawMsg ? '<a href="#" class="action_show_raw_pgp_block">show original message</a>' : '';
     await this.view.renderModule.renderContent(`<div class="error">${errBoxContent.replace(/\n/g, '<br>')}</div>${showRawMsgPrompt}`, true);
     $('.action_show_raw_pgp_block').click(this.view.setHandler(async () => { // this may contain content missing MDC

--- a/test/source/mock/google/exported-messages/corrupted-1.json
+++ b/test/source/mock/google/exported-messages/corrupted-1.json
@@ -1,0 +1,18 @@
+{
+  "acctEmail": "flowcrypt.compatibility@gmail.com",
+  "full": {
+    "id": "corrupted-1",
+    "threadId": "corrupted-1",
+    "historyId": "corrupted-1"
+  },
+  "raw": {
+    "id": "corrupted-1",
+    "threadId": "corrupted-1",
+    "labelIds": [
+      "INBOX"
+    ],
+    "sizeEstimate": 2,
+    "raw": "RSo",
+    "historyId": "corrupted-1"
+  }
+}

--- a/test/source/mock/google/google-data.ts
+++ b/test/source/mock/google/google-data.ts
@@ -154,8 +154,10 @@ export class GoogleData {
       msgCopy.raw = undefined;
     }
     if (format === 'metadata' || format === 'raw') {
-      msgCopy.payload!.body = undefined;
-      msgCopy.payload!.parts = undefined;
+      if (msgCopy.payload) {
+        msgCopy.payload.body = undefined;
+        msgCopy.payload.parts = undefined;
+      }
     }
     return msgCopy;
   };

--- a/test/source/tests/decrypt.ts
+++ b/test/source/tests/decrypt.ts
@@ -686,10 +686,10 @@ XZ8r4OC6sguP/yozWlkG+7dDxsgKQVBENeG6Lw==
     }));
 
     ava.default('decrypt - wrong message - checksum throws error', testWithBrowser('compatibility', async (t, browser) => {
-      const acctEmail = 'flowcrypt.compatibility@gmail.com';
       const threadId = '15f7ffb9320bd79e';
       const expectedContent = 'Ascii armor integrity check on message failed';
-      await InboxPageRecipe.checkDecryptMsg(t, browser, { acctEmail, threadId, expectedContent });
+      const params = `?frame_id=&threadId=${threadId}&msgId=${threadId}&senderEmail=&account_email=flowcrypt.compatibility%40gmail.com`;
+      await BrowserRecipe.pgpBlockVerifyDecryptedContent(t, browser, { params, content: [expectedContent], encryption: 'decrypt error', signature: '' });
     }));
 
     ava.default('decrypt - inbox - encrypted message inside signed', testWithBrowser('compatibility', async (t, browser) => {
@@ -733,6 +733,11 @@ XZ8r4OC6sguP/yozWlkG+7dDxsgKQVBENeG6Lw==
       const pgpBlockPage = await pgpHostPage.getFrame(['pgp_block.htm']);
       await pgpBlockPage.waitForSelTestState('ready', 5);
       await pgpBlockPage.waitForContent('@container-err-text', 'API path traversal forbidden');
+    }));
+
+    ava.default(`decrypt - signed only - parse error in a badge`, testWithBrowser('compatibility', async (t, browser) => {
+      const params = "?frame_id=&msgId=corrupted-1&signature=___cu_true___&senderEmail=&account_email=flowcrypt.compatibility%40gmail.com";
+      await BrowserRecipe.pgpBlockVerifyDecryptedContent(t, browser, { params, content: [], encryption: '', signature: 'parse error' });
     }));
 
     ava.default(`decrypt - try path traversal forward slash workaround`, testWithBrowser('compatibility', async (t, browser) => {


### PR DESCRIPTION
This PR adds a red badge when `renderErr` is called.
I figured, in the case when a signed-only message parse error occurs, it'd be more appropriate to display "parse error" than "decrypt error"

close #4211 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
