### PR TITLE
Update dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,10 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/"
-    open-pull-requests-limit: 1
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
+      time: "22:00"
     ignore:
       # ignore all bootstrap major updates
       - dependency-name: "bootstrap"


### PR DESCRIPTION
This PR updates dependabot schedule to run weekly on Sundays, so update commits are not mixed with other commits during the week (it's the same approach as we use for enterprise-server repo)

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
