### PR TITLE
allow spinner image on gmail page

### DIFF
--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -453,6 +453,15 @@ span.pgp_attachment > iframe {
   overflow: hidden;
 }
 
+div.attachment_loader {
+  line-height: 24px;
+}
+
+div.attachment_loader > i {
+  position: relative;
+  top: 6px;
+}
+
 div.reply_message_iframe_container {
   margin-bottom: 0;
   padding-bottom: 0;

--- a/extension/js/common/platform/xss.ts
+++ b/extension/js/common/platform/xss.ts
@@ -254,14 +254,10 @@ export class Xss {
    */
   private static sanitizeHrefRegexp = () => {
     if (typeof Xss.HREF_REGEX_CACHE === 'undefined') {
-      if (window?.location?.origin && window.location.origin.match(/^(?:chrome-extension|moz-extension):\/\/[a-z0-9\-]+$/g)) {
-        Xss.HREF_REGEX_CACHE = new RegExp(
-          `^(?:(http|https|cid):|data:image/|${Str.regexEscape(window.location.origin)}|[^a-z]|[a-z+.\\-]+(?:[^a-z+.\\-:]|$))`,
-          'i'
-        );
-      } else {
-        Xss.HREF_REGEX_CACHE = /^(?:(http|https):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i;
-      }
+      Xss.HREF_REGEX_CACHE = new RegExp(
+        `^(?:(http|https|cid):|data:image/|${Str.regexEscape(chrome.runtime.getURL('/'))}|[^a-z]|[a-z+.\\-]+(?:[^a-z+.\\-:]|$))`,
+        'i'
+      );
     }
     return Xss.HREF_REGEX_CACHE;
   };


### PR DESCRIPTION
This PR allows the spinner image to be visible on gmail page
(actually allows hrefs to extension's resources)

close #5196

----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing?

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
