### PR TITLE
Escape hyphen character

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-footer-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-footer-module.ts
@@ -37,7 +37,7 @@ export class ComposeFooterModule extends ViewModule<ComposeView> {
     if (!footerFirstLine) {
       return '';
     }
-    if (/^[*-_=+#~ ]+$/.test(footerFirstLine)) {
+    if (/^[*\-_=+#~ ]+$/.test(footerFirstLine)) {
       return sanitizedHtmlFooter;  // first line of footer is already a footer separator, made of special characters
     }
     return `--<br>${sanitizedHtmlFooter}`; // create a custom footer separator


### PR DESCRIPTION
This PR escapes a hyphen character. It is to correct the regex to match a character `-` instead of a range between `*` to `_`

close #4674 

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
