### PR TITLE
#5282 Strip query strings on error reports

### DIFF
--- a/extension/chrome/dev/ci_unit_test.ts
+++ b/extension/chrome/dev/ci_unit_test.ts
@@ -23,11 +23,6 @@ import { PgpHash } from '../../js/common/core/crypto/pgp/pgp-hash.js';
 import { PgpArmor } from '../../js/common/core/crypto/pgp/pgp-armor.js';
 import { Xss } from '../../js/common/platform/xss.js';
 
-/* Used for test "Catcher does not include query string on report" */
-const urlParamSize = new URL(window.location.href).searchParams.size;
-if (urlParamSize <= 0) {
-  window.location.href = '?test1=test_value_1&test2=test_value_2';
-}
 /**
  * importing all libs that are tested in ci tests
  * add lib name below, let the IDE resolve the actual import

--- a/extension/chrome/dev/ci_unit_test.ts
+++ b/extension/chrome/dev/ci_unit_test.ts
@@ -23,6 +23,11 @@ import { PgpHash } from '../../js/common/core/crypto/pgp/pgp-hash.js';
 import { PgpArmor } from '../../js/common/core/crypto/pgp/pgp-armor.js';
 import { Xss } from '../../js/common/platform/xss.js';
 
+/* Used for test "Catcher does not include query string on report" */
+const urlParamSize = new URL(window.location.href).searchParams.size;
+if (urlParamSize <= 0) {
+  window.location.href = '?test1=test_value_1&test2=test_value_2';
+}
 /**
  * importing all libs that are tested in ci tests
  * add lib name below, let the IDE resolve the actual import

--- a/extension/js/common/platform/catch.ts
+++ b/extension/js/common/platform/catch.ts
@@ -292,7 +292,7 @@ export class Catch {
     return {
       name: exception.name.substring(0, 50),
       message: exception.message.substring(0, 200),
-      url: window.location.href.substring(0, 100),
+      url: window.location.href.split('?')[0],
       line: line || 0,
       col: col || 0,
       trace: exception.stack || '',

--- a/test/source/tests/browser-unit-tests/unit-Catch.js
+++ b/test/source/tests/browser-unit-tests/unit-Catch.js
@@ -63,8 +63,10 @@ BROWSER_UNIT_TEST_NAME(`Catcher does report sensitive infos`);
 BROWSER_UNIT_TEST_NAME(`Catcher does not include query string on report`);
 (async () => {
   const formatted = Catch.formatExceptionForReport({'name': 'Error'});
+  const expectedUrl = 'chrome-extension://extension-id/chrome/dev/ci_unit_test.htm';
   if (formatted.url.indexOf('?') !== -1) {
-    throw new Error(`The reported URL where the error occurred should not include query strings. Expecting ${expectedUrl} but got ${formatted.url}.`)
+    const url = formatted.url.replace(/(\w{32})/,'extension-id');
+    throw new Error(`The reported URL where the error occurred should not include query strings. Expecting ${expectedUrl} but got ${url}.`);
   }
   return 'pass';
 })();

--- a/test/source/tests/browser-unit-tests/unit-Catch.js
+++ b/test/source/tests/browser-unit-tests/unit-Catch.js
@@ -59,3 +59,12 @@ BROWSER_UNIT_TEST_NAME(`Catcher does report sensitive infos`);
   }
   return 'pass';
 })();
+
+BROWSER_UNIT_TEST_NAME(`Catcher does not include query string on report`);
+(async () => {
+  const formatted = Catch.formatExceptionForReport({'name': 'Error'});
+  if (formatted.url.indexOf('?') !== -1) {
+    throw new Error(`The reported url where the error occur should not include query strings. Expecting ${expectedUrl} but got ${formatted.url}.`)
+  }
+  return 'pass';
+})();

--- a/test/source/tests/browser-unit-tests/unit-Catch.js
+++ b/test/source/tests/browser-unit-tests/unit-Catch.js
@@ -64,7 +64,7 @@ BROWSER_UNIT_TEST_NAME(`Catcher does not include query string on report`);
 (async () => {
   const formatted = Catch.formatExceptionForReport({'name': 'Error'});
   if (formatted.url.indexOf('?') !== -1) {
-    throw new Error(`The reported url where the error occur should not include query strings. Expecting ${expectedUrl} but got ${formatted.url}.`)
+    throw new Error(`The reported URL where the error occurred should not include query strings. Expecting ${expectedUrl} but got ${formatted.url}.`)
   }
   return 'pass';
 })();

--- a/test/source/tests/unit-browser.ts
+++ b/test/source/tests/unit-browser.ts
@@ -61,7 +61,8 @@ export const defineUnitBrowserTests = (testVariant: TestVariant, testWithBrowser
               },
             });
           }
-          const hostPage = await browser.newExtensionPage(t, 'chrome/dev/ci_unit_test.htm');
+          /* The "test" parameter is utilized by the unit test named "Catcher does not include query string on report." */
+          const hostPage = await browser.newExtensionPage(t, 'chrome/dev/ci_unit_test.htm?test=1');
           // update host page h1
           await hostPage.target.evaluate(title => {
             window.document.getElementsByTagName('h1')[0].textContent = title;


### PR DESCRIPTION
This PR strips query strings on reported errors.

close #5282 

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
