### PR TITLE
Add checks for key encryption and signing usability

### DIFF
--- a/extension/js/common/core/crypto/key.ts
+++ b/extension/js/common/core/crypto/key.ts
@@ -271,6 +271,8 @@ export class KeyUtil {
     }
     result.set(`expiration`, KeyUtil.formatResult(key.expiration));
     result.set(`internal dateBeforeExpiration`, await KeyUtil.formatResultAsync(async () => KeyUtil.dateBeforeExpirationIfAlreadyExpired(key)));
+    result.set(`internal usableForEncryption`, KeyUtil.formatResult(key.usableForEncryption));
+    result.set(`internal usableForSigning`, KeyUtil.formatResult(key.usableForSigning));
     result.set(`internal usableForEncryptionButExpired`, KeyUtil.formatResult(key.usableForEncryptionButExpired));
     result.set(`internal usableForSigningButExpired`, KeyUtil.formatResult(key.usableForSigningButExpired));
     return result;


### PR DESCRIPTION
This PR updates the compatibility test by adding the `usableForEncryption` and `usableForSigning` properties to the output results.

close #4996 

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
