### PR TITLE
#5123 fix: get google token info issue

### DIFF
--- a/extension/js/common/api/email-provider/gmail/google-auth.ts
+++ b/extension/js/common/api/email-provider/gmail/google-auth.ts
@@ -85,7 +85,7 @@ export class GoogleAuth {
   public static getTokenInfo = async (accessToken: string): Promise<GoogleTokenInfo> => {
     return (await Api.ajax(
       {
-        url: `${GMAIL_GOOGLE_API_HOST}/oauth2/v1/tokeninfo?access_token=${accessToken}`,
+        url: `${GMAIL_GOOGLE_API_HOST}/oauth2/v3/tokeninfo?access_token=${accessToken}`,
         timeout: 10000,
       },
       Catch.stackTrace()

--- a/tooling/build-types-and-manifests.ts
+++ b/tooling/build-types-and-manifests.ts
@@ -91,12 +91,6 @@ const updateEnterpriseBuild = () => {
       pattern: /const FLAVOR = 'consumer';/g,
       replacement: `const FLAVOR = 'enterprise';`,
     },
-    {
-      // for now we use www.googleapis.com on consumer until CORS resolved to use gmail.googleapis.com
-      // (on enterprise we already use gmail.googleapis.com)
-      pattern: /const GMAIL_GOOGLE_API_HOST = '[^']+';/g,
-      replacement: `const GMAIL_GOOGLE_API_HOST = 'https://gmail.googleapis.com';`,
-    },
   ];
   const constFilepaths = [`${buildDir(CHROME_ENTERPRISE)}/js/common/core/const.js`, `${buildDir(CHROME_ENTERPRISE)}/js/content_scripts/webmail_bundle.js`];
   for (const constFilepath of constFilepaths) {


### PR DESCRIPTION
This PR fixed get google token info issue

close #5123 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test (Mock test is already implemented at `compose - load contacts through API`. However this issue happened because https://gmail.googleapis.com endpoint is no longer available and it's difficult to simulate this situation in live test)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
