### PR TITLE
issue #3905 Refactor to use ContactStore.getOneWithAllPubkeys() instead of .get() 

### DIFF
--- a/extension/chrome/elements/add_pubkey.ts
+++ b/extension/chrome/elements/add_pubkey.ts
@@ -78,9 +78,8 @@ View.run(class AddPubkeyView extends View {
 
   private copyFromEmailHandler = async (fromSelect: HTMLElement) => {
     if ($(fromSelect).val()) {
-      const contactWithPubKeys = await ContactStore.getOneWithAllPubkeys(
-        undefined, String($(fromSelect).val()));
-      if (contactWithPubKeys && contactWithPubKeys.sortedPubkeys && contactWithPubKeys.sortedPubkeys.length > 0) {
+      const pubkeys = (await ContactStore.getEncryptionKeys(undefined, [String($(fromSelect).val())]))[0].keys;
+      if (pubkeys.length > 0) {
         $('.pubkey').val('').prop('disabled', true).prop('style', 'display: none;');
         $('#manual-import-warning').prop('style', 'display: none;');
       } else {

--- a/extension/chrome/elements/add_pubkey.ts
+++ b/extension/chrome/elements/add_pubkey.ts
@@ -78,8 +78,9 @@ View.run(class AddPubkeyView extends View {
 
   private copyFromEmailHandler = async (fromSelect: HTMLElement) => {
     if ($(fromSelect).val()) {
-      const [contact] = await ContactStore.get(undefined, [String($(fromSelect).val())]);
-      if (contact?.pubkey) {
+      const contactWithPubKeys = await ContactStore.getOneWithAllPubkeys(
+        undefined, String($(fromSelect).val()));
+      if (contactWithPubKeys && contactWithPubKeys.sortedPubkeys && contactWithPubKeys.sortedPubkeys.length > 0) {
         $('.pubkey').val('').prop('disabled', true).prop('style', 'display: none;');
         $('#manual-import-warning').prop('style', 'display: none;');
       } else {

--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -461,8 +461,8 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
     this.addedPubkeyDbLookupInterval = Catch.setHandledInterval(async () => {
       const recipientsHasPgp: ValidRecipientElement[] = [];
       for (const recipient of noPgpRecipients) {
-        const [contact] = await ContactStore.get(undefined, [recipient.email]);
-        if (contact && contact.hasPgp) {
+        const contactWithPubKeys = await ContactStore.getOneWithAllPubkeys(undefined, recipient.email);
+        if (contactWithPubKeys && contactWithPubKeys.sortedPubkeys && contactWithPubKeys.sortedPubkeys.length > 0) {
           $(recipient.element).removeClass('no_pgp').find('i').remove();
           clearInterval(this.addedPubkeyDbLookupInterval);
           recipientsHasPgp.push(recipient);

--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -461,8 +461,8 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
     this.addedPubkeyDbLookupInterval = Catch.setHandledInterval(async () => {
       const recipientsHasPgp: ValidRecipientElement[] = [];
       for (const recipient of noPgpRecipients) {
-        const contactWithPubKeys = await ContactStore.getOneWithAllPubkeys(undefined, recipient.email);
-        if (contactWithPubKeys && contactWithPubKeys.sortedPubkeys && contactWithPubKeys.sortedPubkeys.length > 0) {
+        const pubkeys = (await ContactStore.getEncryptionKeys(undefined, [recipient.email]))[0].keys;
+        if (pubkeys.length > 0) {
           $(recipient.element).removeClass('no_pgp').find('i').remove();
           clearInterval(this.addedPubkeyDbLookupInterval);
           recipientsHasPgp.push(recipient);

--- a/extension/chrome/elements/compose-modules/compose-send-btn-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-send-btn-module.ts
@@ -238,9 +238,9 @@ export class ComposeSendBtnModule extends ViewModule<ComposeView> {
     if (sendAs && sendAs[email]?.name) {
       name = sendAs[email].name!;
     } else {
-      const [contact] = await ContactStore.get(undefined, [email]);
-      if (contact?.name) {
-        name = contact.name;
+      const contactWithPubKeys = await ContactStore.getOneWithAllPubkeys(undefined, email);
+      if (contactWithPubKeys && contactWithPubKeys.info.name) {
+        name = contactWithPubKeys.info.name;
       }
     }
     return Str.formatEmailWithOptionalName({ email: parsedEmail.email, name });

--- a/extension/chrome/elements/pgp_pubkey.ts
+++ b/extension/chrome/elements/pgp_pubkey.ts
@@ -125,9 +125,11 @@ View.run(class PgpPubkeyView extends View {
     if (this.publicKeys!.length > 1) {
       $('.action_add_contact').text('import ' + this.publicKeys!.length + ' public keys');
     } else {
-      const [contact] = await ContactStore.get(undefined, [String($('.input_email').val())]);
+      const contactWithPubKeys = await ContactStore.getOneWithAllPubkeys(
+        undefined, String($('.input_email').val()));
       $('.action_add_contact')
-        .text(contact?.hasPgp ? 'update key' : `import ${this.isExpired ? 'expired ' : ''}key`)
+        .text((contactWithPubKeys && contactWithPubKeys.sortedPubkeys && contactWithPubKeys.sortedPubkeys.length > 0)
+          ? 'update key' : `import ${this.isExpired ? 'expired ' : ''}key`)
         .css('background-color', this.isExpired ? '#989898' : '');
     }
   };

--- a/extension/js/common/platform/store/contact-store.ts
+++ b/extension/js/common/platform/store/contact-store.ts
@@ -155,23 +155,6 @@ export class ContactStore extends AbstractStore {
     });
   };
 
-  public static get = async (db: undefined | IDBDatabase, emails: string[]): Promise<(Contact | undefined)[]> => {
-    if (!db) { // relay op through background process
-      return await BrowserMsg.send.bg.await.db({ f: 'get', args: [emails] }) as (Contact | undefined)[];
-    }
-    if (emails.length === 1) {
-      const contact = await ContactStore.dbContactInternalGetOne(db, emails[0]);
-      return [contact];
-    } else {
-      const results: (Contact | undefined)[] = [];
-      for (const email of emails) {
-        const [contact] = await ContactStore.get(db, [email]);
-        results.push(contact);
-      }
-      return results;
-    }
-  };
-
   public static getEncryptionKeys = async (db: undefined | IDBDatabase, emails: string[]): Promise<{ email: string, keys: Key[] }[]> => {
     if (!db) { // relay op through background process
       return await BrowserMsg.send.bg.await.db({ f: 'getEncryptionKeys', args: [emails] }) as { email: string, keys: Key[] }[];

--- a/extension/js/common/platform/store/contact-store.ts
+++ b/extension/js/common/platform/store/contact-store.ts
@@ -585,26 +585,6 @@ export class ContactStore extends AbstractStore {
     return { lowerBound, upperBound };
   };
 
-  private static dbContactInternalGetOne = async (db: IDBDatabase, email: string): Promise<Contact | undefined> => {
-    if (email.includes('@')) { // email
-      const contactWithAllPubkeys = await ContactStore.getOneWithAllPubkeys(db, email);
-      if (!contactWithAllPubkeys) {
-        return contactWithAllPubkeys;
-      }
-      // pick first usableForEncryption
-      let selected = contactWithAllPubkeys.sortedPubkeys.find(entry => !entry.revoked && entry.pubkey.usableForEncryption);
-      if (!selected) {
-        selected = contactWithAllPubkeys.sortedPubkeys.find(entry => !entry.revoked && entry.pubkey.usableForEncryptionButExpired);
-      }
-      if (!selected) {
-        selected = contactWithAllPubkeys.sortedPubkeys[0];
-      }
-      return ContactStore.toContactFromKey(contactWithAllPubkeys.info, selected?.pubkey, selected?.lastCheck, Boolean(selected?.revoked));
-    }
-    // search all longids
-    throw new Error('longid search is deprecated'); // should not get here
-  };
-
   private static getKeyAttributes = (key: Key | undefined): PubkeyAttributes => {
     return { fingerprint: key?.id ?? null, expiresOn: DateUtility.asNumber(key?.expiration) };
   };

--- a/extension/js/common/platform/store/contact-store.ts
+++ b/extension/js/common/platform/store/contact-store.ts
@@ -4,7 +4,7 @@ import { AbstractStore } from './abstract-store.js';
 import { Catch } from '../catch.js';
 import { BrowserMsg } from '../../browser/browser-msg.js';
 import { DateUtility, EmailParts, Str, Value } from '../../core/common.js';
-import { Key, Contact, KeyUtil, PubkeyInfo, ContactInfoWithSortedPubkeys, ContactInfo } from '../../core/crypto/key.js';
+import { Key, KeyUtil, PubkeyInfo, ContactInfoWithSortedPubkeys } from '../../core/crypto/key.js';
 
 // tslint:disable:no-null-keyword
 
@@ -587,19 +587,6 @@ export class ContactStore extends AbstractStore {
 
   private static getKeyAttributes = (key: Key | undefined): PubkeyAttributes => {
     return { fingerprint: key?.id ?? null, expiresOn: DateUtility.asNumber(key?.expiration) };
-  };
-
-  private static toContactFromKey = (email: ContactInfo, key: Key | undefined, lastCheck: number | undefined | null, revokedExternally: boolean): Contact | undefined => {
-    const safeKey = revokedExternally ? undefined : key;
-    return {
-      email: email.email,
-      name: email.name,
-      pubkey: safeKey,
-      hasPgp: safeKey ? 1 : 0,
-      pubkeyLastCheck: lastCheck ?? null,
-      ...ContactStore.getKeyAttributes(key),
-      revoked: revokedExternally || Boolean(key?.revoked)
-    };
   };
 
   private static toContactPreview = (result: Email): ContactPreview => {

--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -698,8 +698,8 @@ export class GmailElementReplacer implements WebmailElementReplacer {
               }
               if (typeof cache === 'undefined') {
                 try {
-                  const [contact] = await ContactStore.get(undefined, [email]);
-                  if (contact && contact.pubkey) {
+                  const contactWithPubKeys = await ContactStore.getOneWithAllPubkeys(undefined, email);
+                  if (contactWithPubKeys && contactWithPubKeys.sortedPubkeys && contactWithPubKeys.sortedPubkeys.length > 0) {
                     this.recipientHasPgpCache[email] = true;
                   } else if ((await this.pubLookup.lookupEmail(email)).pubkeys.length) {
                     this.recipientHasPgpCache[email] = true;

--- a/test/source/tests/browser-unit-tests/unit-ContactStore.js
+++ b/test/source/tests/browser-unit-tests/unit-ContactStore.js
@@ -281,18 +281,17 @@ BROWSER_UNIT_TEST_NAME(`ContactStore saves and returns dates as numbers`);
   return 'pass';
 })();
 
-BROWSER_UNIT_TEST_NAME(`ContactStore gets a valid pubkey by e-mail and all pubkeys with getOneWithAllPubkeys()`);
+BROWSER_UNIT_TEST_NAME('ContactStore.getOneWithAllPubkeys() returns all pubkeys with non-revoked placed first');
 (async () => {
   // Note 1: email differs from pubkey id
   await ContactStore.update(undefined, 'some.revoked@otherhost.com', { pubkey: await KeyUtil.parse(testConstants.somerevokedRevoked1) });
   await ContactStore.update(undefined, 'some.revoked@otherhost.com', { pubkey: await KeyUtil.parse(testConstants.somerevokedValid) });
   await ContactStore.update(undefined, 'some.revoked@otherhost.com', { pubkey: await KeyUtil.parse(testConstants.somerevokedRevoked2) });
 
-  const expectedValid = await ContactStore.getOneWithAllPubkeys(undefined, 'some.revoked@otherhost.com');
-  if (expectedValid.sortedPubkeys[0].pubkey.id !== 'D6662C5FB9BDE9DA01F3994AAA1EF832D8CCA4F2') {
-    throw Error(`Expected to get the key fingerprint D6662C5FB9BDE9DA01F3994AAA1EF832D8CCA4F2 but got ${expectedValid.pubkey.id}`);
-  }
   const { sortedPubkeys: pubs } = await ContactStore.getOneWithAllPubkeys(undefined, 'some.revoked@otherhost.com');
+  if (pubs[0].pubkey.id !== 'D6662C5FB9BDE9DA01F3994AAA1EF832D8CCA4F2') {
+    throw Error(`Expected to get the key fingerprint D6662C5FB9BDE9DA01F3994AAA1EF832D8CCA4F2 but got ${pubs[0].pubkey.id}`);
+  }
   if (pubs.length !== 3) {
     throw new Error(`3 pubkeys were expected to be retrieved from the storage but got ${pubs.length}`);
   }

--- a/test/source/tests/browser-unit-tests/unit-ContactStore.js
+++ b/test/source/tests/browser-unit-tests/unit-ContactStore.js
@@ -286,11 +286,11 @@ BROWSER_UNIT_TEST_NAME(`ContactStore gets a valid pubkey by e-mail and all pubke
   return 'pass';
 })();
 
-// This one gives error:
-// Error: Failed to extract pubkey 16BB407403A3ADC55E1E0E4AF93EEC8FB187C923
-// no idea why
 BROWSER_UNIT_TEST_NAME(`ContactStore stores postfixed fingerprint internally for X.509 certificate`);
 (async () => {
+  // This one gives error:
+  // Error: Failed to extract pubkey 16BB407403A3ADC55E1E0E4AF93EEC8FB187C923
+  // no idea why
   const db = await ContactStore.dbOpen();
   const email = 'actalis@meta.33mail.com';
   await ContactStore.update(undefined, email, { pubkey: testConstants.expiredSmimeCert });

--- a/test/source/tests/browser-unit-tests/unit-ContactStore.js
+++ b/test/source/tests/browser-unit-tests/unit-ContactStore.js
@@ -259,19 +259,6 @@ BROWSER_UNIT_TEST_NAME(`ContactStore.update tests`);
   return 'pass';
 })();
 
-BROWSER_UNIT_TEST_NAME(`ContactStore saves and returns dates as numbers`);
-(async () => {
-  // we'll use background operation to make sure the date isn't transformed on its way
-  const email = 'test@expired.com';
-  const pubkeyLastCheck = Date.now();
-  const lastUse = pubkeyLastCheck + 1000;
-  await ContactStore.update(undefined, email, { pubkey: testConstants.expiredPub, pubkeyLastCheck, lastUse });
-  const loaded = await ContactStore.getOneWithAllPubkeys(undefined, email);
-  if (!loaded.sortedPubkeys.every(key => typeof key.pubkeyLastCheck === 'number')) {
-    throw Error(`pubkeyLastCheck was expected to be a number, but got ${typeof loaded.pubkeyLastCheck}`);
-  }
-})();
-
 BROWSER_UNIT_TEST_NAME(`ContactStore gets a valid pubkey by e-mail and all pubkeys with getOneWithAllPubkeys()`);
 (async () => {
   // Note 1: email differs from pubkey id

--- a/test/source/tests/browser-unit-tests/unit-ContactStore.js
+++ b/test/source/tests/browser-unit-tests/unit-ContactStore.js
@@ -286,7 +286,7 @@ BROWSER_UNIT_TEST_NAME(`ContactStore gets a valid pubkey by e-mail and all pubke
   return 'pass';
 })();
 
-// This ine gives error:
+// This one gives error:
 // Error: Failed to extract pubkey 16BB407403A3ADC55E1E0E4AF93EEC8FB187C923
 // no idea why
 BROWSER_UNIT_TEST_NAME(`ContactStore stores postfixed fingerprint internally for X.509 certificate`);

--- a/test/source/tests/browser-unit-tests/unit-ContactStore.js
+++ b/test/source/tests/browser-unit-tests/unit-ContactStore.js
@@ -286,6 +286,9 @@ BROWSER_UNIT_TEST_NAME(`ContactStore gets a valid pubkey by e-mail and all pubke
   return 'pass';
 })();
 
+// This ine gives error:
+// Error: Failed to extract pubkey 16BB407403A3ADC55E1E0E4AF93EEC8FB187C923
+// no idea why
 BROWSER_UNIT_TEST_NAME(`ContactStore stores postfixed fingerprint internally for X.509 certificate`);
 (async () => {
   const db = await ContactStore.dbOpen();

--- a/test/source/tests/browser-unit-tests/unit-ContactStore.js
+++ b/test/source/tests/browser-unit-tests/unit-ContactStore.js
@@ -309,9 +309,10 @@ BROWSER_UNIT_TEST_NAME('ContactStore.getOneWithAllPubkeys() returns all pubkeys 
 
 BROWSER_UNIT_TEST_NAME(`ContactStore stores postfixed fingerprint internally for X.509 certificate`);
 (async () => {
-  // This one gives error:
+  // This one gives me an error:
   // Error: Failed to extract pubkey 16BB407403A3ADC55E1E0E4AF93EEC8FB187C923
-  // no idea why, comenting out meanwhile
+  // No idea why this happens, so I'm meanwhile comenting out it.
+  //
   // const db = await ContactStore.dbOpen();
   // const email = 'actalis@meta.33mail.com';
   // await ContactStore.update(undefined, email, { pubkey: testConstants.expiredSmimeCert });
@@ -374,7 +375,7 @@ BROWSER_UNIT_TEST_NAME(`ContactStore: OpenPGP revocation affects X.509 certifica
     ContactStore.setTxHandlers(tx, resolve, reject);
     tx.objectStore('revocations').put({ fingerprint: ContactStore.stripFingerprint(smimeKey.id) });
   });
-  // original key should be either revoked or missing
+  // original key should be either revoked
   const loadedCert3 = await ContactStore.getOneWithAllPubkeys(db, 'actalis@meta.33mail.com');
   if (!loadedCert3.sortedPubkeys[0].revoked) {
     throw new Error(`The loaded X.509 certificate (3) was expected to be revoked but it is not.`);

--- a/test/source/tests/browser-unit-tests/unit-ContactStore.js
+++ b/test/source/tests/browser-unit-tests/unit-ContactStore.js
@@ -267,7 +267,7 @@ BROWSER_UNIT_TEST_NAME(`ContactStore saves and returns dates as numbers`);
   const lastUse = pubkeyLastCheck + 1000;
   await ContactStore.update(undefined, email, { pubkey: testConstants.expiredPub, pubkeyLastCheck, lastUse });
   const loaded = await ContactStore.getOneWithAllPubkeys(undefined, email);
-  if (!loaded.sortedPubkeys.all(key => typeof key.pubkeyLastCheck === 'number')) {
+  if (!loaded.sortedPubkeys.every(key => typeof key.pubkeyLastCheck === 'number')) {
     throw Error(`pubkeyLastCheck was expected to be a number, but got ${typeof loaded.pubkeyLastCheck}`);
   }
 })();
@@ -315,7 +315,7 @@ BROWSER_UNIT_TEST_NAME(`ContactStore stores postfixed fingerprint internally for
     throw Error(`Failed to extract pubkey ${fingerprint}`);
   }
   const contactByEmail = await ContactStore.getOneWithAllPubkeys(db, email);
-  if (contactByEmail.sortedPubkeys.pubkey.id !== fingerprint) {
+  if (contactByEmail.sortedPubkeys[0].id !== fingerprint) {
     throw Error(`Failed to extract pubkey ${fingerprint}`);
   }
   return 'pass';
@@ -354,7 +354,7 @@ BROWSER_UNIT_TEST_NAME(`ContactStore: OpenPGP revocation affects X.509 certifica
   const smimeKey = await KeyUtil.parse(testConstants.expiredSmimeCert);
   await ContactStore.update(db, 'actalis@meta.33mail.com', { pubkey: smimeKey });
   const loadedCert1 = await ContactStore.getOneWithAllPubkeys(db, 'actalis@meta.33mail.com');
-  if (loadedCert1.sortedPubkeys[0].pubkey.revoked) {
+  if (loadedCert1.sortedPubkeys[0].revoked) {
     throw new Error(`The loaded X.509 certificate (1) was expected to be valid but it is revoked.`);
   }
   // emulate openPGP revocation
@@ -365,7 +365,7 @@ BROWSER_UNIT_TEST_NAME(`ContactStore: OpenPGP revocation affects X.509 certifica
   });
   // original key should be either revoked or missing
   const loadedCert3 = await ContactStore.getOneWithAllPubkeys(db, 'actalis@meta.33mail.com');
-  if (loadedCert3 && loadedCert3.sortedPubkeys && loadedCert3.sortedPubkeys.length > 0 && loadedCert3.sortedPubkeys[0].pubkey && !loadedCert3.pubkey.revoked) {
+  if (!loadedCert3.sortedPubkeys[0].revoked) {
     throw new Error(`The loaded X.509 certificate (3) was expected to be revoked but it is not.`);
   }
   return 'pass';

--- a/test/source/tests/browser-unit-tests/unit-ContactStore.js
+++ b/test/source/tests/browser-unit-tests/unit-ContactStore.js
@@ -309,27 +309,23 @@ BROWSER_UNIT_TEST_NAME('ContactStore.getOneWithAllPubkeys() returns all pubkeys 
 
 BROWSER_UNIT_TEST_NAME(`ContactStore stores postfixed fingerprint internally for X.509 certificate`);
 (async () => {
-  // This one gives me an error:
-  // Error: Failed to extract pubkey 16BB407403A3ADC55E1E0E4AF93EEC8FB187C923
-  // No idea why this happens, so I'm meanwhile comenting out it.
-  //
-  // const db = await ContactStore.dbOpen();
-  // const email = 'actalis@meta.33mail.com';
-  // await ContactStore.update(undefined, email, { pubkey: testConstants.expiredSmimeCert });
+  const db = await ContactStore.dbOpen();
+  const email = 'actalis@meta.33mail.com';
+  await ContactStore.update(undefined, email, { pubkey: testConstants.expiredSmimeCert });
   // extract the entity directly from the database
-  // const entityFp = '16BB407403A3ADC55E1E0E4AF93EEC8FB187C923-X509';
-  // const fingerprint = '16BB407403A3ADC55E1E0E4AF93EEC8FB187C923';
-  // const entity = await new Promise((resolve, reject) => {
-  //   const req = db.transaction(['pubkeys'], 'readonly').objectStore('pubkeys').get(entityFp);
-  //   ContactStore.setReqPipe(req, resolve, reject);
-  // });
-  // if (entity.fingerprint !== entityFp) {
-  //   throw Error(`Failed to extract pubkey ${fingerprint}`);
-  // }
-  // const contactByEmail = await ContactStore.getOneWithAllPubkeys(db, email);
-  // if (contactByEmail.sortedPubkeys[0].id !== fingerprint) {
-  //   throw Error(`Failed to extract pubkey ${fingerprint}`);
-  //  }
+  const entityFp = '16BB407403A3ADC55E1E0E4AF93EEC8FB187C923-X509';
+  const fingerprint = '16BB407403A3ADC55E1E0E4AF93EEC8FB187C923';
+  const entity = await new Promise((resolve, reject) => {
+    const req = db.transaction(['pubkeys'], 'readonly').objectStore('pubkeys').get(entityFp);
+    ContactStore.setReqPipe(req, resolve, reject);
+  });
+  if (entity.fingerprint !== entityFp) {
+    throw Error(`Failed to extract pubkey ${fingerprint}`);
+  }
+  const contactByEmail = await ContactStore.getOneWithAllPubkeys(db, email);
+  if (contactByEmail.sortedPubkeys[0].pubkey.id !== fingerprint) {
+    throw Error(`Failed to extract pubkey ${fingerprint} with getOneWithAllPubkeys()`);
+  }
   return 'pass';
 })();
 
@@ -375,7 +371,7 @@ BROWSER_UNIT_TEST_NAME(`ContactStore: OpenPGP revocation affects X.509 certifica
     ContactStore.setTxHandlers(tx, resolve, reject);
     tx.objectStore('revocations').put({ fingerprint: ContactStore.stripFingerprint(smimeKey.id) });
   });
-  // original key should be either revoked
+  // original key should be revoked
   const loadedCert3 = await ContactStore.getOneWithAllPubkeys(db, 'actalis@meta.33mail.com');
   if (!loadedCert3.sortedPubkeys[0].revoked) {
     throw new Error(`The loaded X.509 certificate (3) was expected to be revoked but it is not.`);

--- a/test/source/tests/browser-unit-tests/unit-ContactStore.js
+++ b/test/source/tests/browser-unit-tests/unit-ContactStore.js
@@ -267,7 +267,7 @@ BROWSER_UNIT_TEST_NAME(`ContactStore saves and returns dates as numbers`);
   const lastUse = pubkeyLastCheck + 1000;
   await ContactStore.update(undefined, email, { pubkey: testConstants.expiredPub, pubkeyLastCheck, lastUse });
   const loaded = await ContactStore.getOneWithAllPubkeys(undefined, email);
-  if (!loaded.sortedPubKeys.all(key => typeof key.pubkeyLastCheck === 'number')) {
+  if (!loaded.sortedPubkeys.all(key => typeof key.pubkeyLastCheck === 'number')) {
     throw Error(`pubkeyLastCheck was expected to be a number, but got ${typeof loaded.pubkeyLastCheck}`);
   }
 })();
@@ -354,7 +354,7 @@ BROWSER_UNIT_TEST_NAME(`ContactStore: OpenPGP revocation affects X.509 certifica
   const smimeKey = await KeyUtil.parse(testConstants.expiredSmimeCert);
   await ContactStore.update(db, 'actalis@meta.33mail.com', { pubkey: smimeKey });
   const loadedCert1 = await ContactStore.getOneWithAllPubkeys(db, 'actalis@meta.33mail.com');
-  if (loadedCert1.sortedPubKeys[0].pubkey.revoked) {
+  if (loadedCert1.sortedPubkeys[0].pubkey.revoked) {
     throw new Error(`The loaded X.509 certificate (1) was expected to be valid but it is revoked.`);
   }
   // emulate openPGP revocation
@@ -365,7 +365,7 @@ BROWSER_UNIT_TEST_NAME(`ContactStore: OpenPGP revocation affects X.509 certifica
   });
   // original key should be either revoked or missing
   const loadedCert3 = await ContactStore.getOneWithAllPubkeys(db, 'actalis@meta.33mail.com');
-  if (loadedCert3 && loadedCert3.sortedPubKeys && loadedCert3.sortedPubKeys.length > 0 && loadedCert3.sortedPubKeys[0].pubkey && !loadedCert3.pubkey.revoked) {
+  if (loadedCert3 && loadedCert3.sortedPubkeys && loadedCert3.sortedPubkeys.length > 0 && loadedCert3.sortedPubkeys[0].pubkey && !loadedCert3.pubkey.revoked) {
     throw new Error(`The loaded X.509 certificate (3) was expected to be revoked but it is not.`);
   }
   return 'pass';

--- a/test/source/tests/browser-unit-tests/unit-ContactStore.js
+++ b/test/source/tests/browser-unit-tests/unit-ContactStore.js
@@ -267,6 +267,12 @@ BROWSER_UNIT_TEST_NAME(`ContactStore saves and returns dates as numbers`);
   const lastUse = pubkeyLastCheck + 1000;
   await ContactStore.update(undefined, email, { pubkey: testConstants.expiredPub, pubkeyLastCheck, lastUse });
   const loaded = await ContactStore.getOneWithAllPubkeys(undefined, email);
+  if (!loaded) {
+    throw Error('Contact not found');
+  }
+  if (!loaded.sortedPubkeys.length) {
+    throw Error('Contact doesn\'t have pubkeys');
+  }
   if (typeof loaded.sortedPubkeys[0].lastCheck !== 'number') {
     throw Error(
       'pubkeyLastCheck was expected to be a number, ' +

--- a/test/source/tests/browser-unit-tests/unit-ContactStore.js
+++ b/test/source/tests/browser-unit-tests/unit-ContactStore.js
@@ -291,25 +291,23 @@ BROWSER_UNIT_TEST_NAME(`ContactStore stores postfixed fingerprint internally for
   // This one gives error:
   // Error: Failed to extract pubkey 16BB407403A3ADC55E1E0E4AF93EEC8FB187C923
   // no idea why, comenting out meanwhile
-  /*
-  const db = await ContactStore.dbOpen();
-  const email = 'actalis@meta.33mail.com';
-  await ContactStore.update(undefined, email, { pubkey: testConstants.expiredSmimeCert });
+  // const db = await ContactStore.dbOpen();
+  // const email = 'actalis@meta.33mail.com';
+  // await ContactStore.update(undefined, email, { pubkey: testConstants.expiredSmimeCert });
   // extract the entity directly from the database
-  const entityFp = '16BB407403A3ADC55E1E0E4AF93EEC8FB187C923-X509';
-  const fingerprint = '16BB407403A3ADC55E1E0E4AF93EEC8FB187C923';
-  const entity = await new Promise((resolve, reject) => {
-    const req = db.transaction(['pubkeys'], 'readonly').objectStore('pubkeys').get(entityFp);
-    ContactStore.setReqPipe(req, resolve, reject);
-  });
-  if (entity.fingerprint !== entityFp) {
-    throw Error(`Failed to extract pubkey ${fingerprint}`);
-  }
-  const contactByEmail = await ContactStore.getOneWithAllPubkeys(db, email);
-  if (contactByEmail.sortedPubkeys[0].id !== fingerprint) {
-    throw Error(`Failed to extract pubkey ${fingerprint}`);
-  }
-  */
+  // const entityFp = '16BB407403A3ADC55E1E0E4AF93EEC8FB187C923-X509';
+  // const fingerprint = '16BB407403A3ADC55E1E0E4AF93EEC8FB187C923';
+  // const entity = await new Promise((resolve, reject) => {
+  //   const req = db.transaction(['pubkeys'], 'readonly').objectStore('pubkeys').get(entityFp);
+  //   ContactStore.setReqPipe(req, resolve, reject);
+  // });
+  // if (entity.fingerprint !== entityFp) {
+  //   throw Error(`Failed to extract pubkey ${fingerprint}`);
+  // }
+  // const contactByEmail = await ContactStore.getOneWithAllPubkeys(db, email);
+  // if (contactByEmail.sortedPubkeys[0].id !== fingerprint) {
+  //   throw Error(`Failed to extract pubkey ${fingerprint}`);
+  //  }
   return 'pass';
 })();
 

--- a/test/source/tests/browser-unit-tests/unit-ContactStore.js
+++ b/test/source/tests/browser-unit-tests/unit-ContactStore.js
@@ -290,7 +290,8 @@ BROWSER_UNIT_TEST_NAME(`ContactStore stores postfixed fingerprint internally for
 (async () => {
   // This one gives error:
   // Error: Failed to extract pubkey 16BB407403A3ADC55E1E0E4AF93EEC8FB187C923
-  // no idea why
+  // no idea why, comenting out meanwhile
+  /*
   const db = await ContactStore.dbOpen();
   const email = 'actalis@meta.33mail.com';
   await ContactStore.update(undefined, email, { pubkey: testConstants.expiredSmimeCert });
@@ -308,6 +309,7 @@ BROWSER_UNIT_TEST_NAME(`ContactStore stores postfixed fingerprint internally for
   if (contactByEmail.sortedPubkeys[0].id !== fingerprint) {
     throw Error(`Failed to extract pubkey ${fingerprint}`);
   }
+  */
   return 'pass';
 })();
 

--- a/test/source/tests/browser-unit-tests/unit-ContactStore.js
+++ b/test/source/tests/browser-unit-tests/unit-ContactStore.js
@@ -259,6 +259,21 @@ BROWSER_UNIT_TEST_NAME(`ContactStore.update tests`);
   return 'pass';
 })();
 
+BROWSER_UNIT_TEST_NAME(`ContactStore saves and returns dates as numbers`);
+(async () => {
+  // we'll use background operation to make sure the date isn't transformed on its way
+  const email = 'test@expired.com';
+  const pubkeyLastCheck = Date.now();
+  const lastUse = pubkeyLastCheck + 1000;
+  await ContactStore.update(undefined, email, { pubkey: testConstants.expiredPub, pubkeyLastCheck, lastUse });
+  const loaded = await ContactStore.getOneWithAllPubkeys(undefined, email);
+  if (typeof loaded.sortedPubkeys[0].lastCheck !== 'number') {
+    throw Error(
+      'pubkeyLastCheck was expected to be a number, ' +
+      `but got ${typeof loaded.sortedPubkeys[0].lastCheck}`);
+  }
+})();
+
 BROWSER_UNIT_TEST_NAME(`ContactStore gets a valid pubkey by e-mail and all pubkeys with getOneWithAllPubkeys()`);
 (async () => {
   // Note 1: email differs from pubkey id

--- a/test/source/tests/browser-unit-tests/unit-ContactStore.js
+++ b/test/source/tests/browser-unit-tests/unit-ContactStore.js
@@ -278,6 +278,7 @@ BROWSER_UNIT_TEST_NAME(`ContactStore saves and returns dates as numbers`);
       'pubkeyLastCheck was expected to be a number, ' +
       `but got ${typeof loaded.sortedPubkeys[0].lastCheck}`);
   }
+  return 'pass';
 })();
 
 BROWSER_UNIT_TEST_NAME(`ContactStore gets a valid pubkey by e-mail and all pubkeys with getOneWithAllPubkeys()`);


### PR DESCRIPTION
This PR refactors code to use `ContactStore.getOneWithAllPubkeys()` instead of `ContactStore.get()`

close #3905 

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
