### PR TITLE
issue #5211 Add public key lookup in compatibility test page

### DIFF
--- a/extension/chrome/settings/modules/compatibility.htm
+++ b/extension/chrome/settings/modules/compatibility.htm
@@ -17,6 +17,14 @@
       <div class="line">Locally test any public or private key.</div>
 
       <div class="line">
+        <label
+          >Search for public key on FlowCrypt Attester
+          <input type="text" class="input_email" placeholder="Email address" maxlength="256" />
+        </label>
+        <button class="button green action_load_public_key">load public key</button>
+      </div>
+
+      <div class="line">
         <textarea
           placeholder="ASCII Armored Public or Private Key....."
           class="input_key"

--- a/extension/chrome/settings/modules/compatibility.htm
+++ b/extension/chrome/settings/modules/compatibility.htm
@@ -19,7 +19,7 @@
       <div class="line">
         <label
           >Search for public key on FlowCrypt Attester
-          <input type="text" class="input_email" placeholder="Email address" maxlength="256" />
+          <input class="input_email" type="text" placeholder="Email address" style="height: 37px !important" maxlength="256" />
         </label>
         <button class="button green action_load_public_key">load public key</button>
       </div>


### PR DESCRIPTION
This PR Adds a public key lookup in the compatibility test extension page.

close #5211

Screenshots:

![Screenshot from 2023-06-09 13-24-10](https://github.com/FlowCrypt/flowcrypt-browser/assets/46025304/084e4f41-2fed-46eb-98e5-5a189feb886b)
![Screenshot from 2023-06-09 13-23-55](https://github.com/FlowCrypt/flowcrypt-browser/assets/46025304/d8ab8500-25a0-4289-8d06-5407f1a50fdf)

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
