### PR TITLE
#5780 Remove service_worker for firefox's manifest.json build process

### DIFF
--- a/tooling/build-types-and-manifests.ts
+++ b/tooling/build-types-and-manifests.ts
@@ -44,8 +44,9 @@ addManifest('firefox-consumer', manifest => {
       strict_min_version: '112.0', // eslint-disable-line @typescript-eslint/naming-convention
     },
   };
+  delete manifest.background;
   manifest.background = {
-    ...manifest.background,
+    type: 'module',
     scripts: ['/js/service_worker/background.js'],
   };
   // eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-unused-vars

--- a/tooling/build-types-and-manifests.ts
+++ b/tooling/build-types-and-manifests.ts
@@ -44,7 +44,6 @@ addManifest('firefox-consumer', manifest => {
       strict_min_version: '112.0', // eslint-disable-line @typescript-eslint/naming-convention
     },
   };
-  delete manifest.background;
   manifest.background = {
     type: 'module',
     scripts: ['/js/service_worker/background.js'],


### PR DESCRIPTION
This PR removes `background.service_worker` for Firefox's manifest.json build process to remove such warning for unknown property `service_worker` for Manifest V2.

close #5780

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
