### PR TITLE
#5545 Let handlePrivateKeyError() handles userId error

### DIFF
--- a/extension/chrome/settings/modules/my_key_update.ts
+++ b/extension/chrome/settings/modules/my_key_update.ts
@@ -115,8 +115,6 @@ View.run(
         KeyImportUi.allowReselect();
         if (typeof updatedKey === 'undefined') {
           await Ui.modal.warning(Lang.setup.keyFormattedWell(this.prvHeaders.begin, String(this.prvHeaders.end)), Ui.testCompatibilityLink);
-        } else if (updatedKeyEncrypted.identities.length === 0) {
-          await Ui.modal.error(Lang.setup.prvHasUseridIssue);
         } else if (updatedKey.isPublic) {
           await Ui.modal.warning(
             'This was a public key. Please insert a private key instead. It\'s a block of text starting with "' + this.prvHeaders.begin + '"'

--- a/extension/js/common/lang.ts
+++ b/extension/js/common/lang.ts
@@ -46,7 +46,6 @@ export const Lang = {
     keyBackupsNotAllowed: 'Key backups are not allowed on this domain.',
     prvHasFixableCompatIssue:
       'This key has minor usability issues that can be fixed. This commonly happens when importing keys from Symantec&trade; PGP Desktop or other legacy software. It may be missing User IDs, or it may be missing a self-signature. It is also possible that the key is simply expired.',
-    prvHasUseridIssue: 'The set of User IDs in this key is not supported.',
     ppMatchAllSet: "Your pass phrase matches. Good job! You're all set.",
     noKeys: 'Keys for your account were not set up yet - please ask your systems administrator.',
     prvBackupToDesignatedMailboxEmailSubject: (acctEmail: string, fingerprint: string) =>

--- a/test/source/tests/settings.ts
+++ b/test/source/tests/settings.ts
@@ -768,8 +768,9 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
         await myKeyPage.waitAndClick('@action-update-key');
         await myKeyPage.waitAndRespondToModal('error', 'confirm', 'An error happened when processing the key');
         await myKeyPage.waitAndType('@input-prv-key', keyCanBeFixedTestKey);
+        await myKeyPage.waitAndType('@input-passphrase', 'hard to guess passphrase');
         await myKeyPage.waitAndClick('@action-update-key');
-        await myKeyPage.waitAndRespondToModal('error', 'confirm', 'The set of User IDs in this key is not supported.');
+        await myKeyPage.waitAndRespondToModal('confirm', 'confirm', 'Public and private key updated locally');
       })
     );
     test(
@@ -1075,8 +1076,8 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
         }
         await myKeyFrame.type('@input-passphrase', '1234');
         await myKeyFrame.waitAndClick('@action-update-key');
-        await PageRecipe.waitForModalAndRespond(myKeyFrame, 'error', {
-          contentToCheck: 'The set of User IDs in this key is not supported.',
+        await PageRecipe.waitForModalAndRespond(myKeyFrame, 'confirm', {
+          contentToCheck: 'Public and private key updated locally',
           clickOn: 'confirm',
         });
         // test the pubkey in the storage
@@ -1085,11 +1086,14 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
           return await (window as any).ContactStore.getOneWithAllPubkeys(undefined, acctEmail);
         }, acctEmail);
         expect(expectedOldContact.sortedPubkeys.length).to.equal(1);
-        expect((expectedOldContact.sortedPubkeys as PubkeyInfoWithLastCheck[])[0].pubkey.lastModified).to.equal(1610024667000);
+        expect((expectedOldContact.sortedPubkeys as PubkeyInfoWithLastCheck[])[0].pubkey.lastModified).to.equal(1689176967000);
+        console.log('hello2');
+        await myKeyFrame.waitAndClick('@action-update-prv');
         {
           const [fileChooser] = await Promise.all([settingsPage.page.waitForFileChooser(), myKeyFrame.waitAndClick('@source-file', { retryErrs: true })]);
           await fileChooser.accept(['test/samples/openpgp/flowcrypttestkeymultiplegmailcom-0x98acfa1eadab5b92-updated.key']); // binary key
         }
+        await myKeyFrame.type('@input-passphrase', '1234');
         await myKeyFrame.waitAndClick('@action-update-key');
         await PageRecipe.waitForModalAndRespond(myKeyFrame, 'confirm', {
           contentToCheck: 'Public and private key updated locally',


### PR DESCRIPTION
This PR updates the `my_key_updates.ts` identities check and let the `handlePrivateKeyError()` handles the error which offers user an option to fix private keys with issues.

close #5545

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
