### PR TITLE
added signerFingerprints to VerifyRes

### DIFF
--- a/extension/js/common/core/buf.ts
+++ b/extension/js/common/core/buf.ts
@@ -170,6 +170,14 @@ export class Buf extends Uint8Array {
     return chars.join('');
   };
 
+  public toHexStr = (): string => {
+    const chars: string[] = [];
+    for (const v of this.values()) {
+      chars.push((('00' + v.toString(16)).slice(-2)).toUpperCase());
+    }
+    return chars.join('');
+  };
+
   public toBase64Str = (): string => {
     return base64encode(this.toRawBytesStr());
   };

--- a/extension/js/common/core/crypto/pgp/msg-util.ts
+++ b/extension/js/common/core/crypto/pgp/msg-util.ts
@@ -62,6 +62,7 @@ export type DecryptError = { success: false; error: DecryptError$error; longids:
 
 export type VerifyRes = {
   signerLongids: string[]; // signers longids from the message
+  signerFingerprints: string[]; // "issuerFingerprints" from signature subpackets
   suppliedLongids: string[]; // longids from keys supplied to verify the message
   match: boolean | null; // we can return some pubkey information here
   error?: string;

--- a/test/source/tests/unit-node.ts
+++ b/test/source/tests/unit-node.ts
@@ -2173,5 +2173,17 @@ AAAAAAAAAAAAAAAAzzzzzzzzzzzzzzzzzzzzzzzzzzzz.....`)).to.eventually.be.rejectedWi
       expect(Str.splitAlphanumericExtended('part1.part2@part3.part4')).to.eql(['part1.part2@part3.part4', 'part2@part3.part4', 'part3.part4', 'part4']);
       t.pass();
     });
+
+    ava.default(`[unit][MsgUtil.verifyDetached] VerifyRes contains signer fingerprints`, async t => {
+      const prv = await KeyUtil.parse(rsaPrimaryKeyAndSubkeyBothHavePrivateKey);
+      await KeyUtil.decrypt(prv, '1234');
+      const plaintext = 'data to sign';
+      const sigText = await MsgUtil.sign(prv, plaintext, true);
+      const verifyRes = await MsgUtil.verifyDetached({ plaintext: Buf.fromRawBytesStr(plaintext), sigText: Buf.fromRawBytesStr(sigText), verificationPubs: [] });
+      expect(verifyRes.signerFingerprints.length).to.equal(1);
+      expect(verifyRes.signerFingerprints[0]).to.equal(prv.id);
+      t.pass();
+    });
+
   }
 };


### PR DESCRIPTION
This PR extracts signer fingerprints from signature subpackets to `VerifyRes`

close #3873

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
