### PR TITLE
#5764 Fix long ‘environment’ string

### DIFF
--- a/extension/js/common/platform/catch.ts
+++ b/extension/js/common/platform/catch.ts
@@ -193,7 +193,7 @@ export class Catch {
     } else if (origin === 'https://flowcrypt.com') {
       env = 'web:prod';
     } else if (origin === 'https://mail.google.com') {
-      env = 'ex:script:gmail';
+      env = 'ex:s:gmail';
     }
     return browserName + ':' + env;
   }


### PR DESCRIPTION
This PR makes `environment` string shorter to be valid for `log-collector/exception` endpoint

close #5764

----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
