### PR TITLE
#5730 Fix error when sending blank signed message

### DIFF
--- a/extension/js/common/core/crypto/pgp/openpgp-key.ts
+++ b/extension/js/common/core/crypto/pgp/openpgp-key.ts
@@ -268,6 +268,7 @@ export class OpenPGPKey {
       const message = await opgp.createMessage({ text });
       return await opgp.sign({ message, format: 'armored', signingKeys: [signingPrv], detached });
     }
+    text = text ? text : '\n';
     const message = await opgp.createCleartextMessage({ text });
     return await opgp.sign({ message, signingKeys: [signingPrv] });
   }


### PR DESCRIPTION
This PR improves the case where sending an empty signed message using FlowCrypt returns unhandled error. This is due to `createCleartextMessage()` not accepting empty message. So passing a newline that would serve as empty message would satify the condition when user choose to send blank signed email when asked by the FlowCrypt browser extension. 

close #5730

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
