### PR TITLE
issue #5003 remove password messages custom expiry options

### DIFF
--- a/extension/chrome/settings/modules/security.htm
+++ b/extension/chrome/settings/modules/security.htm
@@ -54,21 +54,6 @@
       <h3>Password protected messages</h3>
     </div>
     <div class="settings-form-group">
-      <div class="line password_messages_expiry_container display_none" data-test="container-password-messages-expiry">
-        Password encrypted messages expire in
-        <span class="expiration_container">
-          <span class="select_loader_container"></span>
-          <select class="default_message_expire" style="display: none;" disabled="disabled">
-            <option value="1">1</option>
-            <option value="3">3</option>
-            <option value="7">7</option>
-            <option value="30">30</option>
-            <option value="90">90</option>
-            <option value="365">365</option>
-          </select>
-          days
-        </span>
-      </div>
       <div class="line">
         Recipient will receive message description in
         <select class="password_message_language">

--- a/extension/chrome/settings/modules/security.ts
+++ b/extension/chrome/settings/modules/security.ts
@@ -2,14 +2,11 @@
 
 'use strict';
 
-import { ApiErr } from '../../../js/common/api/shared/api-error.js';
 import { Assert } from '../../../js/common/assert.js';
-import { Catch } from '../../../js/common/platform/catch.js';
 import { Settings } from '../../../js/common/settings.js';
 import { Ui } from '../../../js/common/browser/ui.js';
 import { Url } from '../../../js/common/core/common.js';
 import { View } from '../../../js/common/view.js';
-import { Xss } from '../../../js/common/platform/xss.js';
 import { initPassphraseToggle } from '../../../js/common/ui/passphrase-ui.js';
 import { AcctStore } from '../../../js/common/platform/store/acct-store.js';
 import { KeyStore } from '../../../js/common/platform/store/key-store.js';
@@ -43,7 +40,6 @@ View.run(
       $('#hide_message_password').prop('checked', storage.hide_message_password === true);
       $('.password_message_language').val(storage.outgoing_language || 'EN');
       await this.renderPassPhraseOptionsIfStoredPermanently();
-      await this.loadAndRenderPwdEncryptedMsgSettings();
       if (this.clientConfiguration.mustAutogenPassPhraseQuietly()) {
         $('.hide_if_pass_phrase_not_user_configurable').hide();
       }
@@ -90,32 +86,6 @@ View.run(
         );
         $('.cancel_passphrase_requirement_change').on('click', () => window.location.reload());
         $('#passphrase_entry').keydown(this.setEnterHandlerThatClicks('.confirm_passphrase_requirement_change'));
-      }
-    };
-
-    private loadAndRenderPwdEncryptedMsgSettings = async () => {
-      Xss.sanitizeRender('.select_loader_container', Ui.spinner('green'));
-      try {
-        if (!this.clientConfiguration.usesKeyManager()) {
-          $('.password_messages_expiry_container').show();
-          await this.acctServer.fetchAndSaveClientConfiguration();
-          $('.select_loader_container').text('');
-          const defaultWebPortalMessageExpire = await this.acctServer.getWebPortalMessageExpireDays();
-          $('.default_message_expire').val(`${defaultWebPortalMessageExpire}`).prop('disabled', false).css('display', 'inline-block');
-        }
-      } catch (e) {
-        if (ApiErr.isAuthErr(e)) {
-          Settings.offerToLoginWithPopupShowModalOnErr(this.acctEmail, () => window.location.reload());
-        } else if (ApiErr.isNetErr(e)) {
-          Xss.sanitizeRender('.expiration_container', '(network error: <a href="#">retry</a>)')
-            .find('a')
-            .on('click', () => window.location.reload()); // safe source
-        } else {
-          Catch.reportErr(e);
-          Xss.sanitizeRender('.expiration_container', '(unknown error: <a href="#">retry</a>)')
-            .find('a')
-            .on('click', () => window.location.reload()); // safe source
-        }
       }
     };
 

--- a/test/source/tests/settings.ts
+++ b/test/source/tests/settings.ts
@@ -1537,28 +1537,6 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
         expect(savedPassphrase2).to.be.an('undefined');
       })
     );
-    test(
-      "settings - password messages' expiry settings shouldn't be available for FES users",
-      testWithBrowser('compatibility', async (t, browser) => {
-        const acct1 = 'flowcrypt.compatibility@gmail.com';
-        const settingsPage = await browser.newExtensionSettingsPage(t, 'flowcrypt.compatibility@gmail.com');
-        const securitySettingsFrame1 = await SettingsPageRecipe.awaitNewPageFrame(settingsPage, '@action-open-security-page', ['security.htm']);
-        expect(await securitySettingsFrame1.isElementVisible('@container-password-messages-expiry')).to.equal(true);
-        await SettingsPageRecipe.closeDialog(settingsPage);
-        await SettingsPageRecipe.toggleScreen(settingsPage, 'additional');
-        const experimentalFrame = await SettingsPageRecipe.awaitNewPageFrame(settingsPage, '@action-open-module-experimental', ['experimental.htm']);
-        await experimentalFrame.waitAndClick('@action-reset-account');
-        await experimentalFrame.waitAndRespondToModal('confirm', 'confirm', `This will remove all your FlowCrypt settings for ${acct1}`);
-        await experimentalFrame.waitAndRespondToModal('confirm', 'confirm', "Proceed to reset? Don't come back telling me I didn't warn you.");
-        await settingsPage.close();
-        const acct2 = 'settings@key-manager-autogen.flowcrypt.test';
-        const settingsPage1 = await BrowserRecipe.openSettingsLoginApprove(t, browser, acct2);
-        await SetupPageRecipe.autoSetupWithEKM(settingsPage1);
-        const securitySettingsFrame = await SettingsPageRecipe.awaitNewPageFrame(settingsPage1, '@action-open-security-page', ['security.htm']);
-        expect(await securitySettingsFrame.isElementVisible('@container-password-messages-expiry')).to.equal(false);
-        await settingsPage1.close();
-      })
-    );
     test.todo('settings - change passphrase - mismatch curent pp');
     test.todo('settings - change passphrase - mismatch new pp');
   }


### PR DESCRIPTION
This PR removes the password message custom expiry options.

close #5003

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
