### PR TITLE
#4771 Better ux for disabled password messages

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-err-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-err-module.ts
@@ -151,7 +151,7 @@ export class ComposeErrModule extends ViewModule<ComposeView> {
     }
   };
 
-  public throwIfEncryptionPasswordInvalid = async ({ subject, pwd }: { subject: string, pwd?: string }) => {
+  public throwIfEncryptionPasswordInvalidOrDisabled = async ({ subject, pwd }: { subject: string, pwd?: string }) => {
     // When DISABLE_FLOWCRYPT_HOSTED_PASSWORD_MESSAGES present, and recipients are missing a public key, and the user is using flowcrypt.com/api (not FES)
     if (this.view.clientConfiguration.shouldDisablePasswordMessages() && !this.view.isFesUsed()) {
       throw new ComposerUserError(Lang.compose.addMissingRecipientPubkeys);

--- a/extension/chrome/elements/compose-modules/compose-err-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-err-module.ts
@@ -152,6 +152,10 @@ export class ComposeErrModule extends ViewModule<ComposeView> {
   };
 
   public throwIfEncryptionPasswordInvalid = async ({ subject, pwd }: { subject: string, pwd?: string }) => {
+    // When DISABLE_FLOWCRYPT_HOSTED_PASSWORD_MESSAGES present, and recipients are missing a public key, and the user is using flowcrypt.com/api (not FES)
+    if (this.view.clientConfiguration.shouldDisablePasswordMessages() && !this.view.isFesUsed()) {
+      throw new ComposerUserError(Lang.compose.addMissingRecipientPubkeys);
+    }
     if (pwd) {
       if (await this.view.storageModule.isPwdMatchingPassphrase(pwd)) {
         throw new ComposerUserError('Please do not use your private key pass phrase as a password for this message.\n\n' +

--- a/extension/chrome/elements/compose-modules/compose-pwd-or-pubkey-container-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-pwd-or-pubkey-container-module.ts
@@ -24,27 +24,27 @@ export class ComposePwdOrPubkeyContainerModule extends ViewModule<ComposeView> {
   }
 
   public setHandlers = () => {
-    this.view.S.cached('input_password').keyup(this.view.setHandlerPrevent('spree', () => this.showHideContainerAndColorSendBtn()));
-    this.view.S.cached('input_password').focus(this.view.setHandlerPrevent('spree', () => this.inputPwdFocusHandler()));
-    this.view.S.cached('input_password').blur(this.view.setHandler(() => this.inputPwdBlurHandler()));
-    this.view.S.cached('expiration_note').find('#expiration_note_settings_link').on('click', this.view.setHandler(async (el, e) => {
-      e.preventDefault();
-      await this.view.renderModule.openSettingsWithDialog('security');
-    }, this.view.errModule.handle(`render settings dialog`)));
+    this.view.S.cached('input_password').on('focus', this.view.setHandlerPrevent('spree', () => this.inputPwdFocusHandler()));
+    this.view.S.cached('input_password').on('blur', this.view.setHandler(() => this.inputPwdBlurHandler()));
+    this.view.S.cached('expiration_note').find('#expiration_note_settings_link').on(
+      'click',
+      this.view.setHandler(async (el, e) => {
+        e.preventDefault();
+        await this.view.renderModule.openSettingsWithDialog('security');
+      }, this.view.errModule.handle(`render settings dialog`))
+    );
   };
 
   public inputPwdFocusHandler = () => {
     const passwordContainerHeight = this.view.S.cached('password_or_pubkey').outerHeight() || 0;
     this.view.S.cached('expiration_note').css({ bottom: passwordContainerHeight });
     this.view.S.cached('expiration_note').fadeIn();
-    this.showHideContainerAndColorSendBtn(); // tslint:disable-line:no-floating-promises
   };
 
   public inputPwdBlurHandler = () => {
     Catch.setHandledTimeout(() => { // timeout here is needed so <a> will be visible once clicked
       this.view.S.cached('expiration_note').fadeOut();
     }, 100);
-    this.showHideContainerAndColorSendBtn(); // tslint:disable-line:no-floating-promises
   };
 
   public showHideContainerAndColorSendBtn = async () => {
@@ -122,11 +122,6 @@ export class ComposePwdOrPubkeyContainerModule extends ViewModule<ComposeView> {
     if (!this.isVisible()) {
       await this.initExpirationText();
       this.view.S.cached('password_or_pubkey').css('display', 'table-row');
-    }
-    if (this.view.S.cached('input_password').val() || this.view.S.cached('input_password').is(':focus')) {
-      this.view.S.cached('input_password').attr('placeholder', '');
-    } else {
-      this.view.S.cached('input_password').attr('placeholder', 'message password');
     }
     if (isPasswordMessageDisabled) {
       this.view.S.cached('password_input_container').hide();

--- a/extension/chrome/elements/compose-modules/compose-pwd-or-pubkey-container-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-pwd-or-pubkey-container-module.ts
@@ -55,7 +55,9 @@ export class ComposePwdOrPubkeyContainerModule extends ViewModule<ComposeView> {
     if (!this.view.recipientsModule.getRecipients().length || !this.view.sendBtnModule.popover.choices.encrypt) {
       this.hideMsgPwdUi(); // Hide 'Add Pasword' prompt if there are no recipients or message is not encrypted
       this.view.sendBtnModule.enableBtn();
-    } else if (this.view.recipientsModule.getRecipients().find(r => [RecipientStatus.NO_PGP, RecipientStatus.REVOKED].includes(r.status))) {
+    } else if (this.view.recipientsModule.getRecipients().find(r => [RecipientStatus.NO_PGP, RecipientStatus.REVOKED].includes(r.status))
+      && !(this.view.clientConfiguration.shouldDisablePasswordMessages() && !this.view.isFesUsed())
+    ) {
       await this.showMsgPwdUiAndColorBtn(
         this.view.recipientsModule.getRecipients().some(r => r.status === RecipientStatus.NO_PGP),
         this.view.recipientsModule.getRecipients().some(r => r.status === RecipientStatus.REVOKED),

--- a/extension/chrome/elements/compose-modules/formatters/general-mail-formatter.ts
+++ b/extension/chrome/elements/compose-modules/formatters/general-mail-formatter.ts
@@ -44,7 +44,7 @@ export class GeneralMailFormatter {
     // encrypt (optionally sign)
     const singleFamilyKeys = await view.storageModule.collectSingleFamilyKeys(recipientsEmails, newMsgData.from.email, choices.sign);
     if (singleFamilyKeys.emailsWithoutPubkeys.length) {
-      await view.errModule.throwIfEncryptionPasswordInvalid(newMsgData);
+      await view.errModule.throwIfEncryptionPasswordInvalidOrDisabled(newMsgData);
     }
     let signingKey: ParsedKeyInfo | undefined;
     if (choices.sign) {

--- a/extension/chrome/elements/compose.htm
+++ b/extension/chrome/elements/compose.htm
@@ -173,7 +173,8 @@
             <div class="warning_nopgp"> or ask them to get FlowCrypt.</div>
             <div class="password_input_container" data-test="password-input-container">
               Or send email password protected:
-              <input id="input_password" autocomplete="off" placeholder="" tabindex="5" data-test="input-password">
+              <input id="input_password" autocomplete="off" placeholder="message password" tabindex="5"
+                data-test="input-password">
             </div>
           </div>
         </td>

--- a/extension/chrome/elements/compose.htm
+++ b/extension/chrome/elements/compose.htm
@@ -60,13 +60,13 @@
       <tr id="recipients_row">
         <td class="flex">
           <div class="reply-container">
-              <div id="reply-options-container" class="reply-options-container" data-test="container-reply-options">
-              </div>
-              <button id="toggle_reply_options" class="action-show-reply-options-popover button" title="More reply options"
-                  tabindex="0" data-test="action-show-reply-options-popover">
-                  <img class="reply-options-icon" src="/img/reply-icon.png">
-                  <div class="icon-chevron"></div>
-              </button>
+            <div id="reply-options-container" class="reply-options-container" data-test="container-reply-options">
+            </div>
+            <button id="toggle_reply_options" class="action-show-reply-options-popover button"
+              title="More reply options" tabindex="0" data-test="action-show-reply-options-popover">
+              <img class="reply-options-icon" src="/img/reply-icon.png">
+              <div class="icon-chevron"></div>
+            </button>
           </div>
           <div class="input recipients-inputs flex-1">
             <div id="input_addresses_container" class="invisible">
@@ -80,8 +80,8 @@
                 <span class="recipient-left-label">To</span>
                 <div class="input-right-container">
                   <span class="recipients recipients-to"></span>
-                  <input id="input_to" spellcheck="false" tabindex="1" data-test="input-to"
-                    data-sending-type="to" autocomplete="off" />
+                  <input id="input_to" spellcheck="false" tabindex="1" data-test="input-to" data-sending-type="to"
+                    autocomplete="off" />
                   <span class="container-cc-bcc-buttons" data-test="container-cc-bcc-buttons">
                     <button id="cc" class="cc" tabindex="20" data-test="action-show-cc">cc</button>
                     <button id="bcc" class="bcc" tabindex="21" data-test="action-show-bcc">bcc</button>
@@ -89,22 +89,24 @@
                 </div>
               </div>
               <!-- cc -->
-              <div id="input-container-cc" class="input-container" style="display: none;" data-sending-type="cc" data-test="container-cc">
+              <div id="input-container-cc" class="input-container" style="display: none;" data-sending-type="cc"
+                data-test="container-cc">
                 <span class="recipient-left-label">Cc</span>
                 <div class="input-right-container">
                   <span class="recipients recipients-cc"></span>
                   <input spellcheck="false" tabindex="1" data-test="input-cc" data-sending-type="cc"
                     autocomplete="off" />
-                  </div>
+                </div>
               </div>
               <!-- bcc -->
-              <div id="input-container-bcc" class="input-container" style="display: none;" data-test="container-bcc" data-sending-type="bcc">
+              <div id="input-container-bcc" class="input-container" style="display: none;" data-test="container-bcc"
+                data-sending-type="bcc">
                 <span class="recipient-left-label">Bcc</span>
                 <div class="input-right-container">
                   <span class="recipients recipients-bcc"></span>
                   <input spellcheck="false" tabindex="1" data-test="input-bcc" data-sending-type="bcc"
                     autocomplete="off" />
-                  </div>
+                </div>
               </div>
             </div>
             <div id="recipients_placeholder" class="collapsed" data-test="action-show-container-cc-bcc-buttons"
@@ -118,7 +120,8 @@
       <tr id="section_subject">
         <td class="input">
           <!-- subject -->
-          <input id="input_subject" autocomplete="off" spellcheck="true" tabindex="2" placeholder="Subject" data-test="input-subject" />
+          <input id="input_subject" autocomplete="off" spellcheck="true" tabindex="2" placeholder="Subject"
+            data-test="input-subject" />
         </td>
       </tr>
       <tr class="intro_container">
@@ -146,18 +149,32 @@
       <tr id="password_or_pubkey_container" data-test="password-or-pubkey-container">
         <td>
           <div id="expiration_note">
-            Recipient will have access to this message <a href="#" id="expiration_note_settings_link">for <span id="expiration_note_message_expire">(loading)</span></a>. You are responsible for sharing this password with them (use other medium to share the password - not email).
-            <br /> <br /><span id="password-policy-container"></span><br /><br />
+            Recipient will have access to this message
+            <a href="#" id="expiration_note_settings_link">
+              for
+              <span id="expiration_note_message_expire">(loading)</span>
+            </a>
+            . You are responsible for sharing this password with them (use other medium to share the password - not
+            email).
+            <br /> <br />
+            <span id="password-policy-container"></span>
+            <br /><br />
             (Messages sent to FlowCrypt users don't expire this way and don't need password exchange)
           </div>
           <div>
-            <div class="warning_nopgp" data-test="warning-nopgp">emails <span class="grey">in grey</span> don't use encryption </div>
-            <div class="warning_revoked" data-test="warning-revoked">emails <span class="orange">in orange</span> have expired or revoked key</div>
-            <br /><a href="#" class="add_pubkey" data-test="action-open-add-pubkey-dialog">Add their Public Key</a>
+            <div class="warning_nopgp" data-test="warning-nopgp">
+              emails <span class="grey">in grey</span> don't use encryption
+            </div>
+            <div class="warning_revoked" data-test="warning-revoked">
+              emails <span class="orange">in orange</span> have expired or revoked key
+            </div>
+            <br />
+            <a href="#" class="add_pubkey" data-test="action-open-add-pubkey-dialog">Add their Public Key</a>
             <div class="warning_nopgp"> or ask them to get FlowCrypt.</div>
-            <br />Or send email password protected:
-            <div class="password_input_container"><input id="input_password" autocomplete="off" placeholder="" tabindex="5"
-                data-test="input-password"></div>
+            <div class="password_input_container" data-test="password-input-container">
+              Or send email password protected:
+              <input id="input_password" autocomplete="off" placeholder="" tabindex="5" data-test="input-password">
+            </div>
           </div>
         </td>
       </tr>
@@ -177,10 +194,11 @@
           <div class="icon attach" id="fineuploader_button"><img src="/img/svgs/paperclip-icon.svg" class="attach-file"
               alt="Attach File"></div>
           <div id="send_btn_note" data-test="send-btn-note"></div>
-          <button class="icon right delete_draft" tabindex="11" title="Delete draft"><img src="/img/svgs/trash-can-icon.svg"
-              class="delete-draft" alt="Delete Email"></button>
-          <button class="icon right action_include_pubkey" data-test="action-include-pubkey" tabindex="10" title="Include your Public Key"><i
-              alt="pubkey"></i></button>
+          <button class="icon right delete_draft" tabindex="11" title="Delete draft">
+            <img src="/img/svgs/trash-can-icon.svg" class="delete-draft" alt="Delete Email">
+          </button>
+          <button class="icon right action_include_pubkey" data-test="action-include-pubkey" tabindex="10"
+            title="Include your Public Key"><i alt="pubkey"></i></button>
         </td>
       </tr>
     </table>

--- a/extension/chrome/elements/compose.ts
+++ b/extension/chrome/elements/compose.ts
@@ -216,6 +216,7 @@ export class ComposeView extends View {
     this.draftModule.setHandlers(); // must be the last one so that 'onRecipientAdded/draftSave' to works properly
   };
 
+  public isFesUsed = () => Boolean(this.fesUrl);
 }
 
 View.run(ComposeView);

--- a/extension/chrome/elements/compose.ts
+++ b/extension/chrome/elements/compose.ts
@@ -95,7 +95,7 @@ export class ComposeView extends View {
     add_their_pubkey: '.add_pubkey',
     intro_container: '.intro_container',
     password_or_pubkey: '#password_or_pubkey_container',
-    password_label: '.label_password',
+    password_input_container: '.password_input_container',
     warning_nopgp: '.warning_nopgp',
     warning_revoked: '.warning_revoked',
     send_btn_note: '#send_btn_note',

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -2260,6 +2260,8 @@ table#compose tr#password_or_pubkey_container td {
 }
 table#compose tr#password_or_pubkey_container td input#input_password::placeholder { color: #d14836; }
 
+table#compose tr#password_or_pubkey_container td input#input_password:focus::placeholder { color: transparent; }
+
 table#compose tr#password_or_pubkey_container td input {
   padding-left: 3px;
   padding-right: 3px;

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -2276,17 +2276,6 @@ table#compose tr#password_or_pubkey_container td input#input_password {
   text-align: center;
 }
 
-table#compose tr#password_or_pubkey_container td .label_password {
-  position: absolute;
-  margin-left: 10px;
-  margin-top: 22px;
-  font-size: 10px;
-  text-transform: uppercase;
-  color: #777;
-  display: none;
-  animation: fadeInDown 0.5s;
-}
-
 table#compose tr#password_or_pubkey_container td .grey {
   padding: 1px 5px;
   background: #989898;

--- a/extension/js/common/client-configuration.ts
+++ b/extension/js/common/client-configuration.ts
@@ -9,7 +9,7 @@ import { UnreportableError } from './platform/catch.js';
 
 type ClientConfiguration$flag = 'NO_PRV_CREATE' | 'NO_PRV_BACKUP' | 'PRV_AUTOIMPORT_OR_AUTOGEN' | 'PASS_PHRASE_QUIET_AUTOGEN' |
   'ENFORCE_ATTESTER_SUBMIT' | 'NO_ATTESTER_SUBMIT' | 'SETUP_ENSURE_IMPORTED_PRV_MATCH_LDAP_PUB' |
-  'DEFAULT_REMEMBER_PASS_PHRASE' | 'HIDE_ARMOR_META' | 'FORBID_STORING_PASS_PHRASE';
+  'DEFAULT_REMEMBER_PASS_PHRASE' | 'HIDE_ARMOR_META' | 'FORBID_STORING_PASS_PHRASE' | 'DISABLE_FLOWCRYPT_HOSTED_PASSWORD_MESSAGES';
 
 export type ClientConfigurationJson = {
   flags?: ClientConfiguration$flag[],
@@ -216,6 +216,14 @@ export class ClientConfiguration {
    */
   public shouldHideArmorMeta = (): boolean => {
     return (this.clientConfigurationJson.flags || []).includes('HIDE_ARMOR_META');
+  };
+
+  /**
+   * with this option and recipients are missing a public key, and the user is using flowcrypt.com/api (not FES)
+   * it will not give the user option to enter a message password, as if that functionality didn't exist.
+   */
+  public shouldDisablePasswordMessages = (): boolean => {
+    return (this.clientConfigurationJson.flags || []).includes('DISABLE_FLOWCRYPT_HOSTED_PASSWORD_MESSAGES');
   };
 
 }

--- a/extension/js/common/lang.ts
+++ b/extension/js/common/lang.ts
@@ -74,6 +74,7 @@ export const Lang = { // tslint:disable-line:variable-name
   },
   compose: {
     abortSending: 'A message is currently being sent. Closing the compose window may abort sending the message.\nAbort sending?',
+    addMissingRecipientPubkeys: `Some recipients don't have encryption set up. Please import their public keys or ask them to install Flowcrypt.`,
     pleaseReconnectAccount: 'Please reconnect FlowCrypt to your Gmail Account. This is typically needed after a long time of no use, a password change, or similar account changes. ',
     msgEncryptedHtml: (lang: string, senderEmail: string) => (lang === 'DE') ? `${senderEmail}&nbsp;hat&nbsp;Ihnen&nbsp;eine&nbsp;passwortverschlüsselte&nbsp;E-Mail&nbsp;gesendet ` : `${senderEmail}&nbsp;has&nbsp;sent&nbsp;you&nbsp;a&nbsp;password-encrypted&nbsp;email `,
     msgEncryptedText: (lang: string, senderEmail: string) => (lang === 'DE') ? `${senderEmail} hat Ihnen eine passwortverschlüsselte E-Mail gesendet. Folgen Sie diesem Link, um es zu öffnen: ` : `${senderEmail} has sent you a password-encrypted email. Follow this link to open it: `,

--- a/test/source/mock/backend/backend-data.ts
+++ b/test/source/mock/backend/backend-data.ts
@@ -152,6 +152,9 @@ export class BackendData {
     if (domain === 'key-manager-autoimport-no-prv-create.flowcrypt.test') {
       return { ...keyManagerAutogenRules, flags: [...keyManagerAutogenRules.flags, 'NO_PRV_CREATE'] };
     }
+    if (domain === 'key-manager-disabled-password-message.flowcrypt.test') {
+      return { ...keyManagerAutogenRules, flags: [...keyManagerAutogenRules.flags, 'DISABLE_FLOWCRYPT_HOSTED_PASSWORD_MESSAGES'] };
+    }
     if (domain === 'key-manager-autoimport-no-prv-create-no-attester-submit.flowcrypt.test') {
       return { ...keyManagerAutogenRules, flags: [...keyManagerAutogenRules.flags, 'NO_PRV_CREATE', 'NO_ATTESTER_SUBMIT'] };
     }

--- a/test/source/mock/key-manager/key-manager-endpoints.ts
+++ b/test/source/mock/key-manager/key-manager-endpoints.ts
@@ -229,6 +229,9 @@ export const mockKeyManagerEndpoints: HandlersDefinition = {
       if (acctEmail === 'get.key@key-manager-autogen.flowcrypt.test') {
         return { privateKeys: [{ decryptedPrivateKey: testConstants.existingPrv }] };
       }
+      if (acctEmail === 'user@key-manager-disabled-password-message.flowcrypt.test') {
+        return { privateKeys: [{ decryptedPrivateKey: testConstants.existingPrv }] };
+      }
       if (acctEmail.includes('updating.key')) {
         const { response, badRequestError } = MOCK_KM_KEYS[acctEmail];
         if (response !== undefined && badRequestError === undefined) {

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -130,7 +130,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       await SetupPageRecipe.autoSetupWithEKM(settingsPage);
       const composePage = await ComposePageRecipe.openStandalone(t, browser, acct);
       await ComposePageRecipe.fillMsg(composePage, { to: 'test@gmail.com' }, 'should disable flowcrypt hosted password protected message');
-      await composePage.notPresent('@password-or-pubkey-container');
+      await composePage.notPresent('@password-input-container');
       await composePage.waitAndClick('@action-send', { delay: 1 });
       await PageRecipe.waitForModalAndRespond(composePage, 'error', {
         contentToCheck: `Some recipients don't have encryption set up. Please import their public keys or ask them to install Flowcrypt.`,

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -124,6 +124,20 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
       });
     }));
 
+    ava.default('user@key-manager-disabled-password-message.flowcrypt.test - disabled flowcrypt hosted password protected messages', testWithBrowser(undefined, async (t, browser) => {
+      const acct = 'user@key-manager-disabled-password-message.flowcrypt.test';
+      const settingsPage = await BrowserRecipe.openSettingsLoginApprove(t, browser, acct);
+      await SetupPageRecipe.autoSetupWithEKM(settingsPage);
+      const composePage = await ComposePageRecipe.openStandalone(t, browser, acct);
+      await ComposePageRecipe.fillMsg(composePage, { to: 'test@gmail.com' }, 'should disable flowcrypt hosted password protected message');
+      await composePage.notPresent('@password-or-pubkey-container');
+      await composePage.waitAndClick('@action-send', { delay: 1 });
+      await PageRecipe.waitForModalAndRespond(composePage, 'error', {
+        contentToCheck: `Some recipients don't have encryption set up. Please import their public keys or ask them to install Flowcrypt.`,
+        clickOn: 'confirm'
+      });
+    }));
+
     ava.default('compose - signed with entered pass phrase + will remember pass phrase in session', testWithBrowser('ci.tests.gmail', async (t, browser) => {
       const k = Config.key('ci.tests.gmail');
       const settingsPage = await browser.newPage(t, TestUrls.extensionSettings('ci.tests.gmail@flowcrypt.test'));


### PR DESCRIPTION
This PR introduces DISABLE_FLOWCRYPT_HOSTED_PASSWORD_MESSAGES client configuration flag.
When this flag is present & recipient pub keys are missing & don't use FES, treat like password protected message feature is not there.

close #4771 // if this PR closes an issue

![image](https://user-images.githubusercontent.com/23335944/206152216-515ed06e-7e1d-4aac-9c6c-18e7b0ff28a1.png)

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
