### PR TITLE
#4868 fix: correctly parse draft saved from iOS app and get rid of tags

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-draft-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-draft-module.ts
@@ -3,7 +3,7 @@
 'use strict';
 
 import { GmailRes } from '../../../js/common/api/email-provider/gmail/gmail-parser.js';
-import { InvalidRecipientError } from '../../../js/common/api/email-provider/sendable-msg.js';
+import { InvalidRecipientError, SendableMsg } from '../../../js/common/api/email-provider/sendable-msg.js';
 import { AjaxErr, ApiErr } from '../../../js/common/api/shared/api-error.js';
 import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
 import { Env } from '../../../js/common/browser/env.js';
@@ -131,6 +131,7 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
           sendable.headers['In-Reply-To'] = this.view.replyParams.inReplyTo;
         }
         this.view.S.cached('send_btn_note').text('Saving');
+        this.draftSetPrefixIntoBody(sendable);
         const mimeMsg = await sendable.toMime();
         // If a draft was loaded from the local storage, once a user is back online, the local draft will be moved to the email provider
         if (!this.view.draftId || this.isLocalDraftId(this.view.draftId)) {
@@ -211,6 +212,13 @@ export class ComposeDraftModule extends ViewModule<ComposeView> {
       return localDraft;
     }
     return undefined;
+  };
+
+  private draftSetPrefixIntoBody = (sendable: SendableMsg) => {
+    if (!this.view.threadId && !this.view.draftId) {
+      const prefix = `(saving of this draft was interrupted - to decrypt it, send it to yourself)\n\n`;
+      sendable.body['text/plain'] = `${prefix}${sendable.body['text/plain'] || ''}`;
+    }
   };
 
   private doUploadDraftWithLocalStorageFallback = async (mimeMsg: string, uploadDraft: () => Promise<string>) => {

--- a/extension/js/common/core/crypto/pgp/pgp-armor.ts
+++ b/extension/js/common/core/crypto/pgp/pgp-armor.ts
@@ -64,6 +64,10 @@ export class PgpArmor {
     encryptedMsg: { begin: '-----BEGIN PGP MESSAGE-----', end: '-----END PGP MESSAGE-----', replace: true },
   };
 
+  public static isEncryptedMsg = (msg: string): boolean => {
+    return !!msg.match(new RegExp(`${PgpArmor.ARMOR_HEADER_DICT.encryptedMsg.begin}.*${PgpArmor.ARMOR_HEADER_DICT.encryptedMsg.end}`));
+  };
+
   public static clipIncomplete = (text: string): string | undefined => {
     const match = text?.match(/(-----BEGIN PGP (MESSAGE|SIGNED MESSAGE|SIGNATURE|PUBLIC KEY BLOCK)-----[^]+)/gm);
     return match && match.length ? match[0] : undefined;

--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -315,10 +315,10 @@ export class GmailElementReplacer implements WebmailElementReplacer {
       }
       if (draftId) {
         // close original draft window
-        const closeGmailComposeWindow = (target: HTMLElement | JQuery<HTMLElement>) => {
+        const closeGmailComposeWindow = (target: JQuery<HTMLElement>) => {
           const mouseUpEvent = document.createEvent('Event');
           mouseUpEvent.initEvent('mouseup', true, true); // Gmail listens for the mouseup event, not click
-          $(target).closest('.nH.Hd').find('.Ha')[0].dispatchEvent(mouseUpEvent); // jquery's trigger('mouseup') doesn't work for some reason
+          target.closest('.nH.Hd').find('.Ha')[0].dispatchEvent(mouseUpEvent); // jquery's trigger('mouseup') doesn't work for some reason
         };
         if (this.injector.openComposeWin(draftId)) {
           closeGmailComposeWindow(contenteditable);

--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -305,7 +305,12 @@ export class GmailElementReplacer implements WebmailElementReplacer {
         draftId = legacyDraftId;
       }
       const draftHtml = contenteditable.html();
-      if (PgpArmor.isEncryptedMsg(draftHtml)) {
+      // Used some hacky way to check if draft is compose draft or draft from thread reply
+      // Reply `table` element (class named aoP) has avatar image(class named ajn). Compose draft doesn't have it
+      // For thread reply draft, we don't need to call openComposeWin
+      // Reply draft window will be replaced by secure compose by replaceStandardReplyBox function
+      const isComposeDraft = $(contenteditable).closest('table.aoP').find('img.ajn').length < 1;
+      if (PgpArmor.isEncryptedMsg(draftHtml) && isComposeDraft) {
         draftId = String($(contenteditable).closest('.I5').find('input[name="draft"]')?.val())?.split(':')[1] ?? '';
       }
       if (draftId) {

--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -318,7 +318,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
         const closeGmailComposeWindow = (target: HTMLElement | JQuery<HTMLElement>) => {
           const mouseUpEvent = document.createEvent('Event');
           mouseUpEvent.initEvent('mouseup', true, true); // Gmail listens for the mouseup event, not click
-          $(target).closest('.dw').find('.Ha')[0].dispatchEvent(mouseUpEvent); // jquery's trigger('mouseup') doesn't work for some reason
+          $(target).closest('.nH.Hd').find('.Ha')[0].dispatchEvent(mouseUpEvent); // jquery's trigger('mouseup') doesn't work for some reason
         };
         if (this.injector.openComposeWin(draftId)) {
           closeGmailComposeWindow(contenteditable);

--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -306,26 +306,18 @@ export class GmailElementReplacer implements WebmailElementReplacer {
       }
       const draftHtml = contenteditable.html();
       if (PgpArmor.isEncryptedMsg(draftHtml)) {
-        draftId = document.querySelector('span[data-standalone-draft-id]')?.getAttribute('data-standalone-draft-id')?.split(':')[1] ?? '';
+        draftId = String($(contenteditable).closest('.I5').find('input[name="draft"]')?.val())?.split(':')[1] ?? '';
       }
       if (draftId) {
-        const button = `<a href="#" class="open_draft_${Xss.escape(draftId)}">Open draft</a>`;
-        Xss.sanitizeReplace(contenteditable, button);
-        $(`a.open_draft_${draftId}`).on(
-          'click',
-          Ui.event.handle(target => {
-            if (this.injector.openComposeWin(draftId)) {
-              closeGmailComposeWindow(target);
-            }
-          })
-        );
         // close original draft window
-        const closeGmailComposeWindow = (target: HTMLElement) => {
+        const closeGmailComposeWindow = (target: HTMLElement | JQuery<HTMLElement>) => {
           const mouseUpEvent = document.createEvent('Event');
           mouseUpEvent.initEvent('mouseup', true, true); // Gmail listens for the mouseup event, not click
           $(target).closest('.dw').find('.Ha')[0].dispatchEvent(mouseUpEvent); // jquery's trigger('mouseup') doesn't work for some reason
         };
-        $('.close_gmail_compose_window').on('click', Ui.event.handle(closeGmailComposeWindow));
+        if (this.injector.openComposeWin(draftId)) {
+          closeGmailComposeWindow(contenteditable);
+        }
       }
     }
   };

--- a/test/source/mock/google/google-endpoints.ts
+++ b/test/source/mock/google/google-endpoints.ts
@@ -302,13 +302,6 @@ export const mockGoogleEndpoints: HandlersDefinition = {
         if (body.message.threadId && !(await GoogleData.withInitializedData(acct)).getThreads().find(t => t.id === body.message.threadId)) {
           throw new HttpClientErr('The thread you are replying to not found', 404);
         }
-        const decoded = await Parse.convertBase64ToMimeMsg(body.message.raw);
-        if (
-          !decoded.text?.startsWith('[flowcrypt:') &&
-          !decoded.text?.startsWith('(saving of this draft was interrupted - to decrypt it, send it to yourself)')
-        ) {
-          throw new Error(`The "flowcrypt" draft prefix was not found in the draft. Instead starts with: ${decoded.text?.substr(0, 100)}`);
-        }
         return {
           id: 'mockfakedraftsave',
           message: {

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -334,7 +334,7 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
         // open new compose window and saved draft
         await gmailPage.waitAndClick('@action-secure-compose', { delay: 1 });
         await gmailPage.waitAndClick('//*[text()="Draft"]');
-        await gmailPage.waitAndClick('[class^="open_draft_"]', { delay: 1 });
+        await Util.sleep(2);
         // veryfy that there are two compose windows: new compose window and secure draft
         const urls = await gmailPage.getFramesUrls(['/chrome/elements/compose.htm'], { sleep: 1 });
         expect(urls.length).to.equal(2);

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -347,6 +347,18 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
     );
 
     ava.default(
+      'mail.google.com - check draft saved from iOS app',
+      testWithBrowser('compatibility', async (t, browser) => {
+        const gmailPage = await openGmailPage(t, browser);
+        await gotoGmailPage(gmailPage, '', 'drafts'); // to go drafts section
+        await gmailPage.waitAndClick('[span.data-standalone-draft-id]', { delay: 1 });
+        // Open secure draft by clicking `open draft` button
+        await gmailPage.waitAndClick('[class^="open_draft_"]', { delay: 1 });
+        await pageHasSecureDraft(gmailPage, 'Test draft saved from iOS app');
+      })
+    );
+
+    ava.default(
       'mail.google.com - plain message contains smart replies',
       testWithBrowser('ci.tests.gmail', async (t, browser) => {
         const gmailPage = await openGmailPage(t, browser);

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -347,18 +347,6 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
     );
 
     ava.default(
-      'mail.google.com - check draft saved from iOS app',
-      testWithBrowser('compatibility', async (t, browser) => {
-        const gmailPage = await openGmailPage(t, browser);
-        await gotoGmailPage(gmailPage, '', 'drafts'); // to go drafts section
-        await gmailPage.waitAndClick('[span.data-standalone-draft-id]', { delay: 1 });
-        // Open secure draft by clicking `open draft` button
-        await gmailPage.waitAndClick('[class^="open_draft_"]', { delay: 1 });
-        await pageHasSecureDraft(gmailPage, 'Test draft saved from iOS app');
-      })
-    );
-
-    ava.default(
       'mail.google.com - plain message contains smart replies',
       testWithBrowser('ci.tests.gmail', async (t, browser) => {
         const gmailPage = await openGmailPage(t, browser);


### PR DESCRIPTION
This PR correctly parses draft saved from iOS app and get rid of tags

close #4868 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Couldn't add test (Need to add live test for parsing existing drafts. However, implementing a live test would present a stability issue as drafts cannot be exported and may be discarded prior to the start of the live test or whatsoever reason)


--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
