### PR TITLE
#5136 Fix parsing multiple public keys from LDAP

### DIFF
--- a/extension/chrome/settings/setup.ts
+++ b/extension/chrome/settings/setup.ts
@@ -7,7 +7,7 @@ import { asyncSome, Url } from '../../js/common/core/common.js';
 import { ApiErr } from '../../js/common/api/shared/api-error.js';
 import { Assert } from '../../js/common/assert.js';
 import { Catch, CompanyLdapKeyMismatchError } from '../../js/common/platform/catch.js';
-import { KeyInfoWithIdentity, KeyUtil } from '../../js/common/core/crypto/key.js';
+import { Key, KeyInfoWithIdentity, KeyUtil } from '../../js/common/core/crypto/key.js';
 import { Gmail } from '../../js/common/api/email-provider/gmail/gmail.js';
 import { Google } from '../../js/common/api/email-provider/gmail/google.js';
 import { KeyImportUi } from '../../js/common/ui/key-import-ui.js';
@@ -415,7 +415,10 @@ export class SetupView extends View {
       const result = await this.pubLookup.attester.doLookupLdap(this.acctEmail);
       if (result.pubkeys.length) {
         const prvs = await KeyStoreUtil.parse(await KeyStore.getRequired(this.acctEmail));
-        const parsedPubKeys = await KeyUtil.parseMany(result.pubkeys.join('\n'));
+        const parsedPubKeys: Key[] = [];
+        for (const pubKey of result.pubkeys) {
+          parsedPubKeys.push(...(await KeyUtil.parseMany(pubKey)));
+        }
         const hasMatchingKey = await asyncSome(prvs, async privateKey => {
           return parsedPubKeys.some(parsedPubKey => privateKey.key.id === parsedPubKey.id);
         });

--- a/test/source/tests/setup.ts
+++ b/test/source/tests/setup.ts
@@ -18,7 +18,7 @@ import { BrowserHandle, ControllablePage } from '../browser';
 import { OauthPageRecipe } from './page-recipe/oauth-page-recipe';
 import { AvaContext } from './tooling';
 import { opgp } from '../core/crypto/pgp/openpgpjs-custom';
-import { hasPubKey, protonMailCompatKey, singlePubKeyAttesterConfig, somePubkey } from '../mock/attester/attester-key-constants';
+import { expiredPubkey, hasPubKey, protonMailCompatKey, singlePubKeyAttesterConfig, somePubkey } from '../mock/attester/attester-key-constants';
 import { ConfigurationProvider, HttpClientErr, Status } from '../mock/lib/api';
 import { prvNoSubmit } from '../mock/key-manager/key-manager-constants';
 import {
@@ -980,6 +980,45 @@ AN8G3r5Htj8olot+jm9mIa5XLXWzMNUZgg==
             ldapRelay: {
               [acct]: {
                 pubkey: hasPubKey,
+              },
+            },
+          },
+          fes: flowcryptTestClientConfiguration,
+        });
+        const settingsPage = await BrowserRecipe.openSettingsLoginApprove(t, browser, acct);
+        await SetupPageRecipe.manualEnter(
+          settingsPage,
+          'has.pub.client.configuration.test',
+          { noPrvCreateClientConfiguration: true, enforceAttesterSubmitClientConfiguration: true },
+          { isSavePassphraseChecked: false, isSavePassphraseHidden: false }
+        );
+        await settingsPage.waitAll(['@action-show-encrypted-inbox', '@action-open-security-page']);
+        await Util.sleep(1);
+        await settingsPage.notPresent(['@action-open-backup-page']);
+        const { cryptup_haspubclientconfigurationtestflowcrypttest_keys: keys } = await settingsPage.getFromLocalStorage([
+          'cryptup_haspubclientconfigurationtestflowcrypttest_keys',
+        ]);
+        const ki = keys as KeyInfoWithIdentity[];
+        expect(ki.length).to.equal(1);
+        expect(ki[0].private).to.include('PGP PRIVATE KEY');
+        expect(ki[0].private).to.not.include('Version');
+        expect(ki[0].private).to.not.include('Comment');
+        expect(ki[0].public).to.include('PGP PUBLIC KEY');
+        expect(ki[0].public).to.not.include('Version');
+        expect(ki[0].public).to.not.include('Comment');
+      })
+    );
+
+    // eslint-disable-next-line no-only-tests/no-only-tests
+    test.only(
+      'has.pub@client-configuration-test.flowcrypt.test - no backup, no keygen, multiple keys',
+      testWithBrowser(async (t, browser) => {
+        const acct = 'has.pub@client-configuration-test.flowcrypt.test';
+        t.mockApi!.configProvider = new ConfigurationProvider({
+          attester: {
+            ldapRelay: {
+              [acct]: {
+                pubkey: [expiredPubkey, hasPubKey].join('\n'),
               },
             },
           },

--- a/test/source/tests/setup.ts
+++ b/test/source/tests/setup.ts
@@ -1009,8 +1009,7 @@ AN8G3r5Htj8olot+jm9mIa5XLXWzMNUZgg==
       })
     );
 
-    // eslint-disable-next-line no-only-tests/no-only-tests
-    test.only(
+    test(
       'has.pub@client-configuration-test.flowcrypt.test - no backup, no keygen, multiple keys',
       testWithBrowser(async (t, browser) => {
         const acct = 'has.pub@client-configuration-test.flowcrypt.test';


### PR DESCRIPTION
This PR fixes parsing of multiple public keys returned from LDAP.

close #5136

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
