### PR TITLE
#5609 Replaces the public key auto-include feature when user's public key isn't found in Attester.

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-my-pubkey-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-my-pubkey-module.ts
@@ -76,11 +76,10 @@ export class ComposeMyPubkeyModule extends ViewModule<ComposeView> {
             // they do need pubkey
             // However, on GH issue #5609, users doesn't seem to like it auto-included so
             // a prompt with a hint would be a great replacement.
-            await Ui.modal.info(
+            return await Ui.modal.info(
               `We couldn't locate your public key on the server for others to use. You can manually        include it in this email by clicking the certificate icon beside the trash.\n\nIf you want to submit your public key to the server, please ask ${this.view.fesUrl ? 'your administrator' : 'human@flowcrypt.com'} for an assistance.`,
               true
             );
-            return;
           }
         }
         this.setAttachPreference(false);

--- a/extension/chrome/elements/compose-modules/compose-my-pubkey-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-my-pubkey-module.ts
@@ -74,7 +74,12 @@ export class ComposeMyPubkeyModule extends ViewModule<ComposeView> {
           // new message, and my key is not uploaded where the recipient would look for it
           if (!(await this.view.recipientsModule.doesRecipientHaveMyPubkey(recipient))) {
             // they do need pubkey
-            this.setAttachPreference(true);
+            // However, on GH issue #5609, users doesn't seem to like it auto-included so
+            // a prompt with a hint would be a great replacement.
+            await Ui.modal.info(
+              `We couldn't locate your public key on the server for others to use. You can manually        include it in this email by clicking the certificate icon beside the trash.\n\nIf you want to submit your public key to the server, please ask ${this.view.fesUrl ? 'your administrator' : 'human@flowcrypt.com'} for an assistance.`,
+              true
+            );
             return;
           }
         }


### PR DESCRIPTION
This PR replaces the public key auto-include feature when user's public key isn't found in Attester as it would give user a desirable use-case.

close #5609 

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
