### PR TITLE
#5229 fix: hide "also submit the same pubkey for" label when list is empty

### DIFF
--- a/extension/chrome/settings/setup.htm
+++ b/extension/chrome/settings/setup.htm
@@ -146,7 +146,7 @@
             Submit corresponding pubkey to FlowCrypt Attester (recommended)
           </label>
         </div>
-        <div class="line left display_none remove_if_pubkey_submitting_not_user_configurable">
+        <div class="line left display_none remove_if_pubkey_submitting_not_user_configurable container_for_import_key_email_alias">
           <label>
             <input type="checkbox" class="input_submit_all" disabled="disabled" />
             <span>
@@ -236,7 +236,7 @@
             <div
               class="line left remove_if_pubkey_submitting_not_user_configurable container_for_import_key_email_alias"
               data-test="container-for-import-key-email-alias"
-              style="visibility: hidden"
+              style="display: none"
             >
               <label>
                 <input type="checkbox" class="input_submit_all" disabled="disabled" />

--- a/extension/chrome/settings/setup.htm
+++ b/extension/chrome/settings/setup.htm
@@ -146,7 +146,7 @@
             Submit corresponding pubkey to FlowCrypt Attester (recommended)
           </label>
         </div>
-        <div class="line left display_none remove_if_pubkey_submitting_not_user_configurable container_for_import_key_email_alias">
+        <div class="line left display_none remove_if_pubkey_submitting_not_user_configurable also_submit_alias_key_view">
           <label>
             <input type="checkbox" class="input_submit_all" disabled="disabled" />
             <span>
@@ -234,7 +234,7 @@
               </label>
             </div>
             <div
-              class="line left remove_if_pubkey_submitting_not_user_configurable container_for_import_key_email_alias"
+              class="line left remove_if_pubkey_submitting_not_user_configurable container_for_import_key_email_alias also_submit_alias_key_view"
               data-test="container-for-import-key-email-alias"
               style="display: none"
             >

--- a/extension/chrome/settings/setup/setup-render.ts
+++ b/extension/chrome/settings/setup/setup-render.ts
@@ -189,7 +189,7 @@ export class SetupRenderModule {
       }
     });
     if (emailAliases.length > 0) {
-      $('.container_for_import_key_email_alias').show();
+      $('.also_submit_alias_key_view').show();
     }
     $('.manual .input_submit_all').prop({ checked: true, disabled: false });
   };

--- a/extension/chrome/settings/setup/setup-render.ts
+++ b/extension/chrome/settings/setup/setup-render.ts
@@ -189,9 +189,9 @@ export class SetupRenderModule {
       }
     });
     if (emailAliases.length > 0) {
-      $('.container_for_import_key_email_alias').css('visibility', 'visible');
+      $('.container_for_import_key_email_alias').show();
     }
-    $('.manual .input_submit_all').prop({ checked: true, disabled: false }).closest('div.line').css('display', 'block');
+    $('.manual .input_submit_all').prop({ checked: true, disabled: false });
   };
 
   private filterAddressesForSubmittingKeys = (addresses: string[]): string[] => {


### PR DESCRIPTION
This PR hides `also submit the same pubkey for` label when list is empty

close #5229 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
