### PR TITLE
#4513 fix: PUT rename /v1/end-user/key-pairs field

### DIFF
--- a/extension/chrome/settings/setup/setup-key-manager-autogen.ts
+++ b/extension/chrome/settings/setup/setup-key-manager-autogen.ts
@@ -96,8 +96,7 @@ export class SetupWithEmailKeyManagerModule {
     if (! await KeyUtil.decrypt(decryptablePrv, setupOptions.passphrase)) {
       throw new Error('Unexpectedly cannot decrypt newly generated key');
     }
-    const pubArmor = KeyUtil.armor(await KeyUtil.asPublicKey(decryptablePrv));
-    const storePrvOnKm = async () => this.view.keyManager!.storePrivateKey(this.view.idToken!, KeyUtil.armor(decryptablePrv), pubArmor);
+    const storePrvOnKm = async () => this.view.keyManager!.storePrivateKey(this.view.idToken!, KeyUtil.armor(decryptablePrv));
     await Settings.retryUntilSuccessful(storePrvOnKm, 'Failed to store newly generated key on FlowCrypt Email Key Manager', Lang.general.contactIfNeedAssistance(this.view.isFesUsed()));
     await this.view.saveKeysAndPassPhrase([await KeyUtil.parse(generated.private)], setupOptions); // store encrypted key + pass phrase locally
   };

--- a/extension/js/common/api/key-server/key-manager.ts
+++ b/extension/js/common/api/key-server/key-manager.ts
@@ -25,8 +25,8 @@ export class KeyManager extends Api {
     return await this.request('GET', '/v1/keys/private', undefined, idToken) as LoadPrvRes;
   };
 
-  public storePrivateKey = async (idToken: string, decryptedPrivateKey: string, publicKey: string): Promise<void> => {
-    return await this.request('PUT', '/v1/keys/private', { decryptedPrivateKey, publicKey }, idToken);
+  public storePrivateKey = async (idToken: string, privateKey: string): Promise<void> => {
+    return await this.request('PUT', '/v1/keys/private', { privateKey }, idToken);
   };
 
   private request = async <RT>(method: ReqMethod, path: string, vals?: Dict<any> | undefined, idToken?: string): Promise<RT> => {

--- a/test/source/mock/key-manager/key-manager-endpoints.ts
+++ b/test/source/mock/key-manager/key-manager-endpoints.ts
@@ -207,7 +207,7 @@ yeSm0uVPwODhwX7ezB9jW6uVt0R8S8iM3rQdEMsA/jDep5LNn47K6o8VrDt0zYo6
 -----END PGP PRIVATE KEY BLOCK-----
 `;
 
-export const MOCK_KM_LAST_INSERTED_KEY: { [acct: string]: { decryptedPrivateKey: string, publicKey: string } } = {}; // accessed from test runners
+export const MOCK_KM_LAST_INSERTED_KEY: { [acct: string]: { privateKey: string } } = {}; // accessed from test runners
 
 export const mockKeyManagerEndpoints: HandlersDefinition = {
   '/flowcrypt-email-key-manager/v1/keys/private': async ({ body }, req) => {
@@ -264,9 +264,9 @@ export const mockKeyManagerEndpoints: HandlersDefinition = {
       throw new HttpClientErr(`Unexpectedly calling mockKeyManagerEndpoints:/v1/keys/private GET with acct ${acctEmail}`);
     }
     if (isPut(req)) {
-      const { decryptedPrivateKey, publicKey } = body as Dict<string>;
+      const { privateKey } = body as Dict<string>;
       if (acctEmail === 'put.key@key-manager-autogen.flowcrypt.test') {
-        const prv = await KeyUtil.parseMany(decryptedPrivateKey);
+        const prv = await KeyUtil.parseMany(privateKey);
         expect(prv).to.have.length(1);
         expect(prv[0].algo.bits).to.equal(2048);
         expect(prv[0].identities).to.have.length(1);
@@ -274,15 +274,7 @@ export const mockKeyManagerEndpoints: HandlersDefinition = {
         expect(prv[0].isPrivate).to.be.true;
         expect(prv[0].fullyDecrypted).to.be.true;
         expect(prv[0].expiration).to.not.exist;
-        const pub = await KeyUtil.parseMany(publicKey);
-        expect(pub).to.have.length(1);
-        expect(pub[0].algo.bits).to.equal(2048);
-        expect(pub[0].identities).to.have.length(1);
-        expect(pub[0].identities[0]).to.equal('First Last <put.key@key-manager-autogen.flowcrypt.test>');
-        expect(pub[0].isPrivate).to.equal(false);
-        expect(pub[0].expiration).to.not.exist;
-        expect(pub[0].id).to.equal(prv[0].id);
-        MOCK_KM_LAST_INSERTED_KEY[acctEmail] = { decryptedPrivateKey, publicKey };
+        MOCK_KM_LAST_INSERTED_KEY[acctEmail] = { privateKey };
         return {};
       }
       if (acctEmail === 'put.error@key-manager-autogen.flowcrypt.test') {
@@ -292,7 +284,7 @@ export const mockKeyManagerEndpoints: HandlersDefinition = {
         throw new HttpClientErr(`No key has been generated for ${acctEmail} yet. Please ask your administrator.`, 405);
       }
       if (acctEmail === 'expire@key-manager-keygen-expiration.flowcrypt.test') {
-        const prv = await KeyUtil.parseMany(decryptedPrivateKey);
+        const prv = await KeyUtil.parseMany(privateKey);
         expect(prv).to.have.length(1);
         expect(prv[0].algo.bits).to.equal(2048);
         expect(prv[0].identities).to.have.length(1);
@@ -300,15 +292,7 @@ export const mockKeyManagerEndpoints: HandlersDefinition = {
         expect(prv[0].isPrivate).to.be.true;
         expect(prv[0].fullyDecrypted).to.be.true;
         expect(prv[0].expiration).to.exist;
-        const pub = await KeyUtil.parseMany(publicKey);
-        expect(pub).to.have.length(1);
-        expect(pub[0].algo.bits).to.equal(2048);
-        expect(pub[0].id).to.equal(prv[0].id);
-        expect(pub[0].identities).to.have.length(1);
-        expect(pub[0].identities[0]).to.equal('First Last <expire@key-manager-keygen-expiration.flowcrypt.test>');
-        expect(pub[0].isPrivate).to.be.false;
-        expect(pub[0].expiration).to.exist;
-        MOCK_KM_LAST_INSERTED_KEY[acctEmail] = { decryptedPrivateKey, publicKey };
+        MOCK_KM_LAST_INSERTED_KEY[acctEmail] = { privateKey };
         return {};
       }
       throw new HttpClientErr(`Unexpectedly calling mockKeyManagerEndpoints:/v1/keys/private PUT with acct ${acctEmail}`);

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -1145,7 +1145,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compose');
       await ComposePageRecipe.fillMsg(composePage, { to: 'demo@flowcrypt.com' }, 'should find pubkey from WKD directly');
       await composePage.waitForContent('.email_address.has_pgp', 'demo@flowcrypt.com');
-      expect(await composePage.attr('.email_address.has_pgp', 'title')).to.contain('D688 9296 FD18 83A2 9C56 E7C1 5FF1 C658 5A70 0098 (openpgp)');
+      expect(await composePage.attr('.email_address.has_pgp', 'title')).to.contain('0997 7F6F 512C A5AD 76F0 C210 248B 60EB 6D04 4DF8 (openpgp)');
     }));
 
     ava.default('timeouts when searching WKD - used to never time out', testWithBrowser('ci.tests.gmail', async (t, browser) => {

--- a/test/source/tests/setup.ts
+++ b/test/source/tests/setup.ts
@@ -658,7 +658,7 @@ AN8G3r5Htj8olot+jm9mIa5XLXWzMNUZgg==
       await settingsPage.waitAll('@container-overlay-details');
       await Util.sleep(0.5);
       const details = await settingsPage.read('@container-overlay-details');
-      expect(details).to.contain('500 when PUT-ing https://localhost:8001/flowcrypt-email-key-manager/v1/keys/private string: decryptedPrivateKey,publicKey -> Intentional error for put.error user to test client behavior');
+      expect(details).to.contain('500 when PUT-ing https://localhost:8001/flowcrypt-email-key-manager/v1/keys/private string: privateKey -> Intentional error for put.error user to test client behavior');
       expect(details).to.not.contain('PRIVATE KEY');
       expect(details).to.not.contain('<REDACTED:');
     }));
@@ -718,7 +718,7 @@ AN8G3r5Htj8olot+jm9mIa5XLXWzMNUZgg==
         await Util.sleep(0.5);
         const details = await settingsPage.read('@container-overlay-details');
         expect(details).to.contain('405 when PUT-ing https://localhost:8001/flowcrypt-email-key-manager/v1/keys/private string: ' +
-          'decryptedPrivateKey,publicKey -> No key has been generated for reject.client.keypair@key-manager-autogen.flowcrypt.test yet');
+          'privateKey -> No key has been generated for reject.client.keypair@key-manager-autogen.flowcrypt.test yet');
         expect(details).to.not.contain('PRIVATE KEY');
       })
     );

--- a/test/source/tests/setup.ts
+++ b/test/source/tests/setup.ts
@@ -625,6 +625,8 @@ AN8G3r5Htj8olot+jm9mIa5XLXWzMNUZgg==
       await myKeyFrame.waitAll('@content-fingerprint');
       const fromKm = MOCK_KM_LAST_INSERTED_KEY[acct];
       expect(fromKm).to.exist;
+      const k = await KeyUtil.parse(fromKm.privateKey);
+      expect(await myKeyFrame.read('@content-fingerprint')).to.equal(Str.spaced(k.id));
       expect(await myKeyFrame.read('@content-key-expiration')).to.equal('Key does not expire');
       await SettingsPageRecipe.closeDialog(settingsPage);
       await Util.sleep(2);
@@ -693,6 +695,8 @@ AN8G3r5Htj8olot+jm9mIa5XLXWzMNUZgg==
         await myKeyFrame.waitAll('@content-fingerprint');
         const fromKm = MOCK_KM_LAST_INSERTED_KEY[acct];
         expect(fromKm).to.exist;
+        const k = await KeyUtil.parse(fromKm.privateKey);
+        expect(await myKeyFrame.read('@content-fingerprint')).to.equal(Str.spaced(k.id));
         const approxMonth = [29, 30, 31].map(days => Str.datetimeToDate(Str.fromDate(new Date(Date.now() + 1000 * 60 * 60 * 24 * days))));
         expect(await myKeyFrame.read('@content-key-expiration')).to.be.oneOf(approxMonth);
         await SettingsPageRecipe.closeDialog(settingsPage);

--- a/test/source/tests/setup.ts
+++ b/test/source/tests/setup.ts
@@ -625,8 +625,6 @@ AN8G3r5Htj8olot+jm9mIa5XLXWzMNUZgg==
       await myKeyFrame.waitAll('@content-fingerprint');
       const fromKm = MOCK_KM_LAST_INSERTED_KEY[acct];
       expect(fromKm).to.exist;
-      const k = await KeyUtil.parse(fromKm.publicKey);
-      expect(await myKeyFrame.read('@content-fingerprint')).to.equal(Str.spaced(k.id));
       expect(await myKeyFrame.read('@content-key-expiration')).to.equal('Key does not expire');
       await SettingsPageRecipe.closeDialog(settingsPage);
       await Util.sleep(2);
@@ -695,8 +693,6 @@ AN8G3r5Htj8olot+jm9mIa5XLXWzMNUZgg==
         await myKeyFrame.waitAll('@content-fingerprint');
         const fromKm = MOCK_KM_LAST_INSERTED_KEY[acct];
         expect(fromKm).to.exist;
-        const k = await KeyUtil.parse(fromKm.publicKey);
-        expect(await myKeyFrame.read('@content-fingerprint')).to.equal(Str.spaced(k.id));
         const approxMonth = [29, 30, 31].map(days => Str.datetimeToDate(Str.fromDate(new Date(Date.now() + 1000 * 60 * 60 * 24 * days))));
         expect(await myKeyFrame.read('@content-key-expiration')).to.be.oneOf(approxMonth);
         await SettingsPageRecipe.closeDialog(settingsPage);


### PR DESCRIPTION
This PR renamed PUT /v1/end-user/key-pairs field

close #4513 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
