### PR TITLE
issue #4387 expect exact file names when using awaitDownloadTriggeredByClicking() in tests

### DIFF
--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -817,10 +817,10 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await composePage.waitAndClick('@action-send', { delay: 1 });
       const attachment = await composePage.getFrame(['attachment.htm', `name=${attachmentFilename}`]);
       await attachment.waitForSelTestState('ready');
-      const fileText = await composePage.awaitDownloadTriggeredByClicking(async () => {
+      const downloadedFiles = await composePage.awaitDownloadTriggeredByClicking(async () => {
         await attachment.click('#download');
       });
-      expect(Object.values(fileText).pop()!.toString()).to.equal(`small text file\nnot much here\nthis worked\n`);
+      expect(downloadedFiles[attachmentFilename].toString()).to.equal(`small text file\nnot much here\nthis worked\n`);
       await composePage.close();
     }));
 
@@ -1241,10 +1241,10 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       const fileInput = await composeFrame.target.$('input[type=file]');
       await fileInput!.uploadFile('test/samples/small.txt', 'test/samples/small.png', 'test/samples/small.pdf');
       // attachments in composer can be downloaded
-      const fileText = await inboxPage.awaitDownloadTriggeredByClicking(async () => {
+      const downloadedFiles = await inboxPage.awaitDownloadTriggeredByClicking(async () => {
         await composeFrame.click('.qq-file-id-0');
       });
-      expect(Object.values(fileText).pop()!.toString()).to.equal(`small text file\nnot much here\nthis worked\n`);
+      expect(downloadedFiles['small.txt'].toString()).to.equal(`small text file\nnot much here\nthis worked\n`);
       await composeFrame.waitAndClick('@action-send', { delay: 2 });
       await inboxPage.waitTillGone('@container-new-message');
     }));
@@ -1261,10 +1261,10 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       const fileInput = await composeFrame.target.$('input[type=file]');
       await fileInput!.uploadFile('test/samples/small.txt', 'test/samples/small.png', 'test/samples/small.pdf');
       // attachments in composer can be downloaded
-      const fileText = await inboxPage.awaitDownloadTriggeredByClicking(async () => {
+      const downloadedFiles = await inboxPage.awaitDownloadTriggeredByClicking(async () => {
         await composeFrame.click('.qq-file-id-0');
       });
-      expect(Object.values(fileText).pop()!.toString()).to.equal(`small text file\nnot much here\nthis worked\n`);
+      expect(downloadedFiles['small.txt'].toString()).to.equal(`small text file\nnot much here\nthis worked\n`);
       await composeFrame.waitAndClick('@action-send', { delay: 2 });
       await inboxPage.waitTillGone('@container-new-message');
     }));

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -820,7 +820,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       const downloadedFiles = await composePage.awaitDownloadTriggeredByClicking(async () => {
         await attachment.click('#download');
       });
-      expect(downloadedFiles[attachmentFilename].toString()).to.equal(`small text file\nnot much here\nthis worked\n`);
+      expect(downloadedFiles[attachmentFilename]!.toString()).to.equal(`small text file\nnot much here\nthis worked\n`);
       await composePage.close();
     }));
 
@@ -1244,7 +1244,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       const downloadedFiles = await inboxPage.awaitDownloadTriggeredByClicking(async () => {
         await composeFrame.click('.qq-file-id-0');
       });
-      expect(downloadedFiles['small.txt'].toString()).to.equal(`small text file\nnot much here\nthis worked\n`);
+      expect(downloadedFiles['small.txt']!.toString()).to.equal(`small text file\nnot much here\nthis worked\n`);
       await composeFrame.waitAndClick('@action-send', { delay: 2 });
       await inboxPage.waitTillGone('@container-new-message');
     }));
@@ -1264,7 +1264,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       const downloadedFiles = await inboxPage.awaitDownloadTriggeredByClicking(async () => {
         await composeFrame.click('.qq-file-id-0');
       });
-      expect(downloadedFiles['small.txt'].toString()).to.equal(`small text file\nnot much here\nthis worked\n`);
+      expect(downloadedFiles['small.txt']!.toString()).to.equal(`small text file\nnot much here\nthis worked\n`);
       await composeFrame.waitAndClick('@action-send', { delay: 2 });
       await inboxPage.waitTillGone('@container-new-message');
     }));

--- a/test/source/tests/flaky.ts
+++ b/test/source/tests/flaky.ts
@@ -108,9 +108,9 @@ export const defineFlakyTests = (testVariant: TestVariant, testWithBrowser: Test
       const fingerprint = (await settingsPage.read('.good', true)).split(' ').join('');
       const myKeyFrame = await browser.newPage(t, `chrome/settings/modules/my_key.htm?placement=settings&parentTabId=60%3A0&acctEmail=${acctEmail}&fingerprint=${fingerprint}`);
       const downloadedFiles = await myKeyFrame.awaitDownloadTriggeredByClicking('@action-download-prv');
-      // Key ID is last 16 characters of the fingerprint
-      const keyID = fingerprint.substring(fingerprint.length - 16);
-      const fileName = `flowcrypt-backup-usernosubmitorgruleflowcrypttest-0x${keyID}.asc`;
+      // const longid = OpenPGPKey.fingerprintToLongid(fingerprint);
+      const longid = fingerprint.substring(fingerprint.length - 16);
+      const fileName = `flowcrypt-backup-usernosubmitorgruleflowcrypttest-0x${longid}.asc`;
       const key = await KeyUtil.parse(downloadedFiles[fileName]!.toString());
       expect(key.algo.bits).to.equal(3072);
       expect(key.algo.algorithm).to.equal('rsa_encrypt_sign');

--- a/test/source/tests/flaky.ts
+++ b/test/source/tests/flaky.ts
@@ -108,9 +108,9 @@ export const defineFlakyTests = (testVariant: TestVariant, testWithBrowser: Test
       const fingerprint = (await settingsPage.read('.good', true)).split(' ').join('');
       const myKeyFrame = await browser.newPage(t, `chrome/settings/modules/my_key.htm?placement=settings&parentTabId=60%3A0&acctEmail=${acctEmail}&fingerprint=${fingerprint}`);
       const downloadedFiles = await myKeyFrame.awaitDownloadTriggeredByClicking('@action-download-prv');
-      // It is not possible to have predictable file name here, because key is generated
-      // and file name depends on the key ID.
-      const fileName = `flowcrypt-backup-usernosubmitorgruleflowcrypttest-0x${fingerprint}.asc`;
+      // Key ID is last 16 characters of the fingerprint
+      const keyID = fingerprint.substring(fingerprint.length - 16);
+      const fileName = `flowcrypt-backup-usernosubmitorgruleflowcrypttest-0x${keyID}.asc`;
       console.log('>>> DOWNLOADED FILES: ' + Object.keys(downloadedFiles));
       console.log('>>> EXPECTED FILE: ' + fileName);
       const key = await KeyUtil.parse(downloadedFiles[fileName]!.toString());

--- a/test/source/tests/flaky.ts
+++ b/test/source/tests/flaky.ts
@@ -107,8 +107,9 @@ export const defineFlakyTests = (testVariant: TestVariant, testWithBrowser: Test
       await SettingsPageRecipe.toggleScreen(settingsPage, 'additional');
       const fingerprint = (await settingsPage.read('.good', true)).split(' ').join('');
       const myKeyFrame = await browser.newPage(t, `chrome/settings/modules/my_key.htm?placement=settings&parentTabId=60%3A0&acctEmail=${acctEmail}&fingerprint=${fingerprint}`);
-      const files = await myKeyFrame.awaitDownloadTriggeredByClicking('@action-download-prv');
-      const key = await KeyUtil.parse(Object.values(files).pop()!.toString());
+      const downloadedFiles = await myKeyFrame.awaitDownloadTriggeredByClicking('@action-download-prv');
+      console.log("*** FILES(1):" + JSON.stringify(Object.keys(downloadedFiles)));
+      const key = await KeyUtil.parse(Object.values(downloadedFiles).pop()!.toString());
       expect(key.algo.bits).to.equal(3072);
       expect(key.algo.algorithm).to.equal('rsa_encrypt_sign');
       await myKeyFrame.close();

--- a/test/source/tests/flaky.ts
+++ b/test/source/tests/flaky.ts
@@ -111,8 +111,6 @@ export const defineFlakyTests = (testVariant: TestVariant, testWithBrowser: Test
       // Key ID is last 16 characters of the fingerprint
       const keyID = fingerprint.substring(fingerprint.length - 16);
       const fileName = `flowcrypt-backup-usernosubmitorgruleflowcrypttest-0x${keyID}.asc`;
-      console.log('>>> DOWNLOADED FILES: ' + Object.keys(downloadedFiles));
-      console.log('>>> EXPECTED FILE: ' + fileName);
       const key = await KeyUtil.parse(downloadedFiles[fileName]!.toString());
       expect(key.algo.bits).to.equal(3072);
       expect(key.algo.algorithm).to.equal('rsa_encrypt_sign');

--- a/test/source/tests/flaky.ts
+++ b/test/source/tests/flaky.ts
@@ -110,6 +110,7 @@ export const defineFlakyTests = (testVariant: TestVariant, testWithBrowser: Test
       const downloadedFiles = await myKeyFrame.awaitDownloadTriggeredByClicking('@action-download-prv');
       // It is not possible to have predictable file name here, because key is generated
       // and file name depends on the key ID.
+      console.log('>>> DOWNLOADED FILES: ' + Object.keys(downloadedFiles));
       const key = await KeyUtil.parse(Object.values(downloadedFiles).pop()!.toString());
       expect(key.algo.bits).to.equal(3072);
       expect(key.algo.algorithm).to.equal('rsa_encrypt_sign');

--- a/test/source/tests/flaky.ts
+++ b/test/source/tests/flaky.ts
@@ -108,7 +108,6 @@ export const defineFlakyTests = (testVariant: TestVariant, testWithBrowser: Test
       const fingerprint = (await settingsPage.read('.good', true)).split(' ').join('');
       const myKeyFrame = await browser.newPage(t, `chrome/settings/modules/my_key.htm?placement=settings&parentTabId=60%3A0&acctEmail=${acctEmail}&fingerprint=${fingerprint}`);
       const downloadedFiles = await myKeyFrame.awaitDownloadTriggeredByClicking('@action-download-prv');
-      console.log("*** FILES(1):" + JSON.stringify(Object.keys(downloadedFiles)));
       // It is not possible to have predictable file name here, because key is generated
       // and file name depends on the key ID.
       const key = await KeyUtil.parse(Object.values(downloadedFiles).pop()!.toString());

--- a/test/source/tests/flaky.ts
+++ b/test/source/tests/flaky.ts
@@ -110,8 +110,10 @@ export const defineFlakyTests = (testVariant: TestVariant, testWithBrowser: Test
       const downloadedFiles = await myKeyFrame.awaitDownloadTriggeredByClicking('@action-download-prv');
       // It is not possible to have predictable file name here, because key is generated
       // and file name depends on the key ID.
+      const fileName = `flowcrypt-backup-usernosubmitorgruleflowcrypttest-0x${fingerprint}.asc`;
       console.log('>>> DOWNLOADED FILES: ' + Object.keys(downloadedFiles));
-      const key = await KeyUtil.parse(Object.values(downloadedFiles).pop()!.toString());
+      console.log('>>> EXPECTED FILE: ' + fileName);
+      const key = await KeyUtil.parse(downloadedFiles[fileName]!.toString());
       expect(key.algo.bits).to.equal(3072);
       expect(key.algo.algorithm).to.equal('rsa_encrypt_sign');
       await myKeyFrame.close();

--- a/test/source/tests/flaky.ts
+++ b/test/source/tests/flaky.ts
@@ -109,7 +109,7 @@ export const defineFlakyTests = (testVariant: TestVariant, testWithBrowser: Test
       const myKeyFrame = await browser.newPage(t, `chrome/settings/modules/my_key.htm?placement=settings&parentTabId=60%3A0&acctEmail=${acctEmail}&fingerprint=${fingerprint}`);
       const downloadedFiles = await myKeyFrame.awaitDownloadTriggeredByClicking('@action-download-prv');
       console.log("*** FILES(1):" + JSON.stringify(Object.keys(downloadedFiles)));
-      const key = await KeyUtil.parse(Object.values(downloadedFiles).pop()!.toString());
+      const key = await KeyUtil.parse(downloadedFiles['flowcrypt-backup-usernosubmitorgruleflowcrypttest-0x042CDA70288EC003.asc'].toString());
       expect(key.algo.bits).to.equal(3072);
       expect(key.algo.algorithm).to.equal('rsa_encrypt_sign');
       await myKeyFrame.close();

--- a/test/source/tests/flaky.ts
+++ b/test/source/tests/flaky.ts
@@ -109,7 +109,9 @@ export const defineFlakyTests = (testVariant: TestVariant, testWithBrowser: Test
       const myKeyFrame = await browser.newPage(t, `chrome/settings/modules/my_key.htm?placement=settings&parentTabId=60%3A0&acctEmail=${acctEmail}&fingerprint=${fingerprint}`);
       const downloadedFiles = await myKeyFrame.awaitDownloadTriggeredByClicking('@action-download-prv');
       console.log("*** FILES(1):" + JSON.stringify(Object.keys(downloadedFiles)));
-      const key = await KeyUtil.parse(downloadedFiles['flowcrypt-backup-usernosubmitorgruleflowcrypttest-0x042CDA70288EC003.asc'].toString());
+      // It is not possible to have predictable file name here, because key is generated
+      // and file name depends on the key ID.
+      const key = await KeyUtil.parse(Object.values(downloadedFiles).pop()!.toString());
       expect(key.algo.bits).to.equal(3072);
       expect(key.algo.algorithm).to.equal('rsa_encrypt_sign');
       await myKeyFrame.close();

--- a/test/source/tests/settings.ts
+++ b/test/source/tests/settings.ts
@@ -607,9 +607,7 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
       // backing up to file when two keys are checked
       const backupFileRawData2 = await backupPage.awaitDownloadTriggeredByClicking('@action-backup-step3manual-continue', 2);
       console.log("*** FILES(3):" + JSON.stringify(Object.keys(backupFileRawData2)));
-      const { keys: keys2 } = await KeyUtil.readMany(Buf.fromUtfStr(
-        backupFileRawData2['flowcrypt-backup-flowcrypttestkeymultiplegmailcom-515431151DDD3EA232B37A4C98ACFA1EADAB5B92.asc']
-          .toString()));
+      const { keys: keys2 } = await KeyUtil.readMany(Buf.fromUtfStr(Buf.concat(Object.values(backupFileRawData2)).toString()));
       expect(keys2.length).to.equal(2);
       await backupPage.close();
     }));

--- a/test/source/tests/settings.ts
+++ b/test/source/tests/settings.ts
@@ -595,7 +595,7 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
       // backing up to file when only one key is checked
       const backupFileRawData1 = await backupPage.awaitDownloadTriggeredByClicking('@action-backup-step3manual-continue');
       console.log("*** FILES(2):" + JSON.stringify(Object.keys(backupFileRawData1)));
-      const fileName = testVariant == 'CONSUMER-MOCK'
+      const fileName = testVariant === 'CONSUMER-MOCK'
         ? 'flowcrypt-backup-flowcrypttestkeymultiplegmailcom-515431151DDD3EA232B37A4C98ACFA1EADAB5B92.asc'
         : 'flowcrypt-backup-flowcrypttestkeymultiplegmailcom-CB0485FE44FC22FF09AF0DB31B383D0334E38B28.asc';
       const { keys: keys1 } = await KeyUtil.readMany(Buf.fromUtfStr(backupFileRawData1[fileName]!.toString()));

--- a/test/source/tests/settings.ts
+++ b/test/source/tests/settings.ts
@@ -607,7 +607,9 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
       // backing up to file when two keys are checked
       const backupFileRawData2 = await backupPage.awaitDownloadTriggeredByClicking('@action-backup-step3manual-continue', 2);
       console.log("*** FILES(3):" + JSON.stringify(Object.keys(backupFileRawData1)));
-      const { keys: keys2 } = await KeyUtil.readMany(Buf.fromUtfStr(Buf.concat(Object.values(backupFileRawData2)).toString()));
+      const { keys: keys2 } = await KeyUtil.readMany(Buf.fromUtfStr(
+        backupFileRawData2['flowcrypt-backup-flowcrypttestkeymultiplegmailcom-515431151DDD3EA232B37A4C98ACFA1EADAB5B92.asc']
+          .toString()));
       expect(keys2.length).to.equal(2);
       await backupPage.close();
     }));
@@ -672,7 +674,7 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
       await backupPage.waitAndClick('@input-backup-step3manual-file');
       // one passphrase is not known but successfully guessed
       const downloadedFiles = await backupPage.awaitDownloadTriggeredByClicking('@action-backup-step3manual-continue', 2);
-      console.log("*** FILES(2):" + JSON.stringify(Object.keys(downloadedFiles)));
+      console.log("*** FILES(4):" + JSON.stringify(Object.keys(downloadedFiles)));
       const { keys } = await KeyUtil.readMany(Buf.fromUtfStr(Buffer.concat(Object.values(downloadedFiles)).toString()));
       expect(keys.length).to.equal(2);
       await backupPage.close();
@@ -782,7 +784,7 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
         '&type=openpgp&id=515431151DDD3EA232B37A4C98ACFA1EADAB5B92&idToken=fakeheader.01'));
       await backupPage.waitAndClick('@input-backup-step3manual-file');
       const downloadedFiles = await backupPage.awaitDownloadTriggeredByClicking('@action-backup-step3manual-continue');
-      console.log("*** FILES(2):" + JSON.stringify(Object.keys(downloadedFiles)));
+      console.log("*** FILES(5):" + JSON.stringify(Object.keys(downloadedFiles)));
       const { keys } = await KeyUtil.readMany(Buf.fromUtfStr(Object.values(downloadedFiles).pop()!.toString()));
       expect(keys.length).to.equal(1);
       expect(keys[0].id).to.equal("515431151DDD3EA232B37A4C98ACFA1EADAB5B92");

--- a/test/source/tests/settings.ts
+++ b/test/source/tests/settings.ts
@@ -595,10 +595,8 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
       // backing up to file when only one key is checked
       const backupFileRawData1 = await backupPage.awaitDownloadTriggeredByClicking('@action-backup-step3manual-continue');
       console.log("*** FILES(2):" + JSON.stringify(Object.keys(backupFileRawData1)));
-      const fileName = testVariant === 'CONSUMER-MOCK'
-        ? 'flowcrypt-backup-flowcrypttestkeymultiplegmailcom-515431151DDD3EA232B37A4C98ACFA1EADAB5B92.asc'
-        : 'flowcrypt-backup-flowcrypttestkeymultiplegmailcom-CB0485FE44FC22FF09AF0DB31B383D0334E38B28.asc';
-      const { keys: keys1 } = await KeyUtil.readMany(Buf.fromUtfStr(backupFileRawData1[fileName]!.toString()));
+      const { keys: keys1 } = await KeyUtil.readMany(Buf.fromUtfStr(backupFileRawData1['flowcrypt-backup-flowcrypttestkeymultiplegmailcom-515431151DDD3EA232B37A4C98ACFA1EADAB5B92.asc']!
+        .toString()));
       expect(keys1.length).to.equal(1);
       expect(keys1[0].id).to.equal("515431151DDD3EA232B37A4C98ACFA1EADAB5B92");
       await backupPage.waitAndRespondToModal('info', 'confirm', 'Downloading private key backup file');
@@ -673,7 +671,7 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
       // one passphrase is not known but successfully guessed
       const downloadedFiles = await backupPage.awaitDownloadTriggeredByClicking('@action-backup-step3manual-continue', 2);
       console.log("*** FILES(4):" + JSON.stringify(Object.keys(downloadedFiles)));
-      expect(Object.keys(downloadedFiles.length)).to.equal(2);
+      expect(Object.keys(downloadedFiles).length).to.equal(2);
       const keys1 = await KeyUtil.readMany(Buf.fromUtfStr(downloadedFiles['flowcrypt-backup-flowcrypttestkeymultiplegmailcom-515431151DDD3EA232B37A4C98ACFA1EADAB5B92.asc']!.toString()));
       expect(keys1.keys.length).to.equal(1);
       const keys2 = await KeyUtil.readMany(Buf.fromUtfStr(downloadedFiles['flowcrypt-backup-flowcrypttestkeymultiplegmailcom-515431151DDD3EA232B37A4C98ACFA1EADAB5B92.asc']!.toString()));
@@ -786,7 +784,7 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
       await backupPage.waitAndClick('@input-backup-step3manual-file');
       const downloadedFiles = await backupPage.awaitDownloadTriggeredByClicking('@action-backup-step3manual-continue');
       console.log("*** FILES(5):" + JSON.stringify(Object.keys(downloadedFiles)));
-      const { keys } = await KeyUtil.readMany(Buf.fromUtfStr(Object.values(downloadedFiles).pop()!.toString()));
+      const { keys } = await KeyUtil.readMany(Buf.fromUtfStr(downloadedFiles['flowcrypt-backup-flowcrypttestkeymultiplegmailcom-515431151DDD3EA232B37A4C98ACFA1EADAB5B92.asc']!.toString()));
       expect(keys.length).to.equal(1);
       expect(keys[0].id).to.equal("515431151DDD3EA232B37A4C98ACFA1EADAB5B92");
       await backupPage.waitAndRespondToModal('info', 'confirm', 'Downloading private key backup file');

--- a/test/source/tests/settings.ts
+++ b/test/source/tests/settings.ts
@@ -675,8 +675,11 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
       // one passphrase is not known but successfully guessed
       const downloadedFiles = await backupPage.awaitDownloadTriggeredByClicking('@action-backup-step3manual-continue', 2);
       console.log("*** FILES(4):" + JSON.stringify(Object.keys(downloadedFiles)));
-      const { keys } = await KeyUtil.readMany(Buf.fromUtfStr(Buffer.concat(Object.values(downloadedFiles)).toString()));
-      expect(keys.length).to.equal(2);
+      expect(Object.keys(downloadedFiles.length)).to.equal(2);
+      const keys1 = await KeyUtil.readMany(Buf.fromUtfStr(downloadedFiles['flowcrypt-backup-flowcrypttestkeymultiplegmailcom-515431151DDD3EA232B37A4C98ACFA1EADAB5B92.asc']!.toString()));
+      expect(keys1.keys.length).to.equal(1);
+      const keys2 = await KeyUtil.readMany(Buf.fromUtfStr(downloadedFiles['flowcrypt-backup-flowcrypttestkeymultiplegmailcom-515431151DDD3EA232B37A4C98ACFA1EADAB5B92.asc']!.toString()));
+      expect(keys2.keys.length).to.equal(1);
       await backupPage.close();
     }));
 

--- a/test/source/tests/settings.ts
+++ b/test/source/tests/settings.ts
@@ -595,7 +595,10 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
       // backing up to file when only one key is checked
       const backupFileRawData1 = await backupPage.awaitDownloadTriggeredByClicking('@action-backup-step3manual-continue');
       console.log("*** FILES(2):" + JSON.stringify(Object.keys(backupFileRawData1)));
-      const { keys: keys1 } = await KeyUtil.readMany(Buf.fromUtfStr(Object.values(backupFileRawData1).pop()!.toString()));
+      const fileName = testVariant == 'CONSUMER-MOCK'
+        ? 'flowcrypt-backup-flowcrypttestkeymultiplegmailcom-515431151DDD3EA232B37A4C98ACFA1EADAB5B92.asc'
+        : 'flowcrypt-backup-flowcrypttestkeymultiplegmailcom-CB0485FE44FC22FF09AF0DB31B383D0334E38B28.asc';
+      const { keys: keys1 } = await KeyUtil.readMany(Buf.fromUtfStr(backupFileRawData1[fileName]!.toString()));
       expect(keys1.length).to.equal(1);
       expect(keys1[0].id).to.equal("515431151DDD3EA232B37A4C98ACFA1EADAB5B92");
       await backupPage.waitAndRespondToModal('info', 'confirm', 'Downloading private key backup file');

--- a/test/source/tests/settings.ts
+++ b/test/source/tests/settings.ts
@@ -594,6 +594,7 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
       await backupPage.waitAndClick('[data-id="CB0485FE44FC22FF09AF0DB31B383D0334E38B28"]'); // uncheck
       // backing up to file when only one key is checked
       const backupFileRawData1 = await backupPage.awaitDownloadTriggeredByClicking('@action-backup-step3manual-continue');
+      console.log("*** FILES(2):" + JSON.stringify(Object.keys(backupFileRawData1)));
       const { keys: keys1 } = await KeyUtil.readMany(Buf.fromUtfStr(Object.values(backupFileRawData1).pop()!.toString()));
       expect(keys1.length).to.equal(1);
       expect(keys1[0].id).to.equal("515431151DDD3EA232B37A4C98ACFA1EADAB5B92");
@@ -602,6 +603,7 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
       await backupPage.waitAndClick('[data-id="CB0485FE44FC22FF09AF0DB31B383D0334E38B28"]'); // check
       // backing up to file when two keys are checked
       const backupFileRawData2 = await backupPage.awaitDownloadTriggeredByClicking('@action-backup-step3manual-continue', 2);
+      console.log("*** FILES(3):" + JSON.stringify(Object.keys(backupFileRawData1)));
       const { keys: keys2 } = await KeyUtil.readMany(Buf.fromUtfStr(Buf.concat(Object.values(backupFileRawData2)).toString()));
       expect(keys2.length).to.equal(2);
       await backupPage.close();
@@ -667,6 +669,7 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
       await backupPage.waitAndClick('@input-backup-step3manual-file');
       // one passphrase is not known but successfully guessed
       const downloadedFiles = await backupPage.awaitDownloadTriggeredByClicking('@action-backup-step3manual-continue', 2);
+      console.log("*** FILES(2):" + JSON.stringify(Object.keys(downloadedFiles)));
       const { keys } = await KeyUtil.readMany(Buf.fromUtfStr(Buffer.concat(Object.values(downloadedFiles)).toString()));
       expect(keys.length).to.equal(2);
       await backupPage.close();
@@ -776,6 +779,7 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
         '&type=openpgp&id=515431151DDD3EA232B37A4C98ACFA1EADAB5B92&idToken=fakeheader.01'));
       await backupPage.waitAndClick('@input-backup-step3manual-file');
       const downloadedFiles = await backupPage.awaitDownloadTriggeredByClicking('@action-backup-step3manual-continue');
+      console.log("*** FILES(2):" + JSON.stringify(Object.keys(downloadedFiles)));
       const { keys } = await KeyUtil.readMany(Buf.fromUtfStr(Object.values(downloadedFiles).pop()!.toString()));
       expect(keys.length).to.equal(1);
       expect(keys[0].id).to.equal("515431151DDD3EA232B37A4C98ACFA1EADAB5B92");

--- a/test/source/tests/settings.ts
+++ b/test/source/tests/settings.ts
@@ -594,7 +594,6 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
       await backupPage.waitAndClick('[data-id="CB0485FE44FC22FF09AF0DB31B383D0334E38B28"]'); // uncheck
       // backing up to file when only one key is checked
       const backupFileRawData1 = await backupPage.awaitDownloadTriggeredByClicking('@action-backup-step3manual-continue');
-      console.log("*** FILES(2):" + JSON.stringify(Object.keys(backupFileRawData1)));
       const { keys: keys1 } = await KeyUtil.readMany(Buf.fromUtfStr(backupFileRawData1['flowcrypt-backup-flowcrypttestkeymultiplegmailcom-515431151DDD3EA232B37A4C98ACFA1EADAB5B92.asc']!
         .toString()));
       expect(keys1.length).to.equal(1);
@@ -604,7 +603,6 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
       await backupPage.waitAndClick('[data-id="CB0485FE44FC22FF09AF0DB31B383D0334E38B28"]'); // check
       // backing up to file when two keys are checked
       const backupFileRawData2 = await backupPage.awaitDownloadTriggeredByClicking('@action-backup-step3manual-continue', 2);
-      console.log("*** FILES(3):" + JSON.stringify(Object.keys(backupFileRawData2)));
       const { keys: keys2 } = await KeyUtil.readMany(Buf.fromUtfStr(Buf.concat(Object.values(backupFileRawData2)).toString()));
       expect(keys2.length).to.equal(2);
       await backupPage.close();
@@ -670,7 +668,6 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
       await backupPage.waitAndClick('@input-backup-step3manual-file');
       // one passphrase is not known but successfully guessed
       const downloadedFiles = await backupPage.awaitDownloadTriggeredByClicking('@action-backup-step3manual-continue', 2);
-      console.log("*** FILES(4):" + JSON.stringify(Object.keys(downloadedFiles)));
       expect(Object.keys(downloadedFiles).length).to.equal(2);
       const { keys: keys1 } = await KeyUtil.readMany(Buf.fromUtfStr(downloadedFiles['flowcrypt-backup-flowcrypttestkeymultiplegmailcom-515431151DDD3EA232B37A4C98ACFA1EADAB5B92.asc']!
         .toString()));
@@ -785,7 +782,6 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
         '&type=openpgp&id=515431151DDD3EA232B37A4C98ACFA1EADAB5B92&idToken=fakeheader.01'));
       await backupPage.waitAndClick('@input-backup-step3manual-file');
       const downloadedFiles = await backupPage.awaitDownloadTriggeredByClicking('@action-backup-step3manual-continue');
-      console.log("*** FILES(5):" + JSON.stringify(Object.keys(downloadedFiles)));
       const { keys } = await KeyUtil.readMany(Buf.fromUtfStr(downloadedFiles['flowcrypt-backup-flowcrypttestkeymultiplegmailcom-515431151DDD3EA232B37A4C98ACFA1EADAB5B92.asc']!.toString()));
       expect(keys.length).to.equal(1);
       expect(keys[0].id).to.equal("515431151DDD3EA232B37A4C98ACFA1EADAB5B92");

--- a/test/source/tests/settings.ts
+++ b/test/source/tests/settings.ts
@@ -606,7 +606,7 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
       await backupPage.waitAndClick('[data-id="CB0485FE44FC22FF09AF0DB31B383D0334E38B28"]'); // check
       // backing up to file when two keys are checked
       const backupFileRawData2 = await backupPage.awaitDownloadTriggeredByClicking('@action-backup-step3manual-continue', 2);
-      console.log("*** FILES(3):" + JSON.stringify(Object.keys(backupFileRawData1)));
+      console.log("*** FILES(3):" + JSON.stringify(Object.keys(backupFileRawData2)));
       const { keys: keys2 } = await KeyUtil.readMany(Buf.fromUtfStr(
         backupFileRawData2['flowcrypt-backup-flowcrypttestkeymultiplegmailcom-515431151DDD3EA232B37A4C98ACFA1EADAB5B92.asc']
           .toString()));

--- a/test/source/tests/settings.ts
+++ b/test/source/tests/settings.ts
@@ -672,10 +672,12 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
       const downloadedFiles = await backupPage.awaitDownloadTriggeredByClicking('@action-backup-step3manual-continue', 2);
       console.log("*** FILES(4):" + JSON.stringify(Object.keys(downloadedFiles)));
       expect(Object.keys(downloadedFiles).length).to.equal(2);
-      const keys1 = await KeyUtil.readMany(Buf.fromUtfStr(downloadedFiles['flowcrypt-backup-flowcrypttestkeymultiplegmailcom-515431151DDD3EA232B37A4C98ACFA1EADAB5B92.asc']!.toString()));
-      expect(keys1.keys.length).to.equal(1);
-      const keys2 = await KeyUtil.readMany(Buf.fromUtfStr(downloadedFiles['flowcrypt-backup-flowcrypttestkeymultiplegmailcom-515431151DDD3EA232B37A4C98ACFA1EADAB5B92.asc']!.toString()));
-      expect(keys2.keys.length).to.equal(1);
+      const { keys: keys1 } = await KeyUtil.readMany(Buf.fromUtfStr(downloadedFiles['flowcrypt-backup-flowcrypttestkeymultiplegmailcom-515431151DDD3EA232B37A4C98ACFA1EADAB5B92.asc']!
+        .toString()));
+      expect(keys1.length).to.equal(1);
+      const { keys: keys2 } = await KeyUtil.readMany(Buf.fromUtfStr(downloadedFiles['flowcrypt-backup-flowcrypttestkeymultiplegmailcom-515431151DDD3EA232B37A4C98ACFA1EADAB5B92.asc']!
+        .toString()));
+      expect(keys2.length).to.equal(1);
       await backupPage.close();
     }));
 


### PR DESCRIPTION
This PR adds exact file names when using `awaitDownloadTriggeredByClicking()` in tests

close #4387

----------------------------------

**Tests** _(delete all except exactly one)_:

- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
