### PR TITLE
#5367 Add origin check for postMessage

### DIFF
--- a/extension/js/common/browser/browser-msg.ts
+++ b/extension/js/common/browser/browser-msg.ts
@@ -391,7 +391,7 @@ export class BrowserMsg {
       try {
         const iframeOrigin = new URL(iframe.src).origin;
         return iframeOrigin === extensionOrigin;
-      } catch (error) {
+      } catch {
         return false;
       }
     });

--- a/extension/js/common/browser/browser-msg.ts
+++ b/extension/js/common/browser/browser-msg.ts
@@ -385,9 +385,18 @@ export class BrowserMsg {
   };
 
   private static sendToChildren = (encryptedMsg: SymEncryptedMessage) => {
-    const childFrames = $(`iframe`).get() as HTMLIFrameElement[];
-    for (const childFrame of childFrames) {
-      childFrame.contentWindow?.postMessage(encryptedMsg, Env.getExtensionOrigin());
+    const extensionOrigin = Env.getExtensionOrigin();
+    const childFrames = Array.from(document.querySelectorAll('iframe'));
+    const childFramesWithExtensionOrigin = childFrames.filter(iframe => {
+      try {
+        const iframeOrigin = new URL(iframe.src).origin;
+        return iframeOrigin === extensionOrigin;
+      } catch (error) {
+        return false;
+      }
+    });
+    for (const childFrame of childFramesWithExtensionOrigin) {
+      childFrame.contentWindow?.postMessage(encryptedMsg, extensionOrigin);
     }
   };
 

--- a/test/source/browser/controllable.ts
+++ b/test/source/browser/controllable.ts
@@ -693,7 +693,6 @@ export class ControllableAlert {
 }
 
 class ConsoleEvent {
-  // eslint-disable-next-line no-empty-function
   public constructor(
     public type: string,
     public text: string

--- a/test/source/mock/google/strategies/send-message-strategy.ts
+++ b/test/source/mock/google/strategies/send-message-strategy.ts
@@ -310,7 +310,7 @@ class PlainTextMessageTestStrategy implements ITestMsgStrategy {
 }
 
 class NoopTestStrategy implements ITestMsgStrategy {
-  public test = async () => {}; // eslint-disable-line @typescript-eslint/no-empty-function
+  public test = async () => {};
 }
 
 class IncludeQuotedPartTestStrategy implements ITestMsgStrategy {

--- a/test/source/tests/gmail.ts
+++ b/test/source/tests/gmail.ts
@@ -426,7 +426,6 @@ export const defineGmailTests = (testVariant: TestVariant, testWithBrowser: Test
       })
     );
 
-    // eslint-disable-next-line no-only-tests/no-only-tests
     test(
       'mail.google.com - plain reply with dot menu',
       testWithBrowser(async (t, browser) => {

--- a/test/source/tests/settings.ts
+++ b/test/source/tests/settings.ts
@@ -970,7 +970,7 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
         );
         // test the pubkey in the storage
         const oldContact = await dbPage.page.evaluate(async acctEmail => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
           return await (window as any).ContactStore.getOneWithAllPubkeys(undefined, acctEmail);
         }, acctEmail);
         expect(oldContact.sortedPubkeys.length).to.equal(1);
@@ -992,7 +992,7 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
         });
         // test the pubkey in the storage
         const expectedOldContact = await dbPage.page.evaluate(async acctEmail => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
           return await (window as any).ContactStore.getOneWithAllPubkeys(undefined, acctEmail);
         }, acctEmail);
         expect(expectedOldContact.sortedPubkeys.length).to.equal(1);
@@ -1008,7 +1008,7 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
         });
         // test the pubkey in the storage
         const newContact = await dbPage.page.evaluate(async acctEmail => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
           return await (window as any).ContactStore.getOneWithAllPubkeys(undefined, acctEmail);
         }, acctEmail);
         expect(newContact.sortedPubkeys.length).to.equal(1);

--- a/test/source/tests/setup.ts
+++ b/test/source/tests/setup.ts
@@ -2409,7 +2409,7 @@ AN8G3r5Htj8olot+jm9mIa5XLXWzMNUZgg==
             },
           },
         });
-        /* eslint-disable @typescript-eslint/naming-convention */
+        /* eslint-enable @typescript-eslint/naming-convention */
         const settingsPage = await BrowserRecipe.openSettingsLoginApprove(t, browser, acctEmail);
         await SetupPageRecipe.createKey(settingsPage, '', 'disabled', {
           skipForPassphrase: true,


### PR DESCRIPTION
This PR checks iframe origin before sending message with `postMessage`

close #5367

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
