### PR TITLE
#5169 fix: disable contacts search when pasting long string

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-recipients-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-recipients-module.ts
@@ -634,8 +634,14 @@ export class ComposeRecipientsModule extends ViewModule<ComposeView> {
    */
   private searchContacts = async (input: JQuery<HTMLElement>): Promise<void> => {
     try {
+      const searchString = String(input.val());
+      if (searchString.includes(',') || searchString.length >= 100) {
+        // https://github.com/FlowCrypt/flowcrypt-browser/issues/5169
+        this.view.errModule.debug(`Skipping searchContacts if the user is pasting multiple recipients or the search string length exceeds 100 characters`);
+        return;
+      }
       this.view.errModule.debug(`searchContacts`);
-      const substring = Str.parseEmail(String(input.val()), 'DO-NOT-VALIDATE').email;
+      const substring = Str.parseEmail(searchString, 'DO-NOT-VALIDATE').email;
       this.view.errModule.debug(`searchContacts.query.substring(${JSON.stringify(substring)})`);
       if (!substring) {
         this.view.errModule.debug(`searchContacts 1`);


### PR DESCRIPTION
This PR disables contacts search when pasting long string

close #5169 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
