### PR TITLE
use node 16 on semaphore ci (live test)

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -97,9 +97,9 @@ blocks:
           value: /home/semaphore/git/flowcrypt-browser
       prologue:
         commands:
-          - nvm use 12
-          - nvm alias default 12
-          - npm install -g npm@6.14.6 && mkdir ~/git && checkout && mv ~/test-secrets.json ~/git/flowcrypt-browser/test/test-secrets.json
+          - nvm use 16
+          - nvm alias default 16
+          - npm install -g npm@8.11.0 && mkdir ~/git && checkout && mv ~/test-secrets.json ~/git/flowcrypt-browser/test/test-secrets.json
           - cd ~/git/flowcrypt-browser
           - npm install
           - echo "NODE=$(node --version), NPM=$(npm --version), TSC=$( ./node_modules/typescript/bin/tsc --version)"


### PR DESCRIPTION
This PR will adjust semaphore.yml to use node 16 and npm 8.11.0 on semaphore ci 

related issue: https://github.com/FlowCrypt/flowcrypt-deploy/issues/179

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
