### PR TITLE
issue #4862 add warning modal when downloading unencrypted attachment

### DIFF
--- a/extension/chrome/elements/attachment.ts
+++ b/extension/chrome/elements/attachment.ts
@@ -289,7 +289,9 @@ export class AttachmentDownloadView extends View {
       await this.recoverMissingAttachmentIdIfNeeded();
       await this.downloadDataIfNeeded();
       if (!this.isEncrypted) {
-        Browser.saveToDownloads(this.attachment);
+        if (await AttachmentWarnings.confirmSaveToDownloadsIfNeeded(this.attachment, this)) {
+          Browser.saveToDownloads(this.attachment);
+        }
       } else {
         await this.decryptAndSaveAttachmentToDownloads();
       }

--- a/test/source/mock/google/exported-messages/message-export-187cfc92db548a0c.json
+++ b/test/source/mock/google/exported-messages/message-export-187cfc92db548a0c.json
@@ -1,0 +1,126 @@
+{
+  "acctEmail": "flowcrypt.compatibility@gmail.com",
+  "full": {
+    "id": "187cfc92db548a0c",
+    "threadId": "187cfc92db548a0c",
+    "labelIds": [
+      "Label_15",
+      "SENT",
+      "INBOX"
+    ],
+    "snippet": "This is a test for flowcrypt-browser issue #4862.",
+    "payload": {
+      "partId": "",
+      "mimeType": "multipart/mixed",
+      "filename": "",
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "multipart/mixed; boundary=\"----sinikael-?=_1-16828182793220.34977726009444443\""
+        },
+        {
+          "name": "Openpgp",
+          "value": "id=E8F0517BA6D7DAB6081C96E4ADAC279C95093207"
+        },
+        {
+          "name": "From",
+          "value": "sender@domain.com"
+        },
+        {
+          "name": "To",
+          "value": "flowcrypt.compatibility@gmail.com"
+        },
+        {
+          "name": "Subject",
+          "value": "test for flowcrypt-browser #4862 (unencrypted executable attachment)"
+        },
+        {
+          "name": "Date",
+          "value": "Sat, 29 Apr 2023 18:31:20 -0700"
+        },
+        {
+          "name": "MIME-Version",
+          "value": "1.0"
+        }
+      ],
+      "body": {
+        "size": 0
+      },
+      "parts": [
+        {
+          "partId": "0",
+          "mimeType": "text/plain",
+          "filename": "",
+          "headers": [
+            {
+              "name": "Content-Type",
+              "value": "text/plain"
+            },
+            {
+              "name": "Content-Transfer-Encoding",
+              "value": "quoted-printable"
+            }
+          ],
+          "body": {
+            "size": 49,
+            "data": "VGhpcyBpcyBhIHRlc3QgZm9yIGZsb3djcnlwdC1icm93c2VyIGlzc3VlICM0ODYyLg=="
+          }
+        },
+        {
+          "partId": "1",
+          "mimeType": "application/octet-stream",
+          "filename": "sample.bat",
+          "headers": [
+            {
+              "name": "Content-Type",
+              "value": "application/octet-stream; name=sample.bat"
+            },
+            {
+              "name": "Content-Disposition",
+              "value": "attachment; filename=sample.bat"
+            },
+            {
+              "name": "X-Attachment-Id",
+              "value": "f_qdClfJyEaCcMGdWXeOWAmfZJYDsiuo@flowcrypt"
+            },
+            {
+              "name": "Content-Id",
+              "value": "<f_qdClfJyEaCcMGdWXeOWAmfZJYDsiuo@flowcrypt>"
+            },
+            {
+              "name": "Content-Transfer-Encoding",
+              "value": "base64"
+            }
+          ],
+          "body": {
+            "attachmentId": "ANGjdJ90eWOuNbh5w_y2DNzPy549jNjxzLC99zc7Eolh6oBkpNjYaW_iZAVBOejL1KWEYLF-ozIBcVxfgVdWygqbkJ0UpZTDHT_B1ue8EdVQQ7ORIY59HNN9PCTp6CCrKVQqP9w1skB03PKltsLJlTVrdntQa8fXUNYeiUN75b5HLYdUM-HfAy2n4BstnMi4qXbu2moJG_0MkdDwGzdUlkRxk3fJcXcpNCfULiA9txJldvG-0ApY8NE0UAYsLPdrx-UowQoADk23FiteSR5qM12YU2yK0DQzMhDoBaiQlkpuIg8KcXRM1GzhuqOTN4PaIbttZsEZX1czkpt2rS52YNB5jg3DwXoMeyysBdP6Wa3rEd1QbFpzsjt5X1LYFdCEVnGIRERg55oe8Q37I73M",
+            "size": 18
+          }
+        }
+      ]
+    },
+    "sizeEstimate": 1207,
+    "historyId": "1403825",
+    "internalDate": "1682818280000"
+  },
+  "attachments": {
+    "ANGjdJ90eWOuNbh5w_y2DNzPy549jNjxzLC99zc7Eolh6oBkpNjYaW_iZAVBOejL1KWEYLF-ozIBcVxfgVdWygqbkJ0UpZTDHT_B1ue8EdVQQ7ORIY59HNN9PCTp6CCrKVQqP9w1skB03PKltsLJlTVrdntQa8fXUNYeiUN75b5HLYdUM-HfAy2n4BstnMi4qXbu2moJG_0MkdDwGzdUlkRxk3fJcXcpNCfULiA9txJldvG-0ApY8NE0UAYsLPdrx-UowQoADk23FiteSR5qM12YU2yK0DQzMhDoBaiQlkpuIg8KcXRM1GzhuqOTN4PaIbttZsEZX1czkpt2rS52YNB5jg3DwXoMeyysBdP6Wa3rEd1QbFpzsjt5X1LYFdCEVnGIRERg55oe8Q37I73M": {
+      "data": "IyB0ZXN0IGJhdGNoIGZpbGUK",
+      "size": 18
+    }
+  },
+  "raw": {
+    "id": "187cfc92db548a0c",
+    "threadId": "187cfc92db548a0c",
+    "labelIds": [
+      "Label_15",
+      "SENT",
+      "INBOX"
+    ],
+    "snippet": "This is a test for flowcrypt-browser issue #4862.",
+    "sizeEstimate": 1207,
+    "raw": "UmVjZWl2ZWQ6IGZyb20gNzE3Mjg0NzMwMjQ0DQoJbmFtZWQgdW5rbm93bg0KCWJ5IGdtYWlsYXBpLmdvb2dsZS5jb20NCgl3aXRoIEhUVFBSRVNUOw0KCVNhdCwgMjkgQXByIDIwMjMgMTg6MzE6MjAgLTA3MDANCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L21peGVkOw0KIGJvdW5kYXJ5PSItLS0tc2luaWthZWwtPz1fMS0xNjgyODE4Mjc5MzIyMC4zNDk3NzcyNjAwOTQ0NDQ0MyINCk9wZW5wZ3A6IGlkPUU4RjA1MTdCQTZEN0RBQjYwODFDOTZFNEFEQUMyNzlDOTUwOTMyMDcNCkZyb206IEZsb3dDcnlwdCBDb21wYXRpYmlsaXR5IDxmbG93Y3J5cHQuY29tcGF0aWJpbGl0eUBnbWFpbC5jb20-DQpUbzogRmxvd0NyeXB0IENvbXBhdGliaWxpdHkgPGZsb3djcnlwdC5jb21wYXRpYmlsaXR5QGdtYWlsLmNvbT4NClN1YmplY3Q6IHRlc3QgZm9yIGZsb3djcnlwdC1icm93c2VyICM0ODYyICh1bmVuY3J5cHRlZCBleGVjdXRhYmxlDQogYXR0YWNobWVudCkNCkRhdGU6IFNhdCwgMjkgQXByIDIwMjMgMTg6MzE6MjAgLTA3MDANCk1lc3NhZ2UtSWQ6IDxDQUtidUxUcDREMExWb1VZLVhqM2ErUm56RjhtdHFZcjRTZmVxejUrVDB5VU10a1FDMmdAbWFpbC5nbWFpbC5jb20-DQpNSU1FLVZlcnNpb246IDEuMA0KDQotLS0tLS1zaW5pa2FlbC0_PV8xLTE2ODI4MTgyNzkzMjIwLjM0OTc3NzI2MDA5NDQ0NDQzDQpDb250ZW50LVR5cGU6IHRleHQvcGxhaW4NCkNvbnRlbnQtVHJhbnNmZXItRW5jb2Rpbmc6IHF1b3RlZC1wcmludGFibGUNCg0KVGhpcyBpcyBhIHRlc3QgZm9yIGZsb3djcnlwdC1icm93c2VyIGlzc3VlICM0ODYyLg0KLS0tLS0tc2luaWthZWwtPz1fMS0xNjgyODE4Mjc5MzIyMC4zNDk3NzcyNjAwOTQ0NDQ0Mw0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW07IG5hbWU9c2FtcGxlLmJhdA0KQ29udGVudC1EaXNwb3NpdGlvbjogYXR0YWNobWVudDsgZmlsZW5hbWU9c2FtcGxlLmJhdA0KWC1BdHRhY2htZW50LUlkOiBmX3FkQ2xmSnlFYUNjTUdkV1hlT1dBbWZaSllEc2l1b0BmbG93Y3J5cHQNCkNvbnRlbnQtSWQ6IDxmX3FkQ2xmSnlFYUNjTUdkV1hlT1dBbWZaSllEc2l1b0BmbG93Y3J5cHQ-DQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBiYXNlNjQNCg0KSXlCMFpYTjBJR0poZEdOb0lHWnBiR1VLDQotLS0tLS1zaW5pa2FlbC0_PV8xLTE2ODI4MTgyNzkzMjIwLjM0OTc3NzI2MDA5NDQ0NDQzLS0NCg==",
+    "historyId": "1403825",
+    "internalDate": "1682818280000"
+  }
+}

--- a/test/source/tests/decrypt.ts
+++ b/test/source/tests/decrypt.ts
@@ -1790,6 +1790,7 @@ d6Z36//MsmczN00Wd60t9T+qyLz0T4/UG2Y9lgf367f3d+kYPE0LS7mXuFmjlPXfw0nKyVsSeFiu
       testWithBrowser(async (t, browser) => {
         const threadId = '187365d19ec9a10c';
         const threadId2 = '18736a0687a8426b';
+        const threadId3 = '187cfc92db548a0c';
         const acctEmail = 'flowcrypt.compatibility@gmail.com';
         const expectedErrMsg = 'This executable file was not checked for viruses, and may be dangerous to download or run. Proceed anyway?';
         t.mockApi!.configProvider = new ConfigurationProvider({
@@ -1874,6 +1875,26 @@ d6Z36//MsmczN00Wd60t9T+qyLz0T4/UG2Y9lgf367f3d+kYPE0LS7mXuFmjlPXfw0nKyVsSeFiu
         );
         expect(Object.entries(downloadedFile6).length).to.equal(1);
         await gmailPage2.close();
+        // check warning modal for regular unencrypted attachment on FlowCrypt web extension page
+        const inboxPage3 = await browser.newExtensionPage(t, `chrome/settings/inbox/inbox.htm?acctEmail=${acctEmail}&threadId=${threadId3}`);
+        const attachmentFrame2 = await inboxPage3.getFrame(['attachment.htm']);
+        await attachmentFrame2.waitAndClick('@download-attachment');
+        const downloadedFile7 = await inboxPage3.awaitDownloadTriggeredByClicking(() =>
+          PageRecipe.waitForModalAndRespond(inboxPage3, 'confirm', {
+            contentToCheck: expectedErrMsg,
+            clickOn: 'confirm',
+          })
+        );
+        await attachmentFrame2.waitAndClick('@attachment-container');
+        const attachmentPreviewPage3 = await inboxPage3.getFrame(['attachment_preview.htm']);
+        await attachmentPreviewPage3.waitAndClick('@attachment-preview-download');
+        const downloadedFile8 = await attachmentPreviewPage3.awaitDownloadTriggeredByClicking(() =>
+          PageRecipe.waitForModalAndRespond(attachmentPreviewPage3, 'confirm', {
+            contentToCheck: expectedErrMsg,
+            clickOn: 'confirm',
+          })
+        );
+        expect(Object.entries([downloadedFile7, downloadedFile8]).length).to.equal(2);
       })
     );
   }


### PR DESCRIPTION
This PR adds a warning modal when downloading unencrypted file attachments on the FlowCrypt web extension page.

close #4862

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
