### PR TITLE
#5513 Fixed uncollapsible contact's public key details UI

### DIFF
--- a/extension/chrome/settings/modules/contacts.ts
+++ b/extension/chrome/settings/modules/contacts.ts
@@ -94,7 +94,7 @@ View.run(
         tableContents += `
         <div email="${e}" class="action_show_pubkey_list" data-test="action-show-email-${e.replace(/[^a-z0-9]+/g, '')}">
           <img src="/img/svgs/chevron-left.svg" class="icon-chevron">
-          <span class="contact_email_address">${e}</span>
+          ${e}
         </div>
       `;
       }

--- a/extension/chrome/settings/modules/contacts.ts
+++ b/extension/chrome/settings/modules/contacts.ts
@@ -55,7 +55,7 @@ View.run(
     };
 
     public setHandlers = () => {
-      $('.action_show_pubkey_list').off().on('click', this.setHandlerPrevent('double', this.actionRenderListPublicKeyHandler));
+      $('.action_show_pubkey_list').off().on('click', this.setHandler(this.actionRenderListPublicKeyHandler));
       $('#edit_contact .action_save_edited_pubkey').off().on('click', this.setHandlerPrevent('double', this.actionSaveEditedPublicKeyHandler));
       $('#bulk_import .action_process').off().on('click', this.setHandlerPrevent('double', this.actionProcessBulkImportTextInput));
       $('.action_export_all').off().on('click', this.setHandlerPrevent('double', this.actionExportAllKeysHandler));
@@ -94,7 +94,7 @@ View.run(
         tableContents += `
         <div email="${e}" class="action_show_pubkey_list" data-test="action-show-email-${e.replace(/[^a-z0-9]+/g, '')}">
           <img src="/img/svgs/chevron-left.svg" class="icon-chevron">
-          ${e}
+          <span class="contact_email_address">${e}</span>
         </div>
       `;
       }
@@ -131,6 +131,11 @@ View.run(
     };
 
     private actionRenderListPublicKeyHandler = async (emailRow: HTMLElement) => {
+      if ($(emailRow).hasClass('opened')) {
+        $(emailRow).removeClass('opened');
+        $(emailRow).children('.contacts-pubkey').remove();
+        return;
+      }
       $(emailRow).addClass('opened');
       const email = $(emailRow).attr('email')!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
       const contact = await ContactStore.getOneWithAllPubkeys(undefined, email);
@@ -163,11 +168,7 @@ View.run(
           </div>
           <div class="contacts-pubkey-actions">${change}${remove}</div></div>`;
         }
-        $(emailRow).after(tableContents); // xss-safe-value
-        // remove all listeners from the old link by creating a new element
-        const newElement = emailRow.cloneNode(true);
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        emailRow!.parentNode!.replaceChild(newElement, emailRow);
+        $(emailRow).append(tableContents); // xss-safe-value
         $('.action_remove').off().on('click', this.setHandlerPrevent('double', this.actionRemovePublicKey));
         $('.action_show').off().on('click', this.setHandlerPrevent('double', this.actionRenderViewPublicKeyHandler));
         $('.action_change').off().on('click', this.setHandlerPrevent('double', this.actionRenderChangePublicKeyHandler));

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -608,9 +608,10 @@ body#settings > div#content.contacts #emails {
 }
 
 body#settings > div#content.contacts #emails .action_show_pubkey_list {
-  display: flex;
+  display: block;
+  margin-bottom: 6px;
   align-items: center;
-  height: 48px;
+  height: auto;
   border-bottom: 1px solid #f6f6f6;
   cursor: pointer;
 }
@@ -625,6 +626,11 @@ body#settings > div#content.contacts #emails .action_show_pubkey_list .icon-chev
 
 body#settings > div#content.contacts #emails .action_show_pubkey_list.opened .icon-chevron {
   transform: rotate(270deg);
+}
+
+body#settings > div#content.contacts #emails .action_show_pubkey_list span.contact_email_address {
+  margin-top: 6px;
+  position: absolute;
 }
 
 body#settings > div#content.contacts #emails .contacts-pubkey {

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -609,11 +609,12 @@ body#settings > div#content.contacts #emails {
 
 body#settings > div#content.contacts #emails .action_show_pubkey_list {
   display: block;
-  margin-bottom: 6px;
   align-items: center;
   height: auto;
   border-bottom: 1px solid #f6f6f6;
   cursor: pointer;
+  padding: 10px 0 10px 25px;
+  position: relative;
 }
 
 body#settings > div#content.contacts #emails .action_show_pubkey_list .icon-chevron {
@@ -622,15 +623,13 @@ body#settings > div#content.contacts #emails .action_show_pubkey_list .icon-chev
   transform: rotate(180deg);
   transition: transform 0.15s;
   opacity: 0.5;
+  position: absolute;
+  left: 0;
+  top: 6px;
 }
 
 body#settings > div#content.contacts #emails .action_show_pubkey_list.opened .icon-chevron {
   transform: rotate(270deg);
-}
-
-body#settings > div#content.contacts #emails .action_show_pubkey_list span.contact_email_address {
-  margin-top: 6px;
-  position: absolute;
 }
 
 body#settings > div#content.contacts #emails .contacts-pubkey {
@@ -638,20 +637,16 @@ body#settings > div#content.contacts #emails .contacts-pubkey {
   align-items: center;
   justify-content: space-between;
   background: #f5f5f5;
-  margin: -7px 0 7px;
   font-size: 14px;
   padding-left: 20px;
   border-bottom: 1px solid #eaeaea;
+  margin-top: 2px;
 }
 
 body#settings > div#content.contacts #emails .contacts-pubkey .action_show {
   flex: 1;
   margin-top: -2px;
   text-decoration: none;
-}
-
-body#settings > div#content.contacts #emails .contacts-pubkey:last-child {
-  margin-bottom: 10px;
 }
 
 body#settings > div#content.contacts #emails .contacts-pubkey .contacts-pubkey-info,


### PR DESCRIPTION
This PR addresses a minor UI issue where the expanded public key details in 'contacts' do not collapse when clicking the contact email header.

<video src="https://github.com/FlowCrypt/flowcrypt-browser/assets/46025304/5034c8bc-afa2-469f-b49a-fe712bea5d65" width="50%">

close #5513 

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
