### PR TITLE
#5079 fix: Message parsing fails with error 'TypeError: imageSrc is null'

### DIFF
--- a/extension/chrome/elements/pgp_block_modules/pgp-block-render-module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp-block-render-module.ts
@@ -334,6 +334,7 @@ export class PgpBlockViewRenderModule {
       // Ensure the node exists and has a 'src' attribute
       if (!node || !('src' in node)) return;
       const imageSrc = node.getAttribute('src') as string;
+      if (!imageSrc) return;
       const matches = imageSrc.match(CID_PATTERN);
 
       // Check if the src attribute contains a CID


### PR DESCRIPTION
This PR fixed message parsing fails with error 'TypeError: imageSrc is null'

close #5079 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
