### PR TITLE
#5715 Fix id token fetch for exception reports

### DIFF
--- a/extension/chrome/settings/setup.ts
+++ b/extension/chrome/settings/setup.ts
@@ -397,7 +397,7 @@ export class SetupView extends View {
       return;
     }
     if (!armoredPubkey) {
-      await Ui.modal.warning('Public key not usable - not sumbitting to Attester');
+      await Ui.modal.warning('Public key not usable - not submitting to Attester');
       return;
     }
     const pub = await KeyUtil.parse(armoredPubkey);

--- a/extension/js/common/platform/catch.ts
+++ b/extension/js/common/platform/catch.ts
@@ -312,13 +312,8 @@ export class Catch {
 
   private static async doSendErrorToSharedTenantFes(errorReport: ErrorReport) {
     try {
-      let acctEmail = Url.parse(['acctEmail']).acctEmail;
-      if (acctEmail) {
-        acctEmail = String(acctEmail);
-      } else {
-        const acctEmails = await GlobalStore.acctEmailsGet();
-        acctEmail = acctEmails?.length ? acctEmails[0] : undefined;
-      }
+      const { acctEmail: parsedEmail } = Url.parse(['acctEmail']);
+      const acctEmail = parsedEmail ? String(parsedEmail) : (await GlobalStore.acctEmailsGet())?.[0];
       if (!acctEmail) {
         console.error('Not reporting error because user is not logged in');
         return;

--- a/extension/js/common/platform/catch.ts
+++ b/extension/js/common/platform/catch.ts
@@ -4,6 +4,7 @@
 
 import { Url } from '../core/common.js';
 import { FLAVOR, InMemoryStoreKeys, SHARED_TENANT_API_HOST, VERSION } from '../core/const.js';
+import { GlobalStore } from './store/global-store.js';
 import { InMemoryStore } from './store/in-memory-store.js';
 
 export class UnreportableError extends Error {}
@@ -283,8 +284,8 @@ export class Catch {
   private static formatExceptionForReport(thrown: unknown, line?: number, col?: number): ErrorReport {
     if (!line || !col) {
       const { line: parsedLine, col: parsedCol } = Catch.getErrorLineAndCol(thrown);
-      line = parsedLine;
-      col = parsedCol;
+      line = parsedLine > 0 ? parsedLine : 1;
+      col = parsedCol > 0 ? parsedCol : 1;
     }
     if (thrown instanceof Error) {
       // reporting stack may differ from the stack of the actual error, both may be interesting
@@ -299,8 +300,8 @@ export class Catch {
       name: exception.name.substring(0, 50),
       message: exception.message.substring(0, 200),
       url: location.href.split('?')[0],
-      line: line || 0,
-      col: col || 0,
+      line: line || 1,
+      col: col || 1,
       trace: exception.stack || '',
       version: VERSION,
       environment: Catch.RUNTIME_ENVIRONMENT,
@@ -311,8 +312,13 @@ export class Catch {
 
   private static async doSendErrorToSharedTenantFes(errorReport: ErrorReport) {
     try {
-      const uncheckedUrlParams = Url.parse(['acctEmail']);
-      const acctEmail = String(uncheckedUrlParams.acctEmail);
+      let acctEmail = Url.parse(['acctEmail']).acctEmail;
+      if (acctEmail) {
+        acctEmail = String(acctEmail);
+      } else {
+        const acctEmails = await GlobalStore.acctEmailsGet();
+        acctEmail = acctEmails?.length ? acctEmails[0] : undefined;
+      }
       if (!acctEmail) {
         console.error('Not reporting error because user is not logged in');
         return;
@@ -376,7 +382,7 @@ export class Catch {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       return { line: Number(matched![1]), col: Number(matched![2]) };
     } catch (lineErr) {
-      return { line: 0, col: 0 };
+      return { line: 1, col: 1 };
     }
   }
 

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -3271,7 +3271,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
         const acct = 'revoked@key-manager-autoimport-no-prv-create.flowcrypt.test';
         const settingsPage = await BrowserRecipe.openSettingsLoginApprove(t, browser, acct);
         await SetupPageRecipe.autoSetupWithEKM(settingsPage, {
-          expectWarnModal: 'Public key not usable - not sumbitting to Attester',
+          expectWarnModal: 'Public key not usable - not submitting to Attester',
         });
       })
     );

--- a/test/source/tests/flaky.ts
+++ b/test/source/tests/flaky.ts
@@ -61,7 +61,7 @@ export const defineFlakyTests = (testVariant: TestVariant, testWithBrowser: Test
           clickOn: 'confirm',
         });
         await SettingsPageRecipe.waitForModalAndRespond(settingsPage, 'warning', {
-          contentToCheck: 'Public key not usable - not sumbitting to Attester',
+          contentToCheck: 'Public key not usable - not submitting to Attester',
           clickOn: 'confirm',
         });
         await settingsPage.waitAndClick('@action-step4done-account-settings');

--- a/test/source/tests/setup.ts
+++ b/test/source/tests/setup.ts
@@ -888,7 +888,7 @@ AN8G3r5Htj8olot+jm9mIa5XLXWzMNUZgg==
           },
         });
         const settingsPage = await BrowserRecipe.openSettingsLoginApprove(t, browser, acctEmail);
-        await SetupPageRecipe.autoSetupWithEKM(settingsPage, { expectWarnModal: 'Public key not usable - not sumbitting to Attester' });
+        await SetupPageRecipe.autoSetupWithEKM(settingsPage, { expectWarnModal: 'Public key not usable - not submitting to Attester' });
         const gmailPage = await openMockGmailPage(t, browser, acctEmail);
         // Check if notification presents
         let warningMsg =


### PR DESCRIPTION
This PR fixes id token fetch for sending error reports from content script.

\+ replaces `{ line: 0, col: 0 }` with `{ line: 1, col: 1}` for reports with unknown error location (as backend expects positive number, and throws error when line or col is 0)

close #5715

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests will be added later (https://github.com/FlowCrypt/flowcrypt-browser/issues/5718)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
