### PR TITLE
Fix: compose - pass phrase dialog - dialog cancel mock test

### DIFF
--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -488,7 +488,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
         await passphraseDialog.waitForContent('@passphrase-text', 'Enter FlowCrypt pass phrase to sign email');
         await ComposePageRecipe.cancelPassphraseDialog(inboxPage, inputMethod);
         await Util.sleep(0.5);
-        expect(await composeFrame.read('@action-send')).to.eq('Sign and Send');
+        await composeFrame.waitForContent('@action-send', 'Sign and Send');
       }));
 
       ava.default(`compose - non-primary pass phrase dialog - dialog cancel (${inputMethod})`, testWithBrowser('ci.tests.gmail', async (t, browser) => {


### PR DESCRIPTION
This PR fixed `compose - pass phrase dialog - dialog cancel` mock test

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
