### PR TITLE
issue 4452 also use gmail.googleapis.com in enterprise content script

### DIFF
--- a/test/source/browser/controllable.ts
+++ b/test/source/browser/controllable.ts
@@ -333,7 +333,7 @@ abstract class ControllableBase {
         }
       }
       const lastText = observedContentHistory[observedContentHistory.length - 1];
-      if (lastText && currentText !== lastText) {
+      if (typeof lastText !== 'undefined' && currentText !== lastText) {
         observedContentHistory.push(currentText);
       }
       await Util.sleep(testLoopLengthMs / 1000);

--- a/test/source/tests/page-recipe/settings-page-recipe.ts
+++ b/test/source/tests/page-recipe/settings-page-recipe.ts
@@ -161,9 +161,9 @@ export class SettingsPageRecipe extends PageRecipe {
     }
     await addPrvPage.waitAndClick('.action_add_private_key', { delay: 1 });
     await addPrvPage.waitTillGone('.swal2-container'); // dialog closed
-    await Util.sleep(1);
+    await Util.sleep(2);
     await addPrvPage.close();
-    await Util.sleep(1);
+    await Util.sleep(2);
     const settingsPage = await browser.newPage(t, TestUrls.extensionSettings(acctEmail));
     await SettingsPageRecipe.toggleScreen(settingsPage, 'additional');
     await settingsPage.waitForContent('@container-settings-keys-list', fp); // confirm key successfully loaded


### PR DESCRIPTION
This PR is a followup from #4419 - I missed content scripts in that PR.

close #4452

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test - would have to do our live Gmail tests on an enterprise build instead of regular. I suppose that's doable, but we may need to consider doing it both on enterprise and on regular. This functionality is expected to eventually be the same on both so it doesn't seem worth testing this in interim period. (Live gmail tests are very flakey)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
