### PR TITLE
Retain block index information when rendering blocks found by MsgBlockParser

### DIFF
--- a/extension/chrome/elements/pgp_block.ts
+++ b/extension/chrome/elements/pgp_block.ts
@@ -28,6 +28,9 @@ export class PgpBlockView extends View {
   public readonly isOutgoing: boolean;
   public readonly senderEmail: string;
   public readonly msgId: string | undefined;
+  // If the block was detected by MsgBlockParser.detectBlock,
+  // it may be useful to know its index in case we want to re-fetch the message by MsgId
+  public readonly blockIndex: number | undefined;
   public readonly encryptedMsgUrlParam: Buf | undefined;
   public readonly signature?: {
     // when parsedSignature is undefined, decryptModule will try to fetch the message
@@ -51,7 +54,18 @@ export class PgpBlockView extends View {
   public constructor() {
     super();
     Ui.event.protect();
-    const uncheckedUrlParams = Url.parse(['acctEmail', 'frameId', 'message', 'parentTabId', 'msgId', 'isOutgoing', 'senderEmail', 'signature', 'debug']);
+    const uncheckedUrlParams = Url.parse([
+      'acctEmail',
+      'frameId',
+      'message',
+      'parentTabId',
+      'msgId',
+      'blockIndex',
+      'isOutgoing',
+      'senderEmail',
+      'signature',
+      'debug',
+    ]);
     this.acctEmail = Assert.urlParamRequire.string(uncheckedUrlParams, 'acctEmail');
     this.parentTabId = Assert.urlParamRequire.string(uncheckedUrlParams, 'parentTabId');
     this.frameId = Assert.urlParamRequire.string(uncheckedUrlParams, 'frameId');
@@ -59,6 +73,7 @@ export class PgpBlockView extends View {
     this.debug = uncheckedUrlParams.debug === true;
     const senderEmail = Assert.urlParamRequire.string(uncheckedUrlParams, 'senderEmail');
     this.senderEmail = Str.parseEmail(senderEmail).email || '';
+    this.blockIndex = Assert.urlParamRequire.optionalInteger(uncheckedUrlParams, 'blockIndex');
     this.msgId = Assert.urlParamRequire.optionalString(uncheckedUrlParams, 'msgId');
     if (/\.\.|\\|\//.test(decodeURI(this.msgId || ''))) {
       throw new Error('API path traversal forbidden');

--- a/extension/chrome/settings/inbox/inbox-modules/inbox-active-thread-module.ts
+++ b/extension/chrome/settings/inbox/inbox-modules/inbox-active-thread-module.ts
@@ -112,7 +112,7 @@ export class InboxActiveThreadModule extends ViewModule<InboxView> {
       const { blocks, headers } = await Mime.process(mimeMsg);
       let r = '';
       let renderedAttachments = '';
-      for (const block of blocks) {
+      for (const [blockIndex, block] of blocks.entries()) {
         if (block.type === 'encryptedMsg' || block.type === 'publicKey' || block.type === 'privateKey' || block.type === 'signedMsg') {
           this.threadHasPgpBlock = true;
         }
@@ -123,6 +123,7 @@ export class InboxActiveThreadModule extends ViewModule<InboxView> {
           renderedAttachments += XssSafeFactory.renderableMsgBlock(
             this.view.factory,
             block,
+            blockIndex,
             message.id,
             from,
             this.view.storage.sendAs && !!this.view.storage.sendAs[from]
@@ -130,7 +131,14 @@ export class InboxActiveThreadModule extends ViewModule<InboxView> {
         } else if (this.view.showOriginal) {
           r += Xss.escape(block.content.toString()).replace(/\n/g, '<br>');
         } else {
-          r += XssSafeFactory.renderableMsgBlock(this.view.factory, block, message.id, from, this.view.storage.sendAs && !!this.view.storage.sendAs[from]);
+          r += XssSafeFactory.renderableMsgBlock(
+            this.view.factory,
+            block,
+            blockIndex,
+            message.id,
+            from,
+            this.view.storage.sendAs && !!this.view.storage.sendAs[from]
+          );
         }
       }
       if (renderedAttachments) {

--- a/extension/js/common/assert.ts
+++ b/extension/js/common/assert.ts
@@ -30,6 +30,19 @@ export class Assert {
       }
       throw new Error(`urlParamRequire.optionalString: type of ${name} unexpectedly ${typeof r}`);
     },
+    optionalInteger: (values: UrlParams, name: string): number | undefined => {
+      const r = Assert.abortAndRenderErrOnUrlParamTypeMismatch(values, name, 'string?');
+      if (typeof r === 'undefined') {
+        return undefined;
+      }
+      if (typeof r === 'string' && Number.isInteger(+r)) {
+        const parsed = Number.parseInt(r);
+        if (Number.isInteger(parsed)) {
+          return parsed;
+        }
+      }
+      throw new Error(`urlParamRequire.optionalInteger: value of ${name} doesn't look like an integer`);
+    },
     oneof: <T>(values: UrlParams, name: string, allowed: T[]): T => {
       return Assert.abortAndRenderErrOnUrlParamValMismatch(values, name, allowed as unknown as UrlParam[]) as unknown as T; // todo - there should be a better way
     },

--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -465,7 +465,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
                 // if it looks like OpenPGP public key
                 nRenderedAttachments = await this.renderPublicKeyFromFile(a, attachmentsContainerInner, msgEl, isOutgoing, attachmentSel, nRenderedAttachments);
               } else if (openpgpType && ['encryptedMsg', 'signedMsg'].includes(openpgpType.type)) {
-                msgEl = this.updateMsgBodyEl_DANGEROUSLY(msgEl, 'append', this.factory.embeddedMsg(openpgpType.type, '', msgId, false, senderEmail)); // xss-safe-factory
+                msgEl = this.updateMsgBodyEl_DANGEROUSLY(msgEl, 'append', this.factory.embeddedMsg(openpgpType.type, '', undefined, msgId, false, senderEmail)); // xss-safe-factory
               } else {
                 attachmentSel.show().children('.attachment_loader').text('Unknown OpenPGP format');
                 nRenderedAttachments++;
@@ -474,7 +474,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
                 console.debug('processAttachments() try -> awaiting done and processed');
               }
             } else {
-              msgEl = this.updateMsgBodyEl_DANGEROUSLY(msgEl, 'set', this.factory.embeddedMsg('encryptedMsg', '', msgId, false, senderEmail)); // xss-safe-factory
+              msgEl = this.updateMsgBodyEl_DANGEROUSLY(msgEl, 'set', this.factory.embeddedMsg('encryptedMsg', '', undefined, msgId, false, senderEmail)); // xss-safe-factory
             }
           } else if (treatAs === 'publicKey') {
             // todo - pubkey should be fetched in pgp_pubkey.js
@@ -482,7 +482,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
           } else if (treatAs === 'privateKey') {
             nRenderedAttachments = await this.renderBackupFromFile(a, attachmentsContainerInner, msgEl, attachmentSel, nRenderedAttachments);
           } else if (treatAs === 'signature') {
-            const embeddedSignedMsgXssSafe = this.factory.embeddedMsg('signedMsg', '', msgId, false, senderEmail, true);
+            const embeddedSignedMsgXssSafe = this.factory.embeddedMsg('signedMsg', '', undefined, msgId, false, senderEmail, true);
             msgEl = this.updateMsgBodyEl_DANGEROUSLY(msgEl, 'set', embeddedSignedMsgXssSafe); // xss-safe-factory
           }
         } else if (treatAs === 'plainFile' && a.name.substr(-4) === '.asc') {


### PR DESCRIPTION
This PR retain block index information when rendering blocks found by MsgBlockParser.
This will allow us to re-fetch msgId and find the right block by its index.

issue #4342

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)
- Difficult to test (explain why)
- Not worth testing
- Tests will be added later (issue #...)
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
