### PR TITLE
issue 4315 remove account file export

### DIFF
--- a/extension/chrome/settings/modules/experimental.htm
+++ b/extension/chrome/settings/modules/experimental.htm
@@ -23,7 +23,6 @@
     <div class="line">These things were not properly tested. They may not work at all and are not user friendly.</div>
     <div class="line"><a href="#" class="action_open_compatibility">Test OpenPGP Key Compatibility</a></div>
     <div class="line"><a href="#" class="action_open_decrypt">Manually decrypt encrypted files</a></div>
-    <div class="line"><a href="#" class="action_backup">Back up account information into a file</a></div>
   </div>
   <div class="line">&nbsp;</div>
   <!--<div class="line"><input type="checkbox" class="action_allow_outlook" id="aao"> <label for="aao">Allow Outlook (no attachments yet)</label></div>-->

--- a/extension/chrome/settings/modules/experimental.ts
+++ b/extension/chrome/settings/modules/experimental.ts
@@ -42,7 +42,6 @@ View.run(class ExperimentalView extends View {
   public setHandlers = () => {
     $('.action_open_compatibility').click(this.setHandler(() => Settings.redirectSubPage(this.acctEmail, this.parentTabId, '/chrome/settings/modules/compatibility.htm')));
     $('.action_open_decrypt').click(this.setHandler(() => Settings.redirectSubPage(this.acctEmail, this.parentTabId, '/chrome/settings/modules/decrypt.htm')));
-    $('.action_backup').click(this.setHandler((el, e) => { e.preventDefault(); Settings.collectInfoAndDownloadBackupFile(this.acctEmail).catch(Catch.reportErr); }));
     $('.action_throw_unchecked').click((e) => { e.preventDefault(); Catch.test('error'); });
     $('.action_throw_err').click(this.setHandler((el, e) => { e.preventDefault(); Catch.test('error'); }));
     $('.action_throw_obj').click(this.setHandler((el, e) => { e.preventDefault(); Catch.test('object'); }));


### PR DESCRIPTION
This PR removes an option to backup account information from experimental settings.

close #4315

----------------------------------

**Tests** :
- removing untested functionality

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
