### PR TITLE
use window.create type from popup to normal window

### DIFF
--- a/extension/js/common/api/email-provider/gmail/google-auth.ts
+++ b/extension/js/common/api/email-provider/gmail/google-auth.ts
@@ -128,7 +128,7 @@ export class GoogleAuth {
     }
     const authRequest: AuthReq = { acctEmail, scopes, csrfToken: `csrf-${Api.randomFortyHexChars()}` };
     const url = GoogleAuth.apiGoogleAuthCodeUrl(authRequest);
-    const oauthWin = await windowsCreate({ url, left: 100, top: 50, height: 800, width: 550, type: 'popup' });
+    const oauthWin = await windowsCreate({ url, left: 100, top: 50, height: 800, width: 550, type: 'normal' });
     if (!oauthWin || !oauthWin.tabs || !oauthWin.tabs.length || !oauthWin.id) {
       return { result: 'Error', error: 'No oauth window returned after initiating it', acctEmail, id_token: undefined };
     }


### PR DESCRIPTION
This PR updates the window.create parameter window type from 'popup' to 'normal'. 

This will make the address bar from the Oauth consent popup visible.

<img width="932" alt="Screen Shot 2022-02-10 at 12 36 49 PM" src="https://user-images.githubusercontent.com/46025304/153338253-88b483ae-9df3-4425-8bf5-9bc3ce1ee545.png">

<img width="943" alt="Screen Shot 2022-02-10 at 1 00 31 PM" src="https://user-images.githubusercontent.com/46025304/153340572-57b5fc0b-1170-4760-88c0-e42d519c7939.png">

close https://github.com/FlowCrypt/flowcrypt-browser/issues/4279 // if this PR closes an issue

issue #0000 // if it doesn't close the issue yet

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests will be added later (issue #...)
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
