### PR TITLE
issue #4494 Allow endpoint handlers configurations from inside a test

### DIFF
--- a/test/source/mock/all-apis-mock.ts
+++ b/test/source/mock/all-apis-mock.ts
@@ -13,7 +13,8 @@ import { mockSksEndpoints } from './sks/sks-endpoints';
 import { mockCustomerUrlFesEndpoints } from './fes/customer-url-fes-endpoints';
 import { mockSharedTenantFesEndpoints } from './fes/shared-tenant-fes-endpoints';
 
-export type HandlersDefinition = Handlers<{ query: { [k: string]: string }; body?: unknown }, unknown>;
+export type RequestType = { query: { [k: string]: string }; body?: unknown };
+export type HandlersDefinition = Handlers<RequestType, unknown>;
 
 export const startAllApisMock = async (logger: (line: string) => void) => {
   class LoggedApi<REQ, RES> extends Api<REQ, RES> {
@@ -25,7 +26,7 @@ export const startAllApisMock = async (logger: (line: string) => void) => {
       }
     };
   }
-  const api = new LoggedApi<{ query: { [k: string]: string }; body?: unknown }, unknown>('google-mock', {
+  const api = new LoggedApi<RequestType, unknown>('google-mock', {
     ...mockGoogleEndpoints,
     ...mockBackendEndpoints,
     ...mockAttesterEndpoints,

--- a/test/source/mock/lib/api.ts
+++ b/test/source/mock/lib/api.ts
@@ -84,6 +84,10 @@ export class Api<REQ, RES> {
     });
   }
 
+  public setHandlers = (handlers: Handlers<REQ, RES>) => {
+    this.handlers = handlers;
+  };
+
   public listen = (host = '127.0.0.1', maxMb = 100): Promise<void> => {
     return new Promise((resolve, reject) => {
       try {

--- a/test/source/test.ts
+++ b/test/source/test.ts
@@ -113,6 +113,7 @@ const startMockApiAndCopyBuild = async (t: AvaContext) => {
 
     t.extensionDir = result.stdout;
     t.urls = new TestUrls(await browserPool.getExtensionId(t), address.port);
+    t.mockApi = mockApi;
   } else {
     t.log('Failed to get mock build address');
   }

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -13,7 +13,7 @@ import { InboxPageRecipe } from './page-recipe/inbox-page-recipe';
 import { OauthPageRecipe } from './page-recipe/oauth-page-recipe';
 import { PageRecipe } from './page-recipe/abstract-page-recipe';
 import { SettingsPageRecipe } from './page-recipe/settings-page-recipe';
-import { protonMailCompatKey, somePubkey } from './../mock/attester/attester-endpoints';
+import { mockAttesterEndpoints, protonMailCompatKey, somePubkey } from './../mock/attester/attester-endpoints';
 import { TestVariant } from './../util';
 import { TestWithBrowser } from './../test';
 import { expect } from 'chai';
@@ -24,6 +24,9 @@ import { MsgUtil } from '../core/crypto/pgp/msg-util';
 import { Buf } from '../core/buf';
 import { PubkeyInfoWithLastCheck } from '../core/crypto/key';
 import { ElementHandle, Page } from 'puppeteer';
+import { mockGoogleEndpoints } from '../mock/google/google-endpoints';
+import { mockKeyManagerEndpoints } from '../mock/key-manager/key-manager-endpoints';
+import { mockCustomerUrlFesEndpoints } from '../mock/fes/customer-url-fes-endpoints';
 
 export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: TestWithBrowser) => {
   if (testVariant !== 'CONSUMER-LIVE-GMAIL') {
@@ -2545,6 +2548,16 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
     test(
       'user3@standardsubdomainfes.localhost:8001 - PWD encrypted message with FES web portal - pubkey recipient in bcc',
       testWithBrowser(undefined, async (t, browser) => {
+        t.mockApi?.setHandlers({
+          ...mockGoogleEndpoints,
+          // ...mockBackendEndpoints,
+          ...mockAttesterEndpoints,
+          ...mockKeyManagerEndpoints,
+          // ...mockWkdEndpoints,
+          // ...mockSksEndpoints,
+          ...mockCustomerUrlFesEndpoints,
+          // ...mockSharedTenantFesEndpoints,
+        });
         const acct = `user3@standardsubdomainfes.localhost:${t.urls?.port}`; // added port to trick extension into calling the mock
         const settingsPage = await BrowserRecipe.openSettingsLoginApprove(t, browser, acct);
         await SetupPageRecipe.manualEnter(

--- a/test/source/tests/tooling/index.ts
+++ b/test/source/tests/tooling/index.ts
@@ -2,6 +2,8 @@
 
 import { ExecutionContext } from 'ava';
 import { TestUrls } from '../../browser/test-urls';
+import { RequestType } from '../../mock/all-apis-mock';
+import { Api } from '../../mock/lib/api';
 
 import { Consts } from '../../test';
 
@@ -12,6 +14,7 @@ export type AvaContext = ExecutionContext<unknown> & {
   attemptText?: string;
   extensionDir?: string;
   urls?: TestUrls;
+  mockApi?: Api<RequestType, unknown>;
 };
 
 const MAX_ATT_SIZE = 5 * 1024 * 1024;


### PR DESCRIPTION
This PR allows to configure handlers from inside a test
(also sets up one test in this way as a demo -- `user3@standardsubdomainfes.localhost:8001 - PWD encrypted message with FES web portal - pubkey recipient in bcc`

TODO: clear handlers after test finishes (if MockApi is reused)?
issue #4494

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
