### PR TITLE
fixed guess contacts from sent messages query to omit top-level domain

### DIFF
--- a/extension/js/common/api/email-provider/gmail/gmail.ts
+++ b/extension/js/common/api/email-provider/gmail/gmail.ts
@@ -269,7 +269,19 @@ export class Gmail extends EmailProviderApi implements EmailProviderInterface {
     let gmailQuery = `is:sent ${this.GMAIL_USELESS_CONTACTS_FILTER} `;
     const needles: string[] = [];
     if (userQuery) {
-      needles.push(...userQuery.split(/[ .]/g).filter(v => !['com', 'org', 'net'].includes(v)));
+      const needlesWithoutSpaces = userQuery.split(/ +/g);
+      needles.push(
+        ...needlesWithoutSpaces
+          .map(bigNeedle => {
+            const email = Str.parseEmail(bigNeedle);
+            if (email?.email) {
+              const match = email.email.match(/^(.*@.+)\.[^@]+?$/);
+              if (match) bigNeedle = match[1]; // omit the top-level domain
+            }
+            return bigNeedle.split('.').filter(v => !['com', 'org', 'net'].includes(v));
+          })
+          .reduce((a, b) => [...a, ...b])
+      );
       if (!needles.includes(userQuery)) {
         needles.push(userQuery);
       }

--- a/test/source/mock/key-manager/key-manager-endpoints.ts
+++ b/test/source/mock/key-manager/key-manager-endpoints.ts
@@ -283,7 +283,7 @@ export const mockKeyManagerEndpoints: HandlersDefinition = {
       if (acctEmail === 'settings@key-manager-autogen.flowcrypt.test') {
         return { privateKeys: [{ decryptedPrivateKey: testConstants.existingPrv }] };
       }
-      if (acctEmail === 'settings@settings.flowcrypt.test') {
+      if (acctEmail === 'settings@test1.settings.flowcrypt.test') {
         return { privateKeys: [{ decryptedPrivateKey: testConstants.existingPrv }] };
       }
       if (acctEmail === 'test-update@settings.flowcrypt.test') {


### PR DESCRIPTION
This PR fixes processing logic in searching sent messages for contacts by query

close #5075 
close #5085 (also removed test interference)

----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing?

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
