### PR TITLE
#5629 Fix decryption error for ambiguous noname file with multipart/mixed email attachment.

### DIFF
--- a/extension/js/common/core/attachment.ts
+++ b/extension/js/common/core/attachment.ts
@@ -206,7 +206,7 @@ export class Attachment {
       return 'signature';
     } else if (this.inline && this.isAttachmentAnImage()) {
       return 'inlineImage';
-    } else if (!this.name && !this.isAttachmentAnImage() && this.type !== 'application/octet-stream') {
+    } else if (!this.name && !this.isAttachmentAnImage() && this.type !== 'application/octet-stream' && this.type !== 'multipart/mixed') {
       // this.name may be '' or undefined - catch either
       return this.length < 100 ? 'hidden' : 'encryptedMsg';
     } else if (this.name === 'msg.asc' && this.length < 100 && this.type === 'application/pgp-encrypted') {


### PR DESCRIPTION
This PR fixes decryption errors that occur on plain emails with ambiguous noname files with `multipart/mixed` email attachments.

close #5629 

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test - The user just received the email, so I think it's something we can't ask to be part of the test. Additionally, I'm not sure how to generate an email with such an attachment. I checked if I can trim down the sensitive part from the noname file, but I think it's not possible and can't be done easily. This can be manually tested through user confirmation, though it works fine for me with the changes in this PR.

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
