### PR TITLE
#4504 Fix: updating of public key in another frame should also re-evaluate pwd prompt

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -909,7 +909,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
       $(el).attr('title', 'Could not verify their encryption setup. You can encrypt the message with a password below. Alternatively, add their pubkey.');
     }
     // Replace updated recipient in addedRecipients
-    const changedIndex = this.addedRecipients.findIndex((addedRecipient) => addedRecipient.email === recipient.email && addedRecipient.id == recipient.id);
+    const changedIndex = this.addedRecipients.findIndex((addedRecipient) => addedRecipient.email === recipient.email && addedRecipient.id === recipient.id);
     this.addedRecipients.splice(changedIndex, 1, recipient);
     this.view.pwdOrPubkeyContainerModule.showHideContainerAndColorSendBtn(); // tslint:disable-line:no-floating-promises
     this.view.myPubkeyModule.reevaluateShouldAttachOrNot();

--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -908,6 +908,9 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
       Xss.sanitizePrepend(el, '<img class="lock-icon" src="/img/svgs/locked-icon.svg" />');
       $(el).attr('title', 'Could not verify their encryption setup. You can encrypt the message with a password below. Alternatively, add their pubkey.');
     }
+    // Replace updated recipient in addedRecipients
+    const changedIndex = this.addedRecipients.findIndex((addedRecipient) => addedRecipient.email === recipient.email);
+    this.addedRecipients.splice(changedIndex, 1, recipient);
     this.view.pwdOrPubkeyContainerModule.showHideContainerAndColorSendBtn(); // tslint:disable-line:no-floating-promises
     this.view.myPubkeyModule.reevaluateShouldAttachOrNot();
   };

--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -909,7 +909,7 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
       $(el).attr('title', 'Could not verify their encryption setup. You can encrypt the message with a password below. Alternatively, add their pubkey.');
     }
     // Replace updated recipient in addedRecipients
-    const changedIndex = this.addedRecipients.findIndex((addedRecipient) => addedRecipient.email === recipient.email);
+    const changedIndex = this.addedRecipients.findIndex((addedRecipient) => addedRecipient.email === recipient.email && addedRecipient.id == recipient.id);
     this.addedRecipients.splice(changedIndex, 1, recipient);
     this.view.pwdOrPubkeyContainerModule.showHideContainerAndColorSendBtn(); // tslint:disable-line:no-floating-promises
     this.view.myPubkeyModule.reevaluateShouldAttachOrNot();

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -1547,7 +1547,6 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await composePage.waitAndClick('@action-forward', { delay: 2 });
       await composePage.waitAny('@input-to');
       await composePage.waitUntilFocused('@input-to');
-      await Util.sleep(1000);
       await expectRecipientElements(composePage, { to: [], cc: [], bcc: [] });
     }));
 

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -1542,11 +1542,12 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
     }));
 
     ava.default('compose - reply - CC&BCC test forward', testWithBrowser('compatibility', async (t, browser) => {
-      const appendUrl = 'threadId=16ce2c965c75e5a6&skipClickPrompt=___cu_false___&ignoreDraft=___cu_false___&replyMsgId=16ce2c965c75e5a6';
+      const appendUrl = 'threadId=17d02296bccd4c5c&skipClickPrompt=___cu_false___&ignoreDraft=___cu_false___&replyMsgId=16ce2c965c75e5a6';
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility', { appendUrl, hasReplyPrompt: true });
       await composePage.waitAndClick('@action-forward', { delay: 2 });
       await composePage.waitAny('@input-to');
       await composePage.waitUntilFocused('@input-to');
+      await Util.sleep(1000);
       await expectRecipientElements(composePage, { to: [], cc: [], bcc: [] });
     }));
 

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -1542,7 +1542,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
     }));
 
     ava.default('compose - reply - CC&BCC test forward', testWithBrowser('compatibility', async (t, browser) => {
-      const appendUrl = 'threadId=17d02296bccd4c5c&skipClickPrompt=___cu_false___&ignoreDraft=___cu_false___&replyMsgId=16ce2c965c75e5a6';
+      const appendUrl = 'threadId=16ce2c965c75e5a6&skipClickPrompt=___cu_false___&ignoreDraft=___cu_false___&replyMsgId=16ce2c965c75e5a6';
       const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compatibility', { appendUrl, hasReplyPrompt: true });
       await composePage.waitAndClick('@action-forward', { delay: 2 });
       await composePage.waitAny('@input-to');


### PR DESCRIPTION
This PR re-evaluates pwd prompt when updating of public key in another frame

close #4504 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
