### PR TITLE
#5548 Improve error handling in updatePrivateKeyHandler()

### DIFF
--- a/extension/chrome/elements/shared/key_errors.ts
+++ b/extension/chrome/elements/shared/key_errors.ts
@@ -55,10 +55,10 @@ export class KeyErrors {
 
   private toggleCompatibilityView = (visible: boolean) => {
     if (visible) {
-      $('#add_key_container').hide();
+      $('#my_key_update_container, #add_key_container').hide();
       $('#compatibility_fix').show();
     } else {
-      $('#add_key_container').show();
+      $('#my_key_update_container, #add_key_container').show();
       $('#compatibility_fix').hide();
     }
   };

--- a/extension/chrome/settings/modules/my_key_update.htm
+++ b/extension/chrome/settings/modules/my_key_update.htm
@@ -16,7 +16,7 @@
   </head>
 
   <body id="settings">
-    <div id="content" class="my_key page compatibility_fix_container display_none" style="text-align: left">
+    <div id="my_key_update_container" class="my_key page display_none" style="text-align: left">
       <div class="line"><b>Update Private Key</b> with Fingerprint: <span class="fingerprint good"></span></div>
       <div class="line">
         You can use other OpenPGP compatible software to update your private key (change expiration, change user ids) and load updated key below.
@@ -49,6 +49,7 @@
       </div>
       <div class="line"><a href="#" class="action_show_public_key">Back to Public Key</a></div>
     </div>
+    <div id="compatibility_fix" class="compatibility_fix_container"></div>
 
     <script src="/lib/purify.js"></script>
     <script src="/lib/fine-uploader.js"></script>

--- a/extension/chrome/settings/modules/my_key_update.ts
+++ b/extension/chrome/settings/modules/my_key_update.ts
@@ -19,7 +19,7 @@ import { PassphraseStore } from '../../../js/common/platform/store/passphrase-st
 import { AcctStore } from '../../../js/common/platform/store/acct-store.js';
 import { InMemoryStore } from '../../../js/common/platform/store/in-memory-store.js';
 import { InMemoryStoreKeys } from '../../../js/common/core/const.js';
-import { KeyImportUi } from '../../../js/common/ui/key-import-ui.js';
+import { KeyCanBeFixed, KeyImportUi } from '../../../js/common/ui/key-import-ui.js';
 import { saveKeysAndPassPhrase } from '../../../js/common/helpers.js';
 import { KeyErrors } from '../../elements/shared/key_errors.js';
 
@@ -64,7 +64,7 @@ View.run(
       `
         );
       } else {
-        $('#content').show();
+        $('#my_key_update_container').show();
         this.keyImportUi.initPrvImportSrcForm(this.acctEmail, undefined);
         this.pubLookup = new PubLookup(this.clientConfiguration);
         [this.ki] = await KeyStore.get(this.acctEmail, [this.fingerprint]);
@@ -115,6 +115,8 @@ View.run(
         KeyImportUi.allowReselect();
         if (typeof updatedKey === 'undefined') {
           await Ui.modal.warning(Lang.setup.keyFormattedWell(this.prvHeaders.begin, String(this.prvHeaders.end)), Ui.testCompatibilityLink);
+        } else if (updatedKeyEncrypted.identities.length === 0) {
+          throw new KeyCanBeFixed(updatedKeyEncrypted);
         } else if (updatedKey.isPublic) {
           await Ui.modal.warning(
             'This was a public key. Please insert a private key instead. It\'s a block of text starting with "' + this.prvHeaders.begin + '"'


### PR DESCRIPTION
This PR completely fixes the error handling in `updatePrivateKeyHandler()` where it doesn't allow the user to fix those "fixable" private keys when updating their private keys.

close #5548 

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
