### PR TITLE
removed reference to Swal from background page

### DIFF
--- a/extension/js/background_page/background_page.htm
+++ b/extension/js/background_page/background_page.htm
@@ -6,7 +6,6 @@
   <body>
     <script src="/lib/purify.js"></script>
     <script src="/lib/jquery.min.js"></script>
-    <script src="/lib/sweetalert2.js"></script>
     <script src="/lib/openpgp.js"></script>
     <script src="/lib/forge.js"></script>
     <script src="/lib/emailjs/punycode.js"></script>


### PR DESCRIPTION
This PR removes sweetalert reference from background page.
Was it ever used? Is it possible to use it?

(as part of research for issue #4866)

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)


--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
