### PR TITLE
#5707 Replace "email password" with "message password" in the Secure Compose window

### DIFF
--- a/extension/chrome/elements/compose.htm
+++ b/extension/chrome/elements/compose.htm
@@ -173,7 +173,7 @@
                 <a href="https://flowcrypt.com/docs/getting-started/send-and-receive/send/send-password-protected-emails.html" target="_blank"
                   >password-protected</a
                 >:
-                <input id="input_password" autocomplete="off" placeholder="email password" tabindex="5" data-test="input-password" maxlength="256" />
+                <input id="input_password" autocomplete="off" placeholder="message password" tabindex="5" data-test="input-password" maxlength="256" />
               </div>
               <div class="warning_no_pubkey_on_attester">
                 <span data-test="container-no-pubkey-on-attester">


### PR DESCRIPTION
This PR replaces "email password" with "message password" in the Secure Compose window

close #5707

Before
![email](https://github.com/FlowCrypt/flowcrypt-browser/assets/22081012/96a2b972-bed6-4a7f-ad92-593804183aa2)

After
![msg](https://github.com/FlowCrypt/flowcrypt-browser/assets/22081012/9b59eb43-517f-4449-a496-50265a7d0999)

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
