### PR TITLE
issue #5093 Add primary key bit size info on compatibility test page

### DIFF
--- a/extension/js/common/core/crypto/pgp/openpgp-key.ts
+++ b/extension/js/common/core/crypto/pgp/openpgp-key.ts
@@ -341,6 +341,7 @@ export class OpenPGPKey {
     );
     result.set(`Primary key creation?`, await KeyUtil.formatResultAsync(async () => OpenPGPKey.formatDate(key.getCreationTime())));
     result.set(`Primary key expiration?`, await KeyUtil.formatResultAsync(async () => OpenPGPKey.formatDate(await key.getExpirationTime())));
+    result.set(`Primary key getBitSize?`, await KeyUtil.formatResultAsync(async () => await key.getAlgorithmInfo().bits));
     const encryptResult = await OpenPGPKey.testEncryptDecrypt(key);
     await Promise.all(encryptResult.map(msg => result.set(`Encrypt/Decrypt test: ${msg}`, '')));
     if (key.isPrivate()) {


### PR DESCRIPTION
This PR adds the primary key's bit size information on the compatibility test page result.

close #5093 

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
