### PR TITLE
issue #5014 update ascii armored private key length limit to 80kb

### DIFF
--- a/extension/chrome/settings/modules/add_key.htm
+++ b/extension/chrome/settings/modules/add_key.htm
@@ -49,7 +49,7 @@
       </div>
       <div class="source_paste_container display_none">
         <div class="line">
-          <textarea class="input_private_key" data-test="input-armored-key" placeholder="ASCII Armored Private Key" maxlength="20000">
+          <textarea class="input_private_key" data-test="input-armored-key" placeholder="ASCII Armored Private Key" maxlength="80000">
           </textarea>
         </div>
         <div class="line display_none unprotected_key_create_pass_phrase" style="text-align: left; padding-left: 40px;">

--- a/extension/chrome/settings/modules/compatibility.htm
+++ b/extension/chrome/settings/modules/compatibility.htm
@@ -20,7 +20,7 @@
     <div class="line">Locally test any public or private key.</div>
 
     <div class="line">
-      <textarea placeholder="ASCII Armored Public or Private Key....." class="input_key" style="width: 650px; height: 200px;" spellcheck="false" maxlength="20000"></textarea>
+      <textarea placeholder="ASCII Armored Public or Private Key....." class="input_key" style="width: 650px; height: 200px;" spellcheck="false" maxlength="80000"></textarea>
     </div>
 
     <div class="line left">

--- a/extension/chrome/settings/modules/my_key_update.htm
+++ b/extension/chrome/settings/modules/my_key_update.htm
@@ -24,7 +24,7 @@
     <div class="line">FlowCrypt will also recreate a new public key from your updated private key.</div>
     <div class="line">
       <textarea class="input_private_key armored" data-test="input-prv-key"
-        placeholder="Updated ASCII Armored Private Key" maxlength="20000"></textarea>
+        placeholder="Updated ASCII Armored Private Key" maxlength="80000"></textarea>
     </div>
     <div class="line">
       <input class="input_passphrase" type="password" data-test="input-passphrase"

--- a/extension/chrome/settings/setup.htm
+++ b/extension/chrome/settings/setup.htm
@@ -187,7 +187,7 @@
         </div>
         <div class="source_paste_container setup_page display_none">
           <div class="line left">
-            <textarea class="input_private_key" placeholder="ASCII Armored Private Key" data-test="input-step2bmanualenter-ascii-key" spellcheck="false" maxlength="20000"></textarea>
+            <textarea class="input_private_key" placeholder="ASCII Armored Private Key" data-test="input-step2bmanualenter-ascii-key" spellcheck="false" maxlength="80000"></textarea>
           </div>
           <div class="line display_none unprotected_key_create_pass_phrase">
             This key is unprotected. Create a pass phrase or <a href="#" class="action_use_random_pass_phrase"


### PR DESCRIPTION
This PR updates the ASCII armored private key length limit to 80kb from 20kb.

close #5014 

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
