### PR TITLE
#5433 Fix: Unchecked runtime.lastError

### DIFF
--- a/extension/js/common/browser/browser-msg.ts
+++ b/extension/js/common/browser/browser-msg.ts
@@ -394,9 +394,8 @@ export class BrowserMsg {
       // console.debug(`listener(${dest}) new message: ${msg.name} to ${msg.to} with id ${msg.uid} from`, _sender);
       if (msg.to && [dest, 'broadcast'].includes(msg.to)) {
         BrowserMsg.handleMsg(msg, rawRespond);
-        return true;
       }
-      return false; // will not respond
+      return false; // will not respond as we only need response for BrowserMsg.send.bg.await
     });
     BrowserMsg.listenForWindowMessages(dest);
   }
@@ -619,7 +618,11 @@ export class BrowserMsg {
               }
             });
           } else {
-            chrome.runtime.sendMessage(msg, processRawMsgResponse);
+            if (awaitRes) {
+              chrome.runtime.sendMessage(msg, processRawMsgResponse);
+            } else {
+              void chrome.runtime.sendMessage(msg);
+            }
           }
         } else {
           BrowserMsg.renderFatalErrCorner('Error: missing chrome.runtime', 'RED-RELOAD-PROMPT');


### PR DESCRIPTION
This PR fixed `unchecked runtime.lastError A listener indicated an asynchronous response by returning true, but the message channel closed before a response was received` issue

close #5433 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
