### PR TITLE
#5408 Fix broken PDF files when downloading from preview page

### DIFF
--- a/extension/chrome/elements/attachment_preview.ts
+++ b/extension/chrome/elements/attachment_preview.ts
@@ -60,7 +60,8 @@ View.run(
               this.attachmentPreviewContainer.html(`<div class="attachment-preview-txt">${Xss.escape(result.toUtfStr()).replace(/\n/g, '<br>')}</div>`); // xss-escaped
             } else if (attachmentType === 'pdf') {
               // PDF
-              pdfjsLib.getDocument({ data: result }).promise.then(async (pdf: PDFDocumentProxy) => {
+              // .slice() is used to copy attachment data https://github.com/FlowCrypt/flowcrypt-browser/issues/5408
+              pdfjsLib.getDocument({ data: result.slice() }).promise.then(async (pdf: PDFDocumentProxy) => {
                 const previewPdf = new AttachmentPreviewPdf(this.attachmentPreviewContainer, pdf);
                 await previewPdf.render();
               });

--- a/test/source/tests/settings.ts
+++ b/test/source/tests/settings.ts
@@ -745,6 +745,29 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
       })
     );
     test(
+      'settings - #5408 PDF files downloaded correctly from attachment previews',
+      testWithBrowser(async (t, browser) => {
+        await BrowserRecipe.setupCommonAcctWithAttester(t, browser, 'compatibility');
+        const inboxPage = await browser.newExtensionPage(
+          t,
+          `chrome/settings/inbox/inbox.htm?acctEmail=flowcrypt.compatibility@gmail.com&threadId=174ab0ba9643b4fa`
+        );
+        const pdfFileName = 'small.pdf';
+        const attachmentPdf = await inboxPage.getFrame(['attachment.htm', `name=${pdfFileName}`]);
+        await attachmentPdf.waitForSelTestState('ready');
+        await attachmentPdf.click('body');
+        const attachmentPreviewPdf = await inboxPage.getFrame(['attachment_preview.htm']);
+        await attachmentPreviewPdf.waitAll('#attachment-preview-container.attachment-preview-pdf .attachment-preview-pdf-page');
+
+        const downloadedPdf = await inboxPage.awaitDownloadTriggeredByClicking(async () => {
+          await attachmentPreviewPdf.waitAndClick('@attachment-preview-download');
+        });
+        expect(Object.entries(downloadedPdf).length).to.equal(1);
+        expect(Object.keys(downloadedPdf)[0]).to.equal(pdfFileName);
+        expect(downloadedPdf[pdfFileName].length).to.equal(15218);
+      })
+    );
+    test(
       'settings - attachment previews with entering pass phrase',
       testWithBrowser(async (t, browser) => {
         await BrowserRecipe.setupCommonAcctWithAttester(t, browser, 'compatibility');


### PR DESCRIPTION
This PR fixes corrupted PDF files when they're downloaded from preview page.

close #5408

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
