### PR TITLE
Hide password messages' expiry settings for FES users

### DIFF
--- a/extension/chrome/settings/modules/security.htm
+++ b/extension/chrome/settings/modules/security.htm
@@ -54,7 +54,7 @@
       <h3>Password protected messages</h3>
     </div>
     <div class="settings-form-group">
-      <div class="line">
+      <div class="line password_messages_expiry_container display_none">
         Password encrypted messages expire in
         <span class="expiration_container">
           <span class="select_loader_container"></span>

--- a/extension/chrome/settings/modules/security.htm
+++ b/extension/chrome/settings/modules/security.htm
@@ -54,7 +54,7 @@
       <h3>Password protected messages</h3>
     </div>
     <div class="settings-form-group">
-      <div class="line password_messages_expiry_container display_none">
+      <div class="line password_messages_expiry_container display_none" data-test="container-password-messages-expiry">
         Password encrypted messages expire in
         <span class="expiration_container">
           <span class="select_loader_container"></span>

--- a/extension/chrome/settings/modules/security.ts
+++ b/extension/chrome/settings/modules/security.ts
@@ -85,10 +85,13 @@ View.run(class SecurityView extends View {
   private loadAndRenderPwdEncryptedMsgSettings = async () => {
     Xss.sanitizeRender('.select_loader_container', Ui.spinner('green'));
     try {
-      const response = await this.acctServer.accountGetAndUpdateLocalStore();
-      $('.select_loader_container').text('');
-      $('.default_message_expire').val(Number(response.account.default_message_expire).toString()).prop('disabled', false).css('display', 'inline-block');
-      $('.default_message_expire').change(this.setHandler(() => this.onDefaultExpireUserChange()));
+      if (!this.clientConfiguration.usesKeyManager()) {
+        $('.password_messages_expiry_container').show();
+        const response = await this.acctServer.accountGetAndUpdateLocalStore();
+        $('.select_loader_container').text('');
+        $('.default_message_expire').val(Number(response.account.default_message_expire).toString()).prop('disabled', false).css('display', 'inline-block');
+        $('.default_message_expire').change(this.setHandler(() => this.onDefaultExpireUserChange()));
+      }
     } catch (e) {
       if (ApiErr.isAuthErr(e)) {
         Settings.offerToLoginWithPopupShowModalOnErr(this.acctEmail, () => window.location.reload());

--- a/test/source/mock/key-manager/key-manager-endpoints.ts
+++ b/test/source/mock/key-manager/key-manager-endpoints.ts
@@ -267,6 +267,9 @@ export const mockKeyManagerEndpoints: HandlersDefinition = {
       if (acctEmail === 'get.error@key-manager-autogen.flowcrypt.test') {
         throw new Error('Intentional error for get.error to test client behavior');
       }
+      if (acctEmail === 'settings@key-manager-autogen.flowcrypt.test') {
+        return { privateKeys: [{ decryptedPrivateKey: testConstants.existingPrv }] };
+      }
       if (acctEmail === 'settings@settings.flowcrypt.test') {
         return { privateKeys: [{ decryptedPrivateKey: testConstants.existingPrv }] };
       }

--- a/test/source/tests/settings.ts
+++ b/test/source/tests/settings.ts
@@ -1155,6 +1155,26 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
       expect(savedPassphrase2).to.be.an('undefined');
     }));
 
+    ava.default('settings - password messages\' expiry settings shouldn\'t be available for FES users', testWithBrowser('compatibility', async (t, browser) => {
+      const acct1 = 'flowcrypt.compatibility@gmail.com';
+      const settingsPage = await browser.newPage(t, TestUrls.extensionSettings('flowcrypt.compatibility@gmail.com'));
+      const securitySettingsFrame1 = await SettingsPageRecipe.awaitNewPageFrame(settingsPage, '@action-open-security-page', ['security.htm']);
+      expect(await securitySettingsFrame1.isElementVisible('@container-password-messages-expiry')).to.equal(true);
+      await SettingsPageRecipe.closeDialog(settingsPage);
+      await SettingsPageRecipe.toggleScreen(settingsPage, 'additional');
+      const experimentalFrame = await SettingsPageRecipe.awaitNewPageFrame(settingsPage, '@action-open-module-experimental', ['experimental.htm']);
+      await experimentalFrame.waitAndClick('@action-reset-account');
+      await experimentalFrame.waitAndRespondToModal('confirm', 'confirm', `This will remove all your FlowCrypt settings for ${acct1}`);
+      await experimentalFrame.waitAndRespondToModal('confirm', 'confirm', 'Proceed to reset? Don\'t come back telling me I didn\'t warn you.');
+      await settingsPage.close();
+      const acct2 = 'settings@key-manager-autogen.flowcrypt.test';
+      const settingsPage1 = await BrowserRecipe.openSettingsLoginApprove(t, browser, acct2);
+      await SetupPageRecipe.autoSetupWithEKM(settingsPage1);
+      const securitySettingsFrame = await SettingsPageRecipe.awaitNewPageFrame(settingsPage1, '@action-open-security-page', ['security.htm']);
+      expect(await securitySettingsFrame.isElementVisible('@container-password-messages-expiry')).to.equal(false);
+      await settingsPage1.close();
+    }));
+
     ava.default.todo('settings - change passphrase - mismatch curent pp');
 
     ava.default.todo('settings - change passphrase - mismatch new pp');

--- a/test/source/tests/tooling/browser-recipe.ts
+++ b/test/source/tests/tooling/browser-recipe.ts
@@ -25,7 +25,7 @@ export class BrowserRecipe {
   };
 
   public static openSettingsLoginApprove = async (t: AvaContext, browser: BrowserHandle, acctEmail: string) => {
-    const settingsPage = await browser.newPage(t, TestUrls.extensionSettings());
+    const settingsPage = await browser.newPage(t, TestUrls.extensionSettings(acctEmail));
     const oauthPopup = await browser.newPageTriggeredBy(t, () => settingsPage.waitAndClick('@action-connect-to-gmail'));
     await OauthPageRecipe.google(t, oauthPopup, acctEmail, 'approve');
     return settingsPage;


### PR DESCRIPTION
This PR fixes issues on #4739 by hiding the password messages' expiry settings for FES users.

close #4739  // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
