### PR TITLE
upgrade OpenPGP to 5.6.0, remove patches

### DIFF
--- a/extension/js/common/core/crypto/pgp/pgp-armor.ts
+++ b/extension/js/common/core/crypto/pgp/pgp-armor.ts
@@ -165,11 +165,6 @@ export class PgpArmor {
   };
 
   public static armor = (messagetype: OpenPGP.enums.armor, body: object): string => {
-    return (
-      opgp as {
-        // https://github.com/openpgpjs/openpgpjs/pull/1585
-        armor(messagetype: OpenPGP.enums.armor, body: object, partindex?: number, parttotal?: number, customComment?: string, config?: OpenPGP.Config): string;
-      }
-    ).armor(messagetype, body, undefined, undefined, undefined, opgp.config);
+    return opgp.armor(messagetype, body, undefined, undefined, undefined, opgp.config);
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "lint-staged": "^13.1.0",
         "mailparser": "3.6.3",
         "mkdirp": "2.1.3",
-        "openpgp": "5.5.0",
+        "openpgp": "^5.6.0",
         "pdfjs-dist": "3.3.122",
         "prettier": "^2.8.3",
         "puppeteer": "19.6.3",
@@ -7664,9 +7664,9 @@
       }
     },
     "node_modules/openpgp": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-5.5.0.tgz",
-      "integrity": "sha512-SpwcJnxrK9Y0HRM6KxSFqkAEOSWEabCH/c8dII/+y2e5f6KvuDG5ZE7JXaPBaVJNE4VUZZeTphxXDoZD0KOHrw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-5.6.0.tgz",
+      "integrity": "sha512-m0UGCSefapbPssLmxJ7z7KydLEdpWjaY5gXoxZgTuNeWDfeRG5lzaORWNxyKg1K4tJnRwSoTp01Vtt8Cenbmgw==",
       "dev": true,
       "dependencies": {
         "asn1.js": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint-staged": "^13.1.0",
     "mailparser": "3.6.3",
     "mkdirp": "2.1.3",
-    "openpgp": "5.5.0",
+    "openpgp": "^5.6.0",
     "pdfjs-dist": "3.3.122",
     "prettier": "^2.8.3",
     "puppeteer": "19.6.3",


### PR DESCRIPTION
This PR upgrades OpenPGP.js to 5.6.0, some patches are no longer needed and are removed

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
