### PR TITLE
#5428 Fix: "Secure reply" button not inserted for non-English Gmail UI

### DIFF
--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -253,7 +253,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
       // only replace the last one FlowCrypt reply button if does not have any buttons replaced yet, and only replace the last one
       for (const elem of convoReplyBtnsArr) {
         $(elem).addClass('inserted');
-        const gmailReplyBtn = $(elem).find('[aria-label="Reply"]');
+        const gmailReplyBtn = $(elem).find('.aaq.L3');
         const secureReplyBtn = $(this.factory.btnSecureReply()).insertAfter(gmailReplyBtn); // xss-safe-factory
         secureReplyBtn.addClass(gmailReplyBtn.attr('class') || '');
         secureReplyBtn.off();


### PR DESCRIPTION
This PR fixed `Secure reply` button not inserted for non-English Gmail UI issue

close #5428 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test (Hard to simulate gmail language change)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
