### PR TITLE
Add external-service to allowed FES service values

### DIFF
--- a/extension/js/common/api/account-servers/enterprise-server.ts
+++ b/extension/js/common/api/account-servers/enterprise-server.ts
@@ -57,7 +57,9 @@ export class EnterpriseServer extends Api {
     }
     try {
       // regardless if this is enterprise or consumer flavor, if FES is available, return yes
-      return (await this.getServiceInfo()).service === 'enterprise-server';
+      const allowedServices = ['external-service', 'enterprise-server'];
+      const serverService = (await this.getServiceInfo()).service;
+      return allowedServices.includes(serverService);
     } catch (e) {
       // FES not available
       if (ApiErr.isNotFound(e)) {

--- a/test/source/mock/fes/fes-endpoints.ts
+++ b/test/source/mock/fes/fes-endpoints.ts
@@ -191,7 +191,7 @@ export const mockFesEndpoints: HandlersDefinition = {
     if ([standardFesUrl].includes(req.headers.host || '') && req.method === 'GET') {
       return {
         vendor: 'Mock',
-        service: 'enterprise-server',
+        service: 'external-service',
         orgId: 'standardsubdomainfes.test',
         version: 'MOCK',
         apiVersion: 'v1',


### PR DESCRIPTION
This PR adds `external-service` as possible value for `service` property of FES response 

close #4874

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
