### PR TITLE
frame-level dest for confirmation_result and pgp_block_render messages

### DIFF
--- a/extension/chrome/elements/attachment.ts
+++ b/extension/chrome/elements/attachment.ts
@@ -25,8 +25,8 @@ import { AttachmentWarnings } from './shared/attachment_warnings.js';
 export class AttachmentDownloadView extends View {
   public fesUrl?: string;
   public confirmationResultResolver?: (confirm: boolean) => void;
+  public readonly parentTabId: string;
   protected readonly acctEmail: string;
-  protected readonly parentTabId: string;
   protected readonly frameId: string;
   protected readonly origNameBasedOnFilename: string;
   protected readonly isEncrypted: boolean;
@@ -85,8 +85,8 @@ export class AttachmentDownloadView extends View {
     this.gmail = new Gmail(this.acctEmail);
   }
 
-  public getParentTabId = () => {
-    return this.parentTabId;
+  public getDest = () => {
+    return this.tabId;
   };
 
   public render = async () => {

--- a/extension/chrome/elements/pgp_block.ts
+++ b/extension/chrome/elements/pgp_block.ts
@@ -4,7 +4,7 @@
 
 import { Url } from '../../js/common/core/common.js';
 import { Assert } from '../../js/common/assert.js';
-import { RenderMessage, RenderMessageWithFrameId } from '../../js/common/render-message.js';
+import { RenderMessage } from '../../js/common/render-message.js';
 import { Attachment } from '../../js/common/core/attachment.js';
 import { Xss } from '../../js/common/platform/xss.js';
 import { PgpBlockViewAttachmentsModule } from './pgp_block_modules/pgp-block-attachmens-module.js';
@@ -12,9 +12,9 @@ import { PgpBlockViewErrorModule } from './pgp_block_modules/pgp-block-error-mod
 import { PgpBlockViewPrintModule } from './pgp_block_modules/pgp-block-print-module.js';
 import { PgpBlockViewQuoteModule } from './pgp_block_modules/pgp-block-quote-module.js';
 import { PgpBlockViewRenderModule } from './pgp_block_modules/pgp-block-render-module.js';
-import { Ui } from '../../js/common/browser/ui.js';
+import { CommonHandlers, Ui } from '../../js/common/browser/ui.js';
 import { View } from '../../js/common/view.js';
-import { Bm } from '../../js/common/browser/browser-msg.js';
+import { BrowserMsg } from '../../js/common/browser/browser-msg.js';
 
 export class PgpBlockView extends View {
   public readonly acctEmail: string; // needed for attachment decryption, probably should be refactored out
@@ -27,6 +27,7 @@ export class PgpBlockView extends View {
   public readonly errorModule: PgpBlockViewErrorModule;
   public readonly renderModule: PgpBlockViewRenderModule;
   public readonly printModule = new PgpBlockViewPrintModule();
+  private tabId!: string;
 
   public constructor() {
     super();
@@ -41,21 +42,14 @@ export class PgpBlockView extends View {
     this.quoteModule = new PgpBlockViewQuoteModule(this);
     this.errorModule = new PgpBlockViewErrorModule(this);
     this.renderModule = new PgpBlockViewRenderModule(this);
-    chrome.runtime.onMessage.addListener((message: Bm.Raw) => {
-      if (message.name === 'pgp_block_render') {
-        const msg = message.data.bm as RenderMessageWithFrameId;
-        if (msg.frameId === this.frameId) {
-          this.processMessage(msg);
-          return true;
-        }
-      }
-      return false;
-    });
-    window.addEventListener('load', () => window.parent.postMessage({ readyToReceive: this.frameId }, '*'));
   }
 
+  public getDest = () => {
+    return this.tabId;
+  };
+
   public render = async () => {
-    //
+    this.tabId = await BrowserMsg.requiredTabId();
   };
 
   public setHandlers = () => {
@@ -63,6 +57,12 @@ export class PgpBlockView extends View {
       'click',
       this.setHandler(() => this.printModule.printPGPBlock())
     );
+    BrowserMsg.addListener('pgp_block_render', async (msg: RenderMessage) => {
+      this.processMessage(msg);
+    });
+    BrowserMsg.addListener('confirmation_result', CommonHandlers.createConfirmationResultHandler(this));
+    BrowserMsg.listen(this.tabId);
+    BrowserMsg.send.pgpBlockReady(this.parentTabId, { frameId: this.frameId, tabId: this.tabId });
   };
 
   private processMessage = (data: RenderMessage) => {

--- a/extension/chrome/elements/pgp_block_modules/pgp-block-attachmens-module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp-block-attachmens-module.ts
@@ -7,7 +7,7 @@ import { Attachment } from '../../../js/common/core/attachment.js';
 import { Browser } from '../../../js/common/browser/browser.js';
 import { BrowserMsg } from '../../../js/common/browser/browser-msg.js';
 import { PgpBlockView } from '../pgp_block.js';
-import { CommonHandlers, Ui } from '../../../js/common/browser/ui.js';
+import { Ui } from '../../../js/common/browser/ui.js';
 import { Xss } from '../../../js/common/platform/xss.js';
 import { KeyStore } from '../../../js/common/platform/store/key-store.js';
 import { XssSafeFactory } from '../../../js/common/xss-safe-factory.js';
@@ -20,10 +20,6 @@ export class PgpBlockViewAttachmentsModule {
   public includedAttachments: Attachment[] = [];
 
   public constructor(private view: PgpBlockView) {}
-
-  public getParentTabId = () => {
-    return this.view.parentTabId;
-  };
 
   public renderInnerAttachments = (attachments: Attachment[], isEncrypted: boolean) => {
     Xss.sanitizeAppend('#pgp_block', '<div id="attachments"></div>');
@@ -78,8 +74,6 @@ export class PgpBlockViewAttachmentsModule {
         }
       })
     );
-    BrowserMsg.addListener('confirmation_result', CommonHandlers.createConfirmationResultHandler(this));
-    BrowserMsg.listen(this.view.parentTabId);
   };
 
   private previewAttachmentClickedHandler = async (attachment: Attachment) => {
@@ -102,7 +96,7 @@ export class PgpBlockViewAttachmentsModule {
         type: encrypted.type,
         data: decrypted.content,
       });
-      if (await AttachmentWarnings.confirmSaveToDownloadsIfNeeded(attachment, this)) {
+      if (await AttachmentWarnings.confirmSaveToDownloadsIfNeeded(attachment, this.view)) {
         Browser.saveToDownloads(attachment);
       }
     } else {

--- a/extension/chrome/elements/pgp_block_modules/pgp-block-render-module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp-block-render-module.ts
@@ -145,7 +145,7 @@ export class PgpBlockViewRenderModule {
   public renderSignatureOffline = () => {
     this.renderSignatureStatus('error verifying signature: offline, click to retry').on(
       'click',
-      this.view.setHandler(() => window.parent.postMessage({ retry: this.view.frameId }, '*'))
+      this.view.setHandler(() => BrowserMsg.send.pgpBlockRetry(this.view.getDest(), { frameId: this.view.frameId }))
     );
   };
 }

--- a/extension/js/common/browser/ui.ts
+++ b/extension/js/common/browser/ui.ts
@@ -14,7 +14,8 @@ type NamedSels = Dict<JQuery<HTMLElement>>;
 type ProvidedEventHandler = (e: HTMLElement, event: JQuery.TriggeredEvent<HTMLElement>) => void | Promise<void>;
 
 export interface ConfirmationResultTracker {
-  getParentTabId: () => string;
+  getDest: () => string;
+  parentTabId: string;
   confirmationResultResolver?: (confirm: boolean) => void;
 }
 
@@ -24,9 +25,9 @@ export class CommonHandlers {
       view.confirmationResultResolver?.(confirm);
     };
   };
-  public static showConfirmationHandler: Bm.AsyncResponselessHandler = async ({ text, isHTML, footer }: Bm.ShowConfirmation) => {
+  public static showConfirmationHandler: Bm.AsyncResponselessHandler = async ({ text, isHTML, footer, responseDest }: Bm.ShowConfirmation) => {
     const confirm = await Ui.modal.confirm(text, isHTML, footer);
-    BrowserMsg.send.confirmationResult('broadcast', { confirm });
+    BrowserMsg.send.confirmationResult(responseDest, { confirm });
   };
 }
 
@@ -335,7 +336,12 @@ export class Ui {
         const p = new Promise((resolve: (value: boolean) => void) => {
           confirmationResultTracker.confirmationResultResolver = resolve;
         });
-        BrowserMsg.send.showConfirmation(confirmationResultTracker.getParentTabId(), { text, isHTML, footer });
+        BrowserMsg.send.showConfirmation(confirmationResultTracker.parentTabId, {
+          text,
+          isHTML,
+          footer,
+          responseDest: confirmationResultTracker.getDest(),
+        });
         return await p;
       },
     };

--- a/extension/js/common/render-message.ts
+++ b/extension/js/common/render-message.ts
@@ -40,7 +40,3 @@ export type RenderMessage = {
   printMailInfo?: PrintMailInfo;
   renderAsRegularContent?: string;
 };
-
-export type RenderMessageWithFrameId = {
-  frameId: string;
-} & RenderMessage;


### PR DESCRIPTION
This PR specifies tabId:frameId in messaging when sending a message from a content script to an iframe within it.

close #5298

issue #1509 (part of refactoring)

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
