### PR TITLE
#4980 feat: make secure compose button clickable for text too

### DIFF
--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -1,7 +1,7 @@
 /* © 2016-2018 FlowCrypt Limited. Limitations apply. Contact human@flowcrypt.com */
 
 /* Secure Compose button */
-#flowcrypt_secure_compose_button {
+#flowcrypt_secure_compose_button_content {
   display: inline-flex;
   align-items: center;
   width: auto;
@@ -27,11 +27,11 @@
   outline: 0;
 }
 
-.small #flowcrypt_secure_compose_button {
+.small #flowcrypt_secure_compose_button_content {
   height: 40px;
 }
 
-#flowcrypt_secure_compose_button::before {
+#flowcrypt_secure_compose_button_content::before {
   display: block;
   content: '';
   background-size: 24px;
@@ -44,34 +44,23 @@
   background-repeat: no-repeat;
 }
 
-.compose_button_simple {
+.compose_icon_simple {
   height: 33px !important;
   margin: 0 12px !important;
   display: block !important;
 }
 
-.compose_button_simple::before {
+.compose_icon_simple::before {
   left: -6px;
   position: relative;
 }
 
-.only-icon #flowcrypt_secure_compose_button {
-  height: 40px;
-  width: 16px;
-  border-radius: 20px;
-}
-
-.only-icon #flowcrypt_secure_compose_button::before {
-  background-position-x: 9px !important;
-  background-position-y: 12px !important;
-}
-
-#flowcrypt_secure_compose_button:hover,
-#flowcrypt_secure_compose_button:focus {
+#flowcrypt_secure_compose_button_content:hover,
+#flowcrypt_secure_compose_button_content:focus {
   box-shadow: 0 5px 10px 2px rgb(60 64 67 / 20%);
 }
 
-.bhZ:not(.bym) #flowcrypt_secure_compose_button {
+.bhZ:not(.bym) #flowcrypt_secure_compose_button_content {
   width: 56px;
   height: 56px;
   border-radius: 28px;
@@ -79,13 +68,13 @@
   padding: 0;
 }
 
-.bhZ:not(.bym) .small #flowcrypt_secure_compose_button {
+.bhZ:not(.bym) .small #flowcrypt_secure_compose_button_content {
   width: 40px;
   height: 40px;
   border-radius: 20px;
 }
 
-.bhZ:not(.bym) .small #flowcrypt_secure_compose_button::before {
+.bhZ:not(.bym) .small #flowcrypt_secure_compose_button_content::before {
   min-width: 42px;
 }
 

--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -1,7 +1,7 @@
 /* © 2016-2018 FlowCrypt Limited. Limitations apply. Contact human@flowcrypt.com */
 
 /* Secure Compose button */
-#flowcrypt_secure_compose_button_content {
+#flowcrypt_secure_compose_button_icon {
   display: inline-flex;
   align-items: center;
   width: auto;
@@ -27,11 +27,11 @@
   outline: 0;
 }
 
-.small #flowcrypt_secure_compose_button_content {
+.small #flowcrypt_secure_compose_button_icon {
   height: 40px;
 }
 
-#flowcrypt_secure_compose_button_content::before {
+#flowcrypt_secure_compose_button_icon::before {
   display: block;
   content: '';
   background-size: 24px;
@@ -55,12 +55,12 @@
   position: relative;
 }
 
-#flowcrypt_secure_compose_button_content:hover,
-#flowcrypt_secure_compose_button_content:focus {
+#flowcrypt_secure_compose_button_icon:hover,
+#flowcrypt_secure_compose_button_icon:focus {
   box-shadow: 0 5px 10px 2px rgb(60 64 67 / 20%);
 }
 
-.bhZ:not(.bym) #flowcrypt_secure_compose_button_content {
+.bhZ:not(.bym) #flowcrypt_secure_compose_button_icon {
   width: 56px;
   height: 56px;
   border-radius: 28px;
@@ -68,13 +68,13 @@
   padding: 0;
 }
 
-.bhZ:not(.bym) .small #flowcrypt_secure_compose_button_content {
+.bhZ:not(.bym) .small #flowcrypt_secure_compose_button_icon {
   width: 40px;
   height: 40px;
   border-radius: 20px;
 }
 
-.bhZ:not(.bym) .small #flowcrypt_secure_compose_button_content::before {
+.bhZ:not(.bym) .small #flowcrypt_secure_compose_button_icon::before {
   min-width: 42px;
 }
 
@@ -170,7 +170,7 @@ body.cryptup_inbox div.new_secure_compose_window_button {
   background: white;
 }
 
-body.cryptup_inbox div.new_secure_compose_window_button > img {
+body.cryptup_inbox div.new_secure_compose_window_button>img {
   width: 28px;
   padding: 6px;
   padding-top: 10px;
@@ -210,7 +210,7 @@ body.cryptup_gmail .inserted div.reply_message_button:hover {
   cursor: pointer;
 }
 
-body.cryptup_gmail div.reply_message_button > img {
+body.cryptup_gmail div.reply_message_button>img {
   width: 28px;
   position: absolute;
   left: 0;
@@ -231,7 +231,7 @@ body.cryptup_gmail_new div.new_secure_compose_window_button:hover {
   background-color: #fafafb;
 }
 
-body.cryptup_gmail div.ade.appended span.cryptup_convo_button > img {
+body.cryptup_gmail div.ade.appended span.cryptup_convo_button>img {
   border: 2px solid #31a217;
   width: 10px;
   margin: 4px;
@@ -240,7 +240,7 @@ body.cryptup_gmail div.ade.appended span.cryptup_convo_button > img {
   opacity: 0.8;
 }
 
-body.cryptup_gmail div.ade.appended span.cryptup_convo_button > span {
+body.cryptup_gmail div.ade.appended span.cryptup_convo_button>span {
   text-transform: uppercase;
   font-size: 9.5px;
   color: white;
@@ -251,8 +251,8 @@ body.cryptup_gmail div.ade.appended span.cryptup_convo_button > span {
   cursor: default;
 }
 
-body.cryptup_gmail div.ade.appended span.cryptup_convo_button:hover > img,
-div.ade.appended span.cryptup_convo_button:hover > span {
+body.cryptup_gmail div.ade.appended span.cryptup_convo_button:hover>img,
+div.ade.appended span.cryptup_convo_button:hover>span {
   opacity: 1;
 }
 
@@ -444,7 +444,7 @@ span.pgp_attachment {
   position: relative;
 }
 
-span.pgp_attachment > iframe {
+span.pgp_attachment>iframe {
   height: 120px;
   width: 180px;
   padding: 0;

--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -170,7 +170,7 @@ body.cryptup_inbox div.new_secure_compose_window_button {
   background: white;
 }
 
-body.cryptup_inbox div.new_secure_compose_window_button>img {
+body.cryptup_inbox div.new_secure_compose_window_button > img {
   width: 28px;
   padding: 6px;
   padding-top: 10px;
@@ -210,7 +210,7 @@ body.cryptup_gmail .inserted div.reply_message_button:hover {
   cursor: pointer;
 }
 
-body.cryptup_gmail div.reply_message_button>img {
+body.cryptup_gmail div.reply_message_button > img {
   width: 28px;
   position: absolute;
   left: 0;
@@ -240,7 +240,7 @@ body.cryptup_gmail div.ade.appended span.cryptup_convo_button>img {
   opacity: 0.8;
 }
 
-body.cryptup_gmail div.ade.appended span.cryptup_convo_button>span {
+body.cryptup_gmail div.ade.appended span.cryptup_convo_button > span {
   text-transform: uppercase;
   font-size: 9.5px;
   color: white;
@@ -252,7 +252,7 @@ body.cryptup_gmail div.ade.appended span.cryptup_convo_button>span {
 }
 
 body.cryptup_gmail div.ade.appended span.cryptup_convo_button:hover>img,
-div.ade.appended span.cryptup_convo_button:hover>span {
+div.ade.appended span.cryptup_convo_button:hover > span {
   opacity: 1;
 }
 
@@ -444,7 +444,7 @@ span.pgp_attachment {
   position: relative;
 }
 
-span.pgp_attachment>iframe {
+span.pgp_attachment > iframe {
   height: 120px;
   width: 180px;
   padding: 0;

--- a/extension/js/common/xss-safe-factory.ts
+++ b/extension/js/common/xss-safe-factory.ts
@@ -250,12 +250,12 @@ export class XssSafeFactory {
 
   public btnCompose = (webmailName: WebMailName, webmailVersion: WebMailVersion) => {
     if (webmailName === 'outlook') {
-      const btn = `<div class="new_secure_compose_window_button" id="flowcrypt_secure_compose_button_content" title="New Secure Email"><img src="${this.srcImg(
+      const btn = `<div class="new_secure_compose_window_button" id="flowcrypt_secure_compose_button_icon" title="New Secure Email"><img src="${this.srcImg(
         'logo-19-19.png'
       )}"></div>`;
       return `<div id="flowcrypt_secure_compose_button" class="_fce_c ${this.destroyableCls} cryptup_compose_button_container" role="presentation">${btn}</div>`;
     } else {
-      const elAttrs = 'data-tooltip="Secure Compose" aria-label="Secure Compose" id="flowcrypt_secure_compose_button_content"';
+      const elAttrs = 'data-tooltip="Secure Compose" aria-label="Secure Compose" id="flowcrypt_secure_compose_button_icon"';
       const title = 'Secure Compose';
       const btnEl =
         webmailVersion === 'gmail2022' ? `<div class="compose_icon_simple" ${elAttrs}></div><div class="apW">${title}</div>` : `<div ${elAttrs}>${title}</div>`;

--- a/extension/js/common/xss-safe-factory.ts
+++ b/extension/js/common/xss-safe-factory.ts
@@ -249,22 +249,18 @@ export class XssSafeFactory {
   };
 
   public btnCompose = (webmailName: WebMailName, webmailVersion: WebMailVersion) => {
-    const btnCls = 'new_secure_compose_window_button';
     if (webmailName === 'outlook') {
-      const btn = `<div class="new_secure_compose_window_button" id="flowcrypt_secure_compose_button" title="New Secure Email"><img src="${this.srcImg(
+      const btn = `<div class="new_secure_compose_window_button" id="flowcrypt_secure_compose_button_content" title="New Secure Email"><img src="${this.srcImg(
         'logo-19-19.png'
       )}"></div>`;
-      return `<div class="_fce_c ${this.destroyableCls} cryptup_compose_button_container" role="presentation">${btn}</div>`;
+      return `<div id="flowcrypt_secure_compose_button" class="_fce_c ${this.destroyableCls} cryptup_compose_button_container" role="presentation">${btn}</div>`;
     } else {
-      const elAttrs =
-        'role="button" tabindex="0" data-test="action-secure-compose" data-tooltip="Secure Compose" aria-label="Secure Compose" id="flowcrypt_secure_compose_button"';
+      const elAttrs = 'data-tooltip="Secure Compose" aria-label="Secure Compose" id="flowcrypt_secure_compose_button_content"';
       const title = 'Secure Compose';
       const btnEl =
-        webmailVersion === 'gmail2022'
-          ? `<div class="${btnCls} compose_button_simple only-icon" ${elAttrs}></div><div class="apW">${title}</div>`
-          : `<div class="${btnCls} small" ${elAttrs}>${title}</div>`;
+        webmailVersion === 'gmail2022' ? `<div class="compose_icon_simple" ${elAttrs}></div><div class="apW">${title}</div>` : `<div ${elAttrs}>${title}</div>`;
       const containerCls = webmailVersion === 'gmail2022' ? 'pb-25px' : 'z0';
-      return `<div class="${this.destroyableCls} ${containerCls}">${btnEl}</div>`;
+      return `<div class="${this.destroyableCls} ${containerCls}" id="flowcrypt_secure_compose_button" role="button" tabindex="0" data-test="action-secure-compose" >${btnEl}</div>`;
     }
   };
 


### PR DESCRIPTION
This PR makes secure compose button clickable for text too

close #4980 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
