### PR TITLE
simple attachments preserve 'download all' button

### DIFF
--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -373,7 +373,6 @@ export class GmailElementReplacer implements WebmailElementReplacer {
     let msgEl = this.getMsgBodyEl(msgId); // not a constant because sometimes elements get replaced, then returned by the function that replaced them
     const senderEmail = this.getSenderEmail(msgEl);
     const isOutgoing = !!this.sendAs[senderEmail];
-    $(this.sel.attachmentsButtons).hide();
     attachmentsContainerInner = $(attachmentsContainerInner);
     attachmentsContainerInner.parent().find(this.sel.numberOfAttachments).hide();
     let nRenderedAttachments = attachmentMetas.length;
@@ -523,6 +522,8 @@ export class GmailElementReplacer implements WebmailElementReplacer {
     if (!attachmentEl.length) {
       attachmentsContainerSel.children('.attachment_loader').text('Missing file info');
     }
+    // according to #4200, no point in showing "download all" button if at least one attachment is encrypted etc.
+    $(this.sel.attachmentsButtons).hide();
   };
 
   private determineMsgId = (innerMsgEl: HTMLElement | JQueryEl) => {

--- a/test/source/mock/google/live-gmail-test-emails/[ci.test] simple attachments trigger processAttachments (KtbxLvHkSWwbVHxgCbWNvXVKGjFgqMbGQq).eml
+++ b/test/source/mock/google/live-gmail-test-emails/[ci.test] simple attachments trigger processAttachments (KtbxLvHkSWwbVHxgCbWNvXVKGjFgqMbGQq).eml
@@ -1,0 +1,47 @@
+MIME-Version: 1.0
+Date: Sun, 16 Jan 2022 12:20:24 +0300
+Message-ID: <CAO9FY9tbmHk7cgZ5p2h8UfenX_fKtEaFMBamXFnpbCMbokwFAg@mail.gmail.com>
+Subject: simple attachments trigger processAttachments
+From: Gmail CI Test <ci.tests.gmail@flowcrypt.dev>
+To: Gmail CI Test <ci.tests.gmail@flowcrypt.dev>
+Content-Type: multipart/mixed; boundary="000000000000c645cf05d5af8b3b"
+
+--000000000000c645cf05d5af8b3b
+Content-Type: multipart/alternative; boundary="000000000000c645cc05d5af8b39"
+
+--000000000000c645cc05d5af8b39
+Content-Type: text/plain; charset="UTF-8"
+
+test
+
+--000000000000c645cc05d5af8b39
+Content-Type: text/html; charset="UTF-8"
+
+<div dir="ltr">test</div>
+
+--000000000000c645cc05d5af8b39--
+--000000000000c645cf05d5af8b3b
+Content-Type: text/plain; charset="US-ASCII"; name="attachment1.txt"
+Content-Disposition: attachment; filename="attachment1.txt"
+Content-Transfer-Encoding: base64
+X-Attachment-Id: f_kyh1s3k81
+Content-ID: <f_kyh1s3k81>
+
+YXR0YWNobWVudDE=
+--000000000000c645cf05d5af8b3b
+Content-Type: application/octet-stream; name=ATT00001
+Content-Disposition: attachment; filename=ATT00001
+Content-Transfer-Encoding: base64
+X-Attachment-Id: f_kyh1s3jy0
+Content-ID: <f_kyh1s3jy0>
+
+dGhlcmUgaXMgc29tZSB0ZXh0IGhlcmU=
+--000000000000c645cf05d5af8b3b
+Content-Type: text/plain; charset="US-ASCII"; name="attachment2.txt"
+Content-Disposition: attachment; filename="attachment2.txt"
+Content-Transfer-Encoding: base64
+X-Attachment-Id: f_kyh1s3ke2
+Content-ID: <f_kyh1s3ke2>
+
+YXR0YWNobWVudDI=
+--000000000000c645cf05d5af8b3b--

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -370,6 +370,16 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       await Util.sleep(5);
       await gmailPage.waitAll('iframe');
       expect(await gmailPage.isElementPresent('@container-attachments')).to.equal(false);
+      await gmailPage.waitAll(['.aZi'], { visible: false });
+      await gmailPage.close();
+    }));
+
+    ava.default(`mail.google.com - simple attachments triggering processAttachments() keep "download all" button visible`, testWithBrowser('ci.tests.gmail', async (t, browser) => {
+      const gmailPage = await openGmailPage(t, browser);
+      await gotoGmailPage(gmailPage, '/KtbxLvHkSWwbVHxgCbWNvXVKGjFgqMbGQq');
+      await Util.sleep(5);
+      await gmailPage.waitAll('iframe');
+      await gmailPage.waitAll(['.aZi'], { visible: true });
       await gmailPage.close();
     }));
 


### PR DESCRIPTION
This PR only hides "download all" or "save to Google Drive" buttons when at least one attachment is recognized as encrypted (or in any other way special to OpenPGP)

close #4247

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
