### PR TITLE
#5609 Add ui modal hint when auto including a public key

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-my-pubkey-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-my-pubkey-module.ts
@@ -75,6 +75,11 @@ export class ComposeMyPubkeyModule extends ViewModule<ComposeView> {
           if (!(await this.view.recipientsModule.doesRecipientHaveMyPubkey(recipient))) {
             // they do need pubkey
             this.setAttachPreference(true);
+            // To improve situation reported in #5609, a notification message about the automatic public key inclusion is displayed
+            await Ui.modal.info(
+              `We couldn't find your public key on the server. We've included it for you so that they can use it to reply back to you encrypted. You may click the certificate icon to exclude it from this email.\n<p style="font-size: 0.9em">If you want to submit your public key, please ask ${this.view.fesUrl ? 'your administrator' : '<span class="link">human@flowcrypt.com</span>'} for assistance.</p>`,
+              true
+            );
             return;
           }
         }

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -363,6 +363,11 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
         await composePage.waitAndFocus('@input-body');
         await composePage.waitTillGone('@spinner');
         await Util.sleep(3); // allow some time to search for messages
+        await composePage.waitAndRespondToModal(
+          'info',
+          'confirm',
+          "We couldn't find your public key on the server. We've included it for you so that they can use it to reply back to you encrypted."
+        );
         expect(await composePage.hasClass('@action-include-pubkey', 'active')).to.be.true;
       })
     );
@@ -3294,10 +3299,13 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
         const settingsPage = await BrowserRecipe.openSettingsLoginApprove(t, browser, acct);
         await SetupPageRecipe.autoSetupWithEKM(settingsPage);
         const composePage = await ComposePageRecipe.openStandalone(t, browser, acct);
-        await Promise.all([
-          ComposePageRecipe.fillMsg(composePage, { to: 'mock.only.pubkey@flowcrypt.com' }, 'no valid key'),
-          ComposePageRecipe.waitForToastToAppearAndDisappear(composePage, 'Draft not saved: Error: Your account keys are revoked'),
-        ]);
+        await ComposePageRecipe.fillMsg(composePage, { to: 'mock.only.pubkey@flowcrypt.com' }, 'no valid key', undefined, undefined, async () => {
+          await composePage.waitAndRespondToModal(
+            'info',
+            'confirm',
+            "We couldn't find your public key on the server. We've included it for you so that they can use it to reply back to you encrypted."
+          );
+        });
         await composePage.waitAndClick('@action-send', { delay: 1 });
         await PageRecipe.waitForModalAndRespond(composePage, 'warning', {
           contentToCheck: 'Failed to send message due to: Error: Your account keys are revoked',

--- a/test/source/tests/page-recipe/compose-page-recipe.ts
+++ b/test/source/tests/page-recipe/compose-page-recipe.ts
@@ -76,7 +76,8 @@ export class ComposePageRecipe extends PageRecipe {
     recipients: Recipients,
     subject?: string | undefined,
     body?: string | undefined,
-    sendingOpt: { encrypt?: boolean; sign?: boolean; richtext?: boolean } = {} // undefined means leave default
+    sendingOpt: { encrypt?: boolean; sign?: boolean; richtext?: boolean } = {}, // undefined means leave default
+    handleModalResponse?: () => Promise<void>
   ) {
     const sendingOpts = sendingOpt as { [key: string]: boolean | undefined };
     const keys = ['richtext', 'encrypt', 'sign'];
@@ -92,6 +93,9 @@ export class ComposePageRecipe extends PageRecipe {
       await composePageOrFrame.click('@input-subject');
       await Util.sleep(1);
       await composePageOrFrame.type('@input-subject', subject?.match(/RTL/) ? subject : `Automated puppeteer test: ${subject}`);
+    }
+    if (handleModalResponse) {
+      await handleModalResponse();
     }
     await composePageOrFrame.click('@input-body');
     // bring cursor to the beginning of the multiline contenteditable


### PR DESCRIPTION
This PR improves UX when the auto include public keys happens by showing a UI modal informing that a public key has been automatically included.

close #5609 

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
