### PR TITLE
#5574 Improve blocks parsing in plain forwarded messages

### DIFF
--- a/extension/js/content_scripts/webmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail-element-replacer.ts
@@ -233,7 +233,7 @@ export class GmailElementReplacer implements WebmailElementReplacer {
     const parseTextBlocks = (text: string) => Mime.processBody({ text });
 
     const el = document.createElement('div');
-    el.appendChild(emailContainer.cloneNode());
+    el.appendChild(emailContainer.cloneNode(true));
 
     // add ">" character to the beginning of each line inside
     // gmail_quote elements for correct parsing of text blocks


### PR DESCRIPTION
This PR improves detection of encrypted content in plain forwarded message

close #5574

before (message rendered as encrypted, but can't be decrypted as it has different recipient)
<img width="500" alt="Screenshot 2024-01-30 at 11 05 28" src="https://github.com/FlowCrypt/flowcrypt-browser/assets/1062093/1eea5742-a6c5-49ef-b430-7dea4990f90e">

after (message correctly displayed as plain text)
<img width="500" alt="Screenshot 2024-01-30 at 11 06 47" src="https://github.com/FlowCrypt/flowcrypt-browser/assets/1062093/9b90e046-8a8a-4feb-bfc0-d39e48a2772c">



----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test (explain why) - wasn't able to recreate similar email message

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
