### PR TITLE
Bounce broadcast messages back to tab in Firefox

### DIFF
--- a/extension/js/common/browser/browser-msg.ts
+++ b/extension/js/common/browser/browser-msg.ts
@@ -312,6 +312,11 @@ export class BrowserMsg {
       try {
         // console.debug(`bgListen: ${msg.name} from ${sender.tab?.id}:${sender.tab?.index} to ${msg.to}`);
         if (BrowserMsg.shouldRelayMsgToOtherPage(sender, msg.to)) { // message that has to be relayed through bg
+          if (msg.to === 'broadcast' && sender.tab?.id) {
+            // bounce the broadcast message back to the sender tab to make it reach all the frames (in Firefox), fixes #4072
+            chrome.tabs.sendMessage(sender.tab.id, msg);
+            return true;
+          }
           const { tab, frame } = BrowserMsg.browserMsgDestParse(msg.to);
           if (!tab) {
             BrowserMsg.sendRawResponse(Promise.reject(new Error(`BrowserMsg.bgListen:${msg.name}:cannot parse destination tab in ${msg.to}`)), respondIfPageStillOpen);


### PR DESCRIPTION
This PR makes the background page bounce incoming broadcast messages back to the sender tab, thus allowing propagation to all its frames in Firefox

close #4072

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test (need Firefox)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
