### PR TITLE
issue #5159 use alternative html injection point for container

### DIFF
--- a/extension/js/common/inject.ts
+++ b/extension/js/common/inject.ts
@@ -25,7 +25,7 @@ export class Injector {
   private S: SelCache;
   private container: { [key: string]: Host } = {
     composeBtnSel: {
-      gmail: 'div.aeN, div.aBO', // .aeN for normal look, .aBO for new look https://github.com/FlowCrypt/flowcrypt-browser/issues/4099
+      gmail: 'div.W8, div.aBO', // .aeN for normal look, .aBO for new look https://github.com/FlowCrypt/flowcrypt-browser/issues/4099
       outlook: 'div._fce_b',
       settings: '#does_not_have',
     },


### PR DESCRIPTION
This PR uses an alternative injection point for the FlowCrypt secure compose button in Gmail (mail.google.com) to fix the compatibility issue with Gmelius.

close #5159

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)
- Difficult to test (explain why)
- Not worth testing
- Tests will be added later (issue #...)
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
