### PR TITLE
#5599 Add checks if rich-text option is enabled before removing support

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-input-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-input-module.ts
@@ -54,7 +54,9 @@ export class ComposeInputModule extends ViewModule<ComposeView> {
   };
 
   public removeRichTextFormatting = () => {
-    this.initSquire(false, true);
+    if (this.view.inputModule.isRichText()) {
+      this.initSquire(false, true);
+    }
   };
 
   public inputTextHtmlSetSafely = (html: string) => {


### PR DESCRIPTION
This PR adds check ensuring that rich-text is enable before ever removing rich text formatting. This solves the issue of having a prepended newlines when typing, for example, "Hello<kbd>Enter</kbd>World" where it produces 
```
World
Hello
```
in the `contenteditable.div` in the master branch.

To test this manually:

1.) Open Gmail with FlowCrypt browser extension installed and configured.
2.) Send you're self a signed message email.
3.) Reply to your own signed message email.  (*The bug appears at this point on "master" branch but not here.*) 
4.) Type "Hello<kbd>Enter</kbd>World" and it will produce output on `contenteditable.div` correctly with:

```
Hello
World
```
instead of the bugged version:

```
World
Hello
```

close #5599 

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test (explain why) - It's difficult to test it in automated manners for some reason as I get correct output's when doing testing for both `master` and this branch. So looks like the bug is particularly be reproducible through actual usage. I can share this build to the reporting users for them to double check it -- though it works perfectly when i tested it.

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
