### PR TITLE
restore trailingComma setting

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,3 +3,4 @@ semi: true
 singleQuote: true
 endOfLine: 'auto'
 arrowParens: 'avoid'
+trailingComma: 'es5'


### PR DESCRIPTION
This PR explicitly sets the previous `trailingComma` prettier's settings

Default value changed from `es5` to `all` in `prettier v3.0.0`

I think we should explicitly set the older value to avoid unnecessary updates

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
