### PR TITLE
#4813 fix: move `compose - test compose after reconnect` test to flaky group

### DIFF
--- a/test/source/test.ts
+++ b/test/source/test.ts
@@ -32,8 +32,8 @@ process.setMaxListeners(60);
 const consts = { // higher concurrency can cause 429 google errs when composing
   TIMEOUT_SHORT: minutes(1),
   TIMEOUT_EACH_RETRY: minutes(3),
-  TIMEOUT_ALL_RETRIES: minutes(18), // this has to suffer waiting for semaphore between retries, thus almost the same as below
-  TIMEOUT_OVERALL: minutes(19),
+  TIMEOUT_ALL_RETRIES: minutes(25), // this has to suffer waiting for semaphore between retries, thus almost the same as below
+  TIMEOUT_OVERALL: minutes(20),
   ATTEMPTS: testGroup === 'STANDARD-GROUP' ? oneIfNotPooled(3) : process.argv.includes('--retry=false') ? 1 : 3,
   POOL_SIZE: oneIfNotPooled(isMock ? 20 : 3),
   PROMISE_TIMEOUT_OVERALL: undefined as unknown as Promise<never>, // will be set right below

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -429,21 +429,6 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       ].join('\n'));
     }));
 
-    ava.default('compose - test compose after reconnect account', testWithBrowser('ci.tests.gmail', async (t, browser) => {
-      const acct = 'ci.tests.gmail@flowcrypt.test';
-      const composePage = await ComposePageRecipe.openStandalone(t, browser, 'compose');
-      await Util.wipeGoogleTokensUsingExperimentalSettingsPage(t, browser, acct);
-      await ComposePageRecipe.showRecipientInput(composePage);
-      const subject = 'PWD encrypted message after reconnect account';
-      await ComposePageRecipe.fillMsg(composePage, { to: 'test@email.com' }, subject);
-      await composePage.waitAndType('@input-password', 'gO0d-pwd');
-      await composePage.waitAndClick('@action-send', { delay: 1 });
-      const oauthPopup = await browser.newPageTriggeredBy(t, () => composePage.waitAndRespondToModal('confirm', 'confirm', 'Please log in with FlowCrypt to continue'));
-      await OauthPageRecipe.google(t, oauthPopup, acct, 'approve');
-      await ComposePageRecipe.closed(composePage);
-      expect((await GoogleData.withInitializedData(acct)).searchMessagesBySubject(subject).length).to.equal(1);
-    }));
-
     for (const inputMethod of ['mouse', 'keyboard']) {
 
       ava.default(`compose - reply - pass phrase dialog - dialog ok (${inputMethod})`, testWithBrowser('compatibility', async (t, browser) => {


### PR DESCRIPTION
This PR move `compose - test compose after reconnect` test to flaky group

close #4813 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
