### PR TITLE
#5601 Fix empty API response handling

### DIFF
--- a/extension/js/common/api/shared/api.ts
+++ b/extension/js/common/api/shared/api.ts
@@ -237,10 +237,12 @@ export class Api {
           return { response, pipe: Value.noop }; // original response
         }
       };
+      const responseLength = response.headers.get('Content-Length');
+      const isResponseNonEmpty = responseLength && parseInt(responseLength) !== 0;
       if (resFmt === 'text') {
         const transformed = transformResponseWithProgressAndTimeout();
         return (await Promise.all([transformed.response.text(), transformed.pipe()]))[0] as FetchResult<T, RT>;
-      } else if (resFmt === 'json') {
+      } else if (resFmt === 'json' && isResponseNonEmpty) {
         const transformed = transformResponseWithProgressAndTimeout();
         return (await Promise.all([transformed.response.json(), transformed.pipe()]))[0] as FetchResult<T, RT>;
       } else {


### PR DESCRIPTION
This PR improves handling of empty API response (usually happens on `DELETE` requests)

close #5601

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test (explain why) - initial error doesn't affect functionality, it's just printed to console

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
