### PR TITLE
change passphrase length limit

### DIFF
--- a/extension/chrome/elements/backup.htm
+++ b/extension/chrome/elements/backup.htm
@@ -16,7 +16,7 @@
     <div class="line">This backup is protected by your pass phrase. Please make sure
       to note your pass phrase down or you may lose access to your encrypted emails!</div>
     <div class="line">
-      <input class="input_pass_phrase" type="password" id="pass_phrase" placeholder="Enter your pass phrase..." maxlength="1000" />
+      <input class="input_pass_phrase" type="password" id="pass_phrase" placeholder="Enter your pass phrase..." maxlength="256" />
       <button class="button green action_test_pass">Test your Passphrase</button>
     </div>
     <div class="line fingerprints hide_if_compact">Key Fingerprint: <span class="fingerprint good"></span></div>

--- a/extension/chrome/elements/passphrase.htm
+++ b/extension/chrome/elements/passphrase.htm
@@ -23,7 +23,7 @@
     <div class="separator"></div>
     <div class="line which_key" data-test="which-key" style="display: none;"></div>
     <div class="line">
-      <input type="text" placeholder="Enter Pass Phrase" id="passphrase" data-test="input-pass-phrase" maxlength="1000">
+      <input type="text" placeholder="Enter Pass Phrase" id="passphrase" data-test="input-pass-phrase" maxlength="256">
     </div>
     <div class="line">
       <button class="button long green action_ok" data-test="action-confirm-pass-phrase-entry">OK</button>

--- a/extension/chrome/settings/modules/add_key.htm
+++ b/extension/chrome/settings/modules/add_key.htm
@@ -60,7 +60,7 @@
           .
         </div>
         <div class="line">
-          <input id="input_passphrase" class="input_passphrase" type="text" placeholder="Private Key Passphrase" maxlength="1000" />
+          <input id="input_passphrase" class="input_passphrase" type="text" placeholder="Private Key Passphrase" maxlength="256" />
         </div>
         <div class="line">
           <label class="input_passphrase_save_label hidden" data-test="input-save-passphrase-label">

--- a/extension/chrome/settings/modules/change_passphrase.htm
+++ b/extension/chrome/settings/modules/change_passphrase.htm
@@ -21,7 +21,7 @@
     <div id="step_0_enter_current" class="display_none">
       <div class="line sentence">Enter your current pass phrase</div>
       <div class="line">
-        <input id="current_pass_phrase" type="text" placeholder="Current pass phrase" data-test="input-current-pp" maxlength="1000" />
+        <input id="current_pass_phrase" type="text" placeholder="Current pass phrase" data-test="input-current-pp" maxlength="256" />
       </div>
       <div class="line">
         <button class="button long green action_test_current_passphrase" data-test="action-confirm-current-pp">continue
@@ -33,7 +33,7 @@
       <div class="line ">See <a href="#" data-swal-page="/chrome/texts/passphrase_help.htm">choosing secure pass
           phrases</a>.</div>
       <div class="line">
-        <input id="new_pass_phrase" type="text" placeholder="Enter a new pass phrase" data-test="input-new-pp" maxlength="1000" />
+        <input id="new_pass_phrase" type="text" placeholder="Enter a new pass phrase" data-test="input-new-pp" maxlength="256" />
       </div>
       <div class="line">
         <button class="button long gray action_set_pass_phrase" data-test="action-show-confirm-new-pp">SET PASS PHRASE
@@ -45,7 +45,7 @@
     <div id="step_2_confirm_new" class="display_none">
       <div class="line">Please repeat it one more time. Make sure to note the pass phrase down.</div>
       <div class="line">
-        <input id="new_pass_phrase_confirm" type="text" placeholder="Repeat pass phrase" data-test="input-confirm-new-pp" maxlength="1000" />
+        <input id="new_pass_phrase_confirm" type="text" placeholder="Repeat pass phrase" data-test="input-confirm-new-pp" maxlength="256" />
       </div>
       <div class="line">
         <button class="button long green action_change" data-test="action-confirm-new-pp">CONFIRM PASS PHRASE</button>

--- a/extension/chrome/settings/modules/compatibility.htm
+++ b/extension/chrome/settings/modules/compatibility.htm
@@ -24,7 +24,7 @@
     </div>
 
     <div class="line left">
-      <input id="input_passphrase" class="input_passphrase" type="password" placeholder="Private Key Passphrase" style="height: 37px !important;" maxlength="1000" />
+      <input id="input_passphrase" class="input_passphrase" type="password" placeholder="Private Key Passphrase" style="height: 37px !important;" maxlength="256" />
       <button class="button green large action_test_key" style="float: right;">test compatibility</button>
     </div>
 

--- a/extension/chrome/settings/modules/my_key.htm
+++ b/extension/chrome/settings/modules/my_key.htm
@@ -40,7 +40,7 @@
         class="action_download_revocation_cert display_none" data-test="action-revoke-certificate">revocation certificate</a>
     </div>
     <div class="line enter_pp" style="display: none;">
-      <input id="input_passphrase" type="text" placeholder="Enter your pass phrase" maxlength="1000" />
+      <input id="input_passphrase" type="text" placeholder="Enter your pass phrase" maxlength="256" />
     </div>
     <div class="line enter_pp" style="display: none;">
       <button class="button green action_continue_download">download</button>

--- a/extension/chrome/settings/modules/my_key_update.htm
+++ b/extension/chrome/settings/modules/my_key_update.htm
@@ -28,7 +28,7 @@
     </div>
     <div class="line">
       <input class="input_passphrase" type="password" data-test="input-passphrase"
-        placeholder="Private Key Passphrase" maxlength="1000"/>
+        placeholder="Private Key Passphrase" maxlength="256"/>
     </div>
     <div class="line"><span class="button green long action_update_private_key" data-test="action-update-key">update
         private key</span></div>

--- a/extension/chrome/settings/modules/security.htm
+++ b/extension/chrome/settings/modules/security.htm
@@ -41,7 +41,7 @@
       </div>
       <div class="line passphrase_entry_container" style="display: none;">
         <input type="text" id="passphrase_entry" placeholder="Enter pass phrase to confirm"
-          data-test="input-confirm-pass-phrase" maxlength="1000" />
+          data-test="input-confirm-pass-phrase" maxlength="256" />
       </div>
       <div class="line passphrase_entry_container" style="display: none;">
         <button class="button green confirm_passphrase_requirement_change"

--- a/extension/chrome/settings/modules/test_passphrase.htm
+++ b/extension/chrome/settings/modules/test_passphrase.htm
@@ -22,7 +22,7 @@
     <div class="line">We <b class="red">STRONGLY</b> encourage you to check that you remember your passphrase
       correctly.</div>
     <div class="line">
-      <input id="password" type="text" placeholder="Your pass phrase" data-test="input-test-passphrase" maxlength="1000" />
+      <input id="password" type="text" placeholder="Your pass phrase" data-test="input-test-passphrase" maxlength="256" />
     </div>
     <div class="line">
       <button class="button green long action_verify" data-test="action-test-passphrase">VERIFY</button>

--- a/extension/chrome/settings/setup.htm
+++ b/extension/chrome/settings/setup.htm
@@ -110,10 +110,10 @@
           data-swal-page="/chrome/texts/passphrase_help.htm">choosing
           secure pass phrases</a></div>
       <div class="line left">
-        <input class="input_password" type="text" placeholder="Pass phrase" style="margin-bottom: 0;" id="step_2a_manual_create_input_password" data-test="input-step2bmanualcreate-passphrase-1" maxlength="1000" />
+        <input class="input_password" type="text" placeholder="Pass phrase" style="margin-bottom: 0;" id="step_2a_manual_create_input_password" data-test="input-step2bmanualcreate-passphrase-1" maxlength="256" />
       </div>
       <div class="line left">
-        <input class="input_password2" type="text" placeholder="Repeat pass phrase" id="step_2a_manual_create_input_password2" data-test="input-step2bmanualcreate-passphrase-2" maxlength="1000" />
+        <input class="input_password2" type="text" placeholder="Repeat pass phrase" id="step_2a_manual_create_input_password2" data-test="input-step2bmanualcreate-passphrase-2" maxlength="256" />
       </div>
 
       <div class="line left">
@@ -195,7 +195,7 @@
               a random one</a>.
           </div>
           <div class="line left">
-            <input class="input_passphrase" type="text" placeholder="Private Key Passphrase" id="step_2b_manual_enter_passphrase" data-test="input-step2bmanualenter-passphrase" maxlength="1000" />
+            <input class="input_passphrase" type="text" placeholder="Private Key Passphrase" id="step_2b_manual_enter_passphrase" data-test="input-step2bmanualenter-passphrase" maxlength="256" />
           </div>
           <div class="line left">
             <label class="input_passphrase_save_label hidden" data-test="input-step2bmanualenter-save-passphrase-label">
@@ -231,10 +231,10 @@
           data-swal-page="/chrome/texts/passphrase_help.htm">choosing
           secure pass phrases</a></div>
       <div class="line">
-        <input class="input_password" type="text" placeholder="Pass phrase" id="step_2_ekm_input_password" data-test="input-step2ekm-passphrase-1" maxlength="1000" />
+        <input class="input_password" type="text" placeholder="Pass phrase" id="step_2_ekm_input_password" data-test="input-step2ekm-passphrase-1" maxlength="256" />
       </div>
       <div class="line">
-        <input class="input_password2" type="text" placeholder="Repeat pass phrase" data-test="input-step2ekm-passphrase-2" id="step_2_ekm_input_password2" maxlength="1000" />
+        <input class="input_password2" type="text" placeholder="Repeat pass phrase" data-test="input-step2ekm-passphrase-2" id="step_2_ekm_input_password2" maxlength="256" />
       </div>
 
       <div class="line">
@@ -254,7 +254,7 @@
       <div class="line recovery_status">Found <span class="backups_count_words"></span> of your account key. Enter your
         pass phrase to continue.</div>
       <div class="wide line recovery_passphrase_container">
-        <input type="text" id="recovery_password" placeholder="Enter your pass phrase" data-test="input-recovery-pass-phrase" maxlength="1000" />
+        <input type="text" id="recovery_password" placeholder="Enter your pass phrase" data-test="input-recovery-pass-phrase" maxlength="256" />
       </div>
       <div class="wide line">
         <button class="button green longer action_recover_account" data-test="action-recover-account">RECOVER ACCOUNT</button>


### PR DESCRIPTION
This PR changes the passphrase length limit to `256` which also fixes the app crash when a user pastes a long string on the passphrase field where the extension evaluates the passphrase complexity.

close #4835 

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
