### PR TITLE
add adjustment on secure compose button for new Gmail UI

### DIFF
--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -44,13 +44,13 @@
   background-repeat: no-repeat;
 }
 
-.secure_compose_simple {
+.compose_button_simple {
   height: 33px !important;
   margin: 0 12px !important;
   display: block !important;
 }
 
-.secure_compose_simple::before {
+.compose_button_simple::before {
   left: -4px;
   position: relative;
 }

--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -44,12 +44,13 @@
   background-repeat: no-repeat;
 }
 
-.new_secure_compose_button_for_new_ui {
+.secure_compose_simple {
   height: 33px !important;
   margin: 0 12px !important;
+  display: block !important;
 }
 
-.new_secure_compose_button_for_new_ui::before {
+.secure_compose_simple::before {
   left: -4px;
   position: relative;
 }
@@ -88,8 +89,13 @@
   min-width: 42px;
 }
 
+.pb-10px {
+  padding-bottom: 10px;
+}
+
 [class*="_destroyable"].z0:not(.small) {
   margin-bottom: 0 !important;
+  display: initial;
 }
 
 /* notifications */

--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -44,6 +44,16 @@
   background-repeat: no-repeat;
 }
 
+.new_secure_compose_button_for_new_ui {
+  height: 33px !important;
+  margin: 0 12px !important;
+}
+
+.new_secure_compose_button_for_new_ui::before {
+  left: -4px;
+  position: relative;
+}
+
 .only-icon #flowcrypt_secure_compose_button {
   height: 40px;
   width: 16px;

--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -89,8 +89,12 @@
   min-width: 42px;
 }
 
-.pb-10px {
-  padding-bottom: 10px;
+.apW {
+  margin-top: 3px;
+}
+
+.pb-25px {
+  padding-bottom: 25px;
 }
 
 [class*="_destroyable"].z0:not(.small) {

--- a/extension/js/common/xss-safe-factory.ts
+++ b/extension/js/common/xss-safe-factory.ts
@@ -233,7 +233,12 @@ export class XssSafeFactory {
       const btn = `<div class="new_secure_compose_window_button" id="flowcrypt_secure_compose_button" title="New Secure Email"><img src="${this.srcImg('logo-19-19.png')}"></div>`;
       return `<div class="_fce_c ${this.destroyableCls} cryptup_compose_button_container" role="presentation">${btn}</div>`;
     } else {
-      const btn = `<div class="new_secure_compose_window_button" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose">Secure Compose</div>`;
+      let btn = '';
+      if ($('.V6.CL.W9').length === 1) { // if mail primary button present for new Gmail UI
+        btn = `<div class="new_secure_compose_window_button new_secure_compose_button_for_new_ui" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose"></div>`
+      } else {
+        btn = `<div class="new_secure_compose_window_button" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose">Secure Compose</div>`; 
+      }
       return `<div class="${this.destroyableCls} z0">${btn}</div>`;
     }
   };

--- a/extension/js/common/xss-safe-factory.ts
+++ b/extension/js/common/xss-safe-factory.ts
@@ -233,12 +233,13 @@ export class XssSafeFactory {
       const btn = `<div class="new_secure_compose_window_button" id="flowcrypt_secure_compose_button" title="New Secure Email"><img src="${this.srcImg('logo-19-19.png')}"></div>`;
       return `<div class="_fce_c ${this.destroyableCls} cryptup_compose_button_container" role="presentation">${btn}</div>`;
     } else {
+      const isNewGmailUi2022 = $('.V6.CL.W9').length === 1;
       let btn = `<div class="new_secure_compose_window_button" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose">Secure Compose</div>`;
-      if ($('.V6.CL.W9').length === 1) { // if mail primary button present for new Gmail UI
+      if (isNewGmailUi2022) {
         btn = `<div class="new_secure_compose_window_button compose_button_simple" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose">
-        </div><div class="apW">FlowCrypt</div>`;
+        </div><div class="apW">Secure Compose</div>`;
       }
-      return `<div class="${this.destroyableCls} z0 ${$('.V6.CL.W9').length === 1 ? 'pb-10px' : '' }">${btn}</div>`;
+      return `<div class="${this.destroyableCls} z0 ${isNewGmailUi2022 ? 'pb-25px' : '' }">${btn}</div>`;
     }
   };
 

--- a/extension/js/common/xss-safe-factory.ts
+++ b/extension/js/common/xss-safe-factory.ts
@@ -233,13 +233,12 @@ export class XssSafeFactory {
       const btn = `<div class="new_secure_compose_window_button" id="flowcrypt_secure_compose_button" title="New Secure Email"><img src="${this.srcImg('logo-19-19.png')}"></div>`;
       return `<div class="_fce_c ${this.destroyableCls} cryptup_compose_button_container" role="presentation">${btn}</div>`;
     } else {
-      let btn = '';
+      let btn = `<div class="new_secure_compose_window_button" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose">Secure Compose</div>`;
       if ($('.V6.CL.W9').length === 1) { // if mail primary button present for new Gmail UI
-        btn = `<div class="new_secure_compose_window_button new_secure_compose_button_for_new_ui" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose"></div>`
-      } else {
-        btn = `<div class="new_secure_compose_window_button" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose">Secure Compose</div>`; 
+        btn = `<div class="new_secure_compose_window_button secure_compose_simple" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose">
+        </div><div class="apW">FlowCrypt</div>`;
       }
-      return `<div class="${this.destroyableCls} z0">${btn}</div>`;
+      return `<div class="${this.destroyableCls} z0 ${$('.V6.CL.W9').length === 1 ? 'pb-10px' : '' }">${btn}</div>`;
     }
   };
 

--- a/extension/js/common/xss-safe-factory.ts
+++ b/extension/js/common/xss-safe-factory.ts
@@ -235,7 +235,7 @@ export class XssSafeFactory {
     } else {
       let btn = `<div class="new_secure_compose_window_button" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose">Secure Compose</div>`;
       if ($('.V6.CL.W9').length === 1) { // if mail primary button present for new Gmail UI
-        btn = `<div class="new_secure_compose_window_button secure_compose_simple" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose">
+        btn = `<div class="new_secure_compose_window_button compose_button_simple" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose">
         </div><div class="apW">FlowCrypt</div>`;
       }
       return `<div class="${this.destroyableCls} z0 ${$('.V6.CL.W9').length === 1 ? 'pb-10px' : '' }">${btn}</div>`;


### PR DESCRIPTION
This PR will adjust the secure compose button UI for the new Gmail UI.

proposed changes looks like:
<img width="65" alt="Screen Shot 2022-03-07 at 3 16 50 PM" src="https://user-images.githubusercontent.com/46025304/156985542-0c629b2c-2bb1-4bc9-8403-1d3e43a1e510.png">

close https://github.com/FlowCrypt/flowcrypt-browser/issues/4308

issue #0000 // if it doesn't close the issue yet

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
