### PR TITLE
#5570 Additional check before encrypted message attachment fetch

### DIFF
--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -181,7 +181,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
 
         ({ body, blocks, attachments, messageInfo } = await this.messageRenderer.msgGetProcessed(msgId));
 
-        if (Mime.isBodyEmpty(body)) {
+        if (Mime.isBodyEmpty(body) && !this.currentlyReplacingAttachments) {
           // check if message body was converted to attachment by Gmail
           // happens for pgp/mime messages with attachments
           // https://github.com/FlowCrypt/flowcrypt-browser/issues/5458


### PR DESCRIPTION
This PR adds additional check before fetching encrypted message attachment to fix `Attachment bytes already set` error

close #5570

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test (explain why) - difficult to reproduce in test environment

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
