### PR TITLE
add "Secure Compose" tooltip on FlowCrypt secure compose button

### DIFF
--- a/extension/js/common/xss-safe-factory.ts
+++ b/extension/js/common/xss-safe-factory.ts
@@ -234,10 +234,11 @@ export class XssSafeFactory {
       return `<div class="_fce_c ${this.destroyableCls} cryptup_compose_button_container" role="presentation">${btn}</div>`;
     } else {
       const isNewGmailUi2022 = $('.V6.CL.W9').length === 1;
-      let btn = `<div class="new_secure_compose_window_button" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose" data-tooltip="Secure Compose" aria-label="Secure Compose">Secure Compose</div>`;
+      let btn = `<div class="new_secure_compose_window_button" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose"
+      data-tooltip="Secure Compose" aria-label="Secure Compose">Secure Compose</div>`;
       if (isNewGmailUi2022) {
-        btn = `<div class="new_secure_compose_window_button compose_button_simple" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose" data-tooltip="Secure Compose" aria-label="Secure Compose">
-        </div><div class="apW">Secure Compose</div>`;
+        btn = `<div class="new_secure_compose_window_button compose_button_simple" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose"
+        data-tooltip="Secure Compose" aria-label="Secure Compose"></div><div class="apW">Secure Compose</div>`;
       }
       return `<div class="${this.destroyableCls} z0 ${isNewGmailUi2022 ? 'pb-25px' : '' }">${btn}</div>`;
     }

--- a/extension/js/common/xss-safe-factory.ts
+++ b/extension/js/common/xss-safe-factory.ts
@@ -234,9 +234,9 @@ export class XssSafeFactory {
       return `<div class="_fce_c ${this.destroyableCls} cryptup_compose_button_container" role="presentation">${btn}</div>`;
     } else {
       const isNewGmailUi2022 = $('.V6.CL.W9').length === 1;
-      let btn = `<div class="new_secure_compose_window_button" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose">Secure Compose</div>`;
+      let btn = `<div class="new_secure_compose_window_button" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose" data-tooltip="Secure Compose" aria-label="Secure Compose">Secure Compose</div>`;
       if (isNewGmailUi2022) {
-        btn = `<div class="new_secure_compose_window_button compose_button_simple" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose">
+        btn = `<div class="new_secure_compose_window_button compose_button_simple" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose" data-tooltip="Secure Compose" aria-label="Secure Compose">
         </div><div class="apW">Secure Compose</div>`;
       }
       return `<div class="${this.destroyableCls} z0 ${isNewGmailUi2022 ? 'pb-25px' : '' }">${btn}</div>`;

--- a/extension/js/common/xss-safe-factory.ts
+++ b/extension/js/common/xss-safe-factory.ts
@@ -234,11 +234,11 @@ export class XssSafeFactory {
       return `<div class="_fce_c ${this.destroyableCls} cryptup_compose_button_container" role="presentation">${btn}</div>`;
     } else {
       const isNewGmailUi2022 = $('.V6.CL.W9').length === 1;
-      let btn = `<div class="new_secure_compose_window_button" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose"
-      data-tooltip="Secure Compose" aria-label="Secure Compose">Secure Compose</div>`;
+      let btn = `<div class="new_secure_compose_window_button" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose"` +
+      `data-tooltip="Secure Compose" aria-label="Secure Compose">Secure Compose</div>`;
       if (isNewGmailUi2022) {
-        btn = `<div class="new_secure_compose_window_button compose_button_simple" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose"
-        data-tooltip="Secure Compose" aria-label="Secure Compose"></div><div class="apW">Secure Compose</div>`;
+        btn = `<div class="new_secure_compose_window_button compose_button_simple" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose"` +
+        `data-tooltip="Secure Compose" aria-label="Secure Compose"></div><div class="apW">Secure Compose</div>`;
       }
       return `<div class="${this.destroyableCls} z0 ${isNewGmailUi2022 ? 'pb-25px' : '' }">${btn}</div>`;
     }


### PR DESCRIPTION
This PR will add a tooltip `Secure Compose` on FlowCrypt secure compose button.

<video src=https://user-images.githubusercontent.com/46025304/157205427-e216c9da-db6a-4520-a949-01236c9751b2.mov>


close https://github.com/FlowCrypt/flowcrypt-browser/issues/4323 

issue #0000 // if it doesn't close the issue yet

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
