### PR TITLE
rephrase error badge when pass phrase is needed

### DIFF
--- a/extension/chrome/elements/pgp_block_modules/pgp-block-decrypt-module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp-block-decrypt-module.ts
@@ -37,7 +37,7 @@ export class PgpBlockViewDecryptModule {
           await this.decryptAndRender(Buf.fromUtfStr(parsed.rawSignedContent), verificationPubs);
         } else {
           await this.view.errorModule.renderErr('Error: could not properly parse signed message',
-            parsed.rawSignedContent || parsed.text || parsed.html || mimeMsg.toUtfStr(), true);
+            parsed.rawSignedContent || parsed.text || parsed.html || mimeMsg.toUtfStr(), 'parse error');
         }
       } else if (this.view.encryptedMsgUrlParam && !forcePullMsgFromApi) { // ascii armored message supplied
         this.view.renderModule.renderText(this.view.signature ? 'Verifying..' : 'Decrypting...');
@@ -91,7 +91,7 @@ export class PgpBlockViewDecryptModule {
         }
       } else if (result.longids.needPassphrase.length) {
         const enterPp = `<a href="#" class="enter_passphrase" data-test="action-show-passphrase-dialog">${Lang.pgpBlock.enterPassphrase}</a> ${Lang.pgpBlock.toOpenMsg}`;
-        await this.view.errorModule.renderErr(enterPp, undefined);
+        await this.view.errorModule.renderErr(enterPp, undefined, 'pass phrase needed');
         $('.enter_passphrase').click(this.view.setHandler(() => {
           Ui.setTestState('waiting');
           BrowserMsg.send.passphraseDialog(this.view.parentTabId, { type: 'message', longids: result.longids.needPassphrase });

--- a/extension/chrome/elements/pgp_block_modules/pgp-block-error-module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp-block-error-module.ts
@@ -17,13 +17,9 @@ export class PgpBlockViewErrorModule {
   constructor(private view: PgpBlockView) {
   }
 
-  public renderErr = async (errBoxContent: string, renderRawMsg: string | undefined, isParseError = false) => {
+  public renderErr = async (errBoxContent: string, renderRawMsg: string | undefined, errMsg?: string) => {
     this.view.renderModule.setFrameColor('red');
-    if (isParseError) {
-      this.view.renderModule.renderErrorStatus('parse error');
-    } else {
-      this.view.renderModule.renderErrorStatus('decrypt error');
-    }
+    this.view.renderModule.renderErrorStatus(errMsg || 'decrypt error');
     const showRawMsgPrompt = renderRawMsg ? '<a href="#" class="action_show_raw_pgp_block">show original message</a>' : '';
     await this.view.renderModule.renderContent(`<div class="error">${errBoxContent.replace(/\n/g, '<br>')}</div>${showRawMsgPrompt}`, true);
     $('.action_show_raw_pgp_block').click(this.view.setHandler(async () => { // this may contain content missing MDC

--- a/test/source/tests/page-recipe/inbox-page-recipe.ts
+++ b/test/source/tests/page-recipe/inbox-page-recipe.ts
@@ -29,6 +29,8 @@ export class InboxPageRecipe extends PageRecipe {
     await pgpBlockFrame.waitForSelTestState('ready');
     if (enterPp) {
       await inboxPage.notPresent("@action-finish-session");
+      const errBadgeContent = await pgpBlockFrame.read('@pgp-error');
+      expect(errBadgeContent).to.equal('pass phrase needed');
       await pgpBlockFrame.waitAndClick('@action-show-passphrase-dialog', { delay: 1 });
       await inboxPage.waitAll('@dialog-passphrase');
       const ppFrame = await inboxPage.getFrame(['passphrase.htm']);
@@ -44,6 +46,7 @@ export class InboxPageRecipe extends PageRecipe {
       await inboxPage.waitAll('@action-finish-session');
       await Util.sleep(1);
     }
+    await pgpBlockFrame.waitAll('@pgp-error', { visible: false });
     const content = await pgpBlockFrame.read('@pgp-block-content');
     if (content.indexOf(expectedContent) === -1) {
       throw new Error(`message did not decrypt`);


### PR DESCRIPTION
This PR displays "pass phrase needed" badge in the pgp_block when the message wasn't decrypted because of missing pass phrase

close #4266

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
