### PR TITLE
#5340 Check if attachment is decrypted before downloading

### DIFF
--- a/extension/chrome/elements/pgp_block.ts
+++ b/extension/chrome/elements/pgp_block.ts
@@ -7,7 +7,7 @@ import { Assert } from '../../js/common/assert.js';
 import { RenderMessage } from '../../js/common/render-message.js';
 import { Attachment } from '../../js/common/core/attachment.js';
 import { Xss } from '../../js/common/platform/xss.js';
-import { PgpBlockViewAttachmentsModule } from './pgp_block_modules/pgp-block-attachmens-module.js';
+import { PgpBlockViewAttachmentsModule } from './pgp_block_modules/pgp-block-attachments-module.js';
 import { PgpBlockViewErrorModule } from './pgp_block_modules/pgp-block-error-module.js';
 import { PgpBlockViewPrintModule } from './pgp_block_modules/pgp-block-print-module.js';
 import { PgpBlockViewQuoteModule } from './pgp_block_modules/pgp-block-quote-module.js';

--- a/extension/chrome/elements/pgp_block_modules/pgp-block-attachments-module.ts
+++ b/extension/chrome/elements/pgp_block_modules/pgp-block-attachments-module.ts
@@ -60,7 +60,7 @@ export class PgpBlockViewAttachmentsModule {
         event.stopPropagation();
         const attachment = this.includedAttachments[Number($(target).attr('index'))];
         if (attachment.hasData()) {
-          await this.downloadAttachment(attachment);
+          await this.decryptIfNeededAndDownloadAttachment(attachment);
         } else {
           Xss.sanitizePrepend($(target).find('.progress'), Ui.spinner('green'));
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -70,7 +70,7 @@ export class PgpBlockViewAttachmentsModule {
           if (!attachment.hasData()) attachment.setData(buf); // there may be some sort of a race
           await Ui.delay(100); // give browser time to render
           $(target).find('.progress').text('');
-          await this.downloadAttachment(attachment);
+          await this.decryptIfNeededAndDownloadAttachment(attachment);
         }
       })
     );
@@ -82,7 +82,7 @@ export class PgpBlockViewAttachmentsModule {
     BrowserMsg.send.showAttachmentPreview(this.view.parentTabId, { iframeUrl });
   };
 
-  private downloadAttachment = async (attachment: Attachment) => {
+  private decryptIfNeededAndDownloadAttachment = async (attachment: Attachment) => {
     if (attachment.treatAs(this.includedAttachments) === 'encryptedFile') {
       await this.decryptAndSaveAttachmentToDownloads(attachment);
     } else {

--- a/test/source/tests/settings.ts
+++ b/test/source/tests/settings.ts
@@ -24,7 +24,7 @@ import { BrowserHandle, ControllablePage } from '../browser';
 import { AvaContext } from './tooling';
 import { ConfigurationProvider, HttpClientErr, Status } from '../mock/lib/api';
 import { somePubkey, testMatchPubKey } from '../mock/attester/attester-key-constants';
-import { emailKeyIndex } from '../core/common';
+import { Dict, emailKeyIndex } from '../core/common';
 import { twoKeys1, twoKeys2 } from '../mock/key-manager/key-manager-constants';
 import { getKeyManagerAutogenRules } from '../mock/fes/fes-constants';
 import { FesClientConfiguration } from '../mock/fes/shared-tenant-fes-endpoints';
@@ -799,23 +799,33 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
       'settings - pgp/mime preview and download attachment',
       testWithBrowser(async (t, browser) => {
         const { authHdr } = await BrowserRecipe.setupCommonAcctWithAttester(t, browser, 'compatibility');
-        const checkPage = async (page: ControllablePage) => {
+        const checkPage = async (page: ControllablePage, withPreview: boolean) => {
           const pgpBlockFrame = await page.getFrame(['pgp_block.htm']);
-          // check if download is awailable
           await pgpBlockFrame.waitAll('.download-attachment');
-          // and preview
-          await pgpBlockFrame.waitAndClick('.preview-attachment');
-          const attachmentPreviewImage = await page.getFrame(['attachment_preview.htm']);
-          await attachmentPreviewImage.waitAll('#attachment-preview-container img.attachment-preview-img');
-          const downloadedFiles = await attachmentPreviewImage.awaitDownloadTriggeredByClicking(() =>
-            attachmentPreviewImage.waitAndClick('@attachment-preview-download')
-          );
+
+          let downloadedFiles: Dict<Buffer>;
+          if (withPreview) {
+            await pgpBlockFrame.waitAndClick('.preview-attachment');
+            const attachmentPreviewImage = await page.getFrame(['attachment_preview.htm']);
+            await attachmentPreviewImage.waitAll('#attachment-preview-container img.attachment-preview-img');
+            downloadedFiles = await attachmentPreviewImage.awaitDownloadTriggeredByClicking(() =>
+              attachmentPreviewImage.waitAndClick('@attachment-preview-download')
+            );
+          } else {
+            downloadedFiles = await pgpBlockFrame.awaitDownloadTriggeredByClicking(() => pgpBlockFrame.waitAndClick('@download-attachment-0'));
+          }
+
           expect(Object.keys(downloadedFiles)).contains('7 years.jpeg');
           await page.close();
         };
         const msgId = '16e8b01f136c3d28';
-        await checkPage(await browser.newPage(t, `${t.context.urls?.mockGmailUrl()}/${msgId}`, undefined, authHdr));
-        await checkPage(await browser.newExtensionPage(t, `chrome/settings/inbox/inbox.htm?acctEmail=flowcrypt.compatibility@gmail.com&threadId=${msgId}`));
+        for (const withPreview of [true, false]) {
+          await checkPage(await browser.newPage(t, `${t.context.urls?.mockGmailUrl()}/${msgId}`, undefined, authHdr), withPreview);
+          await checkPage(
+            await browser.newExtensionPage(t, `chrome/settings/inbox/inbox.htm?acctEmail=flowcrypt.compatibility@gmail.com&threadId=${msgId}`),
+            withPreview
+          );
+        }
       })
     );
     const checkIfFileDownloadsCorrectly = async (t: AvaContext, browser: BrowserHandle, threadId: string, fileName: string) => {


### PR DESCRIPTION
This PR adds check if attachment is decrypted before trying to download it, to fix error message which appeared when extension tried to decrypt already decrypted attachment.

close #5340

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
