### PR TITLE
#5354 Fix extra lines added to user signatures

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-footer-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-footer-module.ts
@@ -32,7 +32,9 @@ export class ComposeFooterModule extends ViewModule<ComposeView> {
   };
 
   public createFooterHtml = (footer: string) => {
-    const sanitizedPlainFooter = Xss.htmlSanitizeAndStripAllTags(footer, '\n');
+    // fix for duplicated new lines https://github.com/FlowCrypt/flowcrypt-browser/issues/5354
+    const footerWithoutEmptyDivs = this.removeDivsWithoutAttributes(footer);
+    const sanitizedPlainFooter = Xss.htmlSanitizeAndStripAllTags(footerWithoutEmptyDivs, '\n');
     const sanitizedHtmlFooter = sanitizedPlainFooter.replace(/\n/g, '<br>');
     const footerFirstLine = sanitizedPlainFooter.split('\n')[0].replace(/&nbsp;/g, ' ');
     if (!footerFirstLine) {
@@ -42,5 +44,9 @@ export class ComposeFooterModule extends ViewModule<ComposeView> {
       return sanitizedHtmlFooter; // first line of footer is already a footer separator, made of special characters
     }
     return `--<br>${sanitizedHtmlFooter}`; // create a custom footer separator
+  };
+
+  private removeDivsWithoutAttributes = (inputString: string) => {
+    return inputString.replace(/<div>(.*?)<\/div>/g, '$1');
   };
 }

--- a/extension/chrome/elements/compose-modules/compose-footer-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-footer-module.ts
@@ -33,8 +33,8 @@ export class ComposeFooterModule extends ViewModule<ComposeView> {
 
   public createFooterHtml = (footer: string) => {
     // fix for duplicated new lines https://github.com/FlowCrypt/flowcrypt-browser/issues/5354
-    const footerWithoutEmptyDivs = this.removeDivsWithoutAttributes(footer);
-    const sanitizedPlainFooter = Xss.htmlSanitizeAndStripAllTags(footerWithoutEmptyDivs, '\n');
+    const footerWithoutExtraNewLines = this.removeFontTagsAndDivsWithNewLines(footer);
+    const sanitizedPlainFooter = Xss.htmlSanitizeAndStripAllTags(footerWithoutExtraNewLines, '\n');
     const sanitizedHtmlFooter = sanitizedPlainFooter.replace(/\n/g, '<br>');
     const footerFirstLine = sanitizedPlainFooter.split('\n')[0].replace(/&nbsp;/g, ' ');
     if (!footerFirstLine) {
@@ -46,7 +46,8 @@ export class ComposeFooterModule extends ViewModule<ComposeView> {
     return `--<br>${sanitizedHtmlFooter}`; // create a custom footer separator
   };
 
-  private removeDivsWithoutAttributes = (inputString: string) => {
-    return inputString.replace(/<div>(.*?)<\/div>/g, '$1');
+  private removeFontTagsAndDivsWithNewLines = (inputString: string) => {
+    const stringWithoutFontTags = inputString.replace(/<font\s*[^>]*>(.*?)<\/font>/g, '$1');
+    return stringWithoutFontTags.replace(/<br><div>(.*?)<\/div>/g, '<br>$1');
   };
 }

--- a/test/source/mock/google/google-endpoints.ts
+++ b/test/source/mock/google/google-endpoints.ts
@@ -93,7 +93,7 @@ export const multipleEmailAliasList: MockUserAlias[] = [
 ];
 
 export const flowcryptCompatibilityPrimarySignature =
-  '<div dir="ltr">flowcrypt.compatibility test footer with an img<br><img src="https://flowcrypt.com/assets/imgs/svgs/flowcrypt-logo.svg" alt="Image result for small image"><br></div>';
+  '<div dir="ltr"><font size="2">flowcrypt.compatibility test footer with an img<br></font><div><font size="2">and second line</font></div<br><img src="https://flowcrypt.com/assets/imgs/svgs/flowcrypt-logo.svg" alt="Image result for small image"><br></div>';
 
 export const flowcryptCompatibilityAliasList = [
   {

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -1615,7 +1615,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
         expect(await composePage.read('.swal2-html-container')).to.include('Send empty message?');
         await composePage.waitAndClick('.swal2-cancel');
         const footer = await composePage.read('@input-body');
-        expect(footer).to.eq('\n\n\n--\nflowcrypt.compatibility test footer with an img');
+        expect(footer).to.eq('\n\n\n--\nflowcrypt.compatibility test footer with an img\nand second line');
         await composePage.waitAndClick(`@action-send`);
         expect(await composePage.read('.swal2-html-container')).to.include('Send empty message?');
         await composePage.waitAndClick('.swal2-cancel');


### PR DESCRIPTION
This PR fixes extra lines added to user signatures

before:

<img width="240" alt="Screenshot 2023-09-29 at 14 36 41" src="https://github.com/FlowCrypt/flowcrypt-browser/assets/1062093/cfab9e52-3ea9-478f-8b5c-19b9e445fb7d">

after:

<img width="240" alt="Screenshot 2023-09-29 at 14 37 50" src="https://github.com/FlowCrypt/flowcrypt-browser/assets/1062093/96f73b4b-5d43-4081-93cb-d30f741fae9b">


close #5354

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
