### PR TITLE
Issue 4239 fix HTML Injection

### DIFF
--- a/extension/chrome/elements/pgp_block_modules/pgp-block-render-module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp-block-render-module.ts
@@ -174,7 +174,7 @@ export class PgpBlockViewRenderModule {
   private getEncryptedSubjectText = (subject: string, isHtml: boolean) => {
     if (isHtml) {
       return `<div style="white-space: normal"> Encrypted Subject:
-                <b> ${subject}</b>
+                <b> ${Xss.escape(subject)}</b>
               </div>
               <hr/>`;
     } else {


### PR DESCRIPTION
This PR will fix HTML injection in the subject name when rendering a rich-text document and will escape only the subject name where we shouldn't expect HTML tags.

close #4239 // if this PR closes an issue

issue #0000 // if it doesn't close the issue yet

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests will be added later (issue #...)
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
