### PR TITLE
Allow expired key in manualEnter recipe

### DIFF
--- a/test/source/tests/page-recipe/setup-page-recipe.ts
+++ b/test/source/tests/page-recipe/setup-page-recipe.ts
@@ -21,7 +21,7 @@ type ManualEnterOpts = {
   fillOnly?: boolean,
   isInvalidKey?: boolean | undefined,
   checkEmailAliasIfPresent?: boolean,
-  key?: { title: string, passphrase: string, armored: string | null, longid: string | null, filePath?: string }
+  key?: TestKeyInfoWithFilepath
 };
 
 type CreateKeyOpts = {
@@ -191,6 +191,10 @@ export class SetupPageRecipe extends PageRecipe {
         await settingsPage.page.setOfflineMode(true); // offline mode
       }
       await settingsPage.waitAndClick('@input-step2bmanualenter-save', { delay: 1 });
+      if (key.expired) {
+        await settingsPage.waitAndRespondToModal('confirm', 'confirm', 'You are importing a key that is expired.');
+        await Util.sleep(1);
+      }
       if (fixKey) {
         await settingsPage.waitAll('@input-compatibility-fix-expire-years', { timeout: 30 });
         await settingsPage.selectOption('@input-compatibility-fix-expire-years', '1');

--- a/test/source/tests/setup.ts
+++ b/test/source/tests/setup.ts
@@ -352,6 +352,7 @@ AN8G3r5Htj8olot+jm9mIa5XLXWzMNUZgg==
 -----END PGP PRIVATE KEY BLOCK-----`,
           passphrase: 'correct horse battery staple',
           longid: '123',
+          expired: true
         }
       }, { isSavePassphraseChecked: false, isSavePassphraseHidden: false });
       await SettingsPageRecipe.toggleScreen(settingsPage, 'additional');


### PR DESCRIPTION
This PR allows an expired key in `manualEnter` test recipe,
fixing the broken test `setup - import key - two e-mails on the screen`

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
