### PR TITLE
issue 4348 only send sender email in replyInfoDiv

### DIFF
--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -599,13 +599,13 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       const correctButtonStatusTxt = 'Encrypt, Sign and Send';
       await ComposePageRecipe.showRecipientInput(composePage);
       await composePage.waitAll('@container-cc-bcc-buttons');
-      expect(await composePage.read('@action-send')).to.eq(correctButtonStatusTxt);
+      await composePage.waitForContent('@action-send', correctButtonStatusTxt);
       await composePage.waitAndType(`@input-to`, 'aaaaa\n'); // First enter invalid recipient
-      expect(await composePage.read('@action-send')).to.eq('Re-enter recipient..');
+      await composePage.waitForContent('@action-send', 'Re-enter recipient..');
       await composePage.press('Backspace'); // Delete invalid recipient
-      expect(await composePage.read('@action-send')).to.eq(correctButtonStatusTxt); // check if sent button status is correct
+      await composePage.waitForContent('@action-send', correctButtonStatusTxt); // check if sent button status is correct
       await composePage.waitAndType(`@input-to`, 'mock.only.pubkey@flowcrypt.com\n'); // Now enter correct recipient and check if send button status is correct.
-      expect(await composePage.read('@action-send')).to.eq(correctButtonStatusTxt);
+      await composePage.waitForContent('@action-send', correctButtonStatusTxt);
     }));
 
     ava.default('compose - reply - CC&BCC test reply', testWithBrowser('compatibility', async (t, browser) => {


### PR DESCRIPTION
This PR fixes `replyInfoDiv` format. It was sending `{email: string, name: string}` instead of `string`.

close #4348

----------------------------------

**Tests** _(delete all except exactly one)_:
- I decided not to test this since I'd like to send out update soon and it's not easy to test. I've refactored the code to make it easier to notice this regression in PR code reviews by adding `type ReplyInfoRaw` which must remain stable to work with FES UI. With this in place, the original problem would have been noticed and corrected during development or review.

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
