### PR TITLE
#5830 Move deleteExpired logic to messageRenderer and perform once per minute instead of every seconds

### DIFF
--- a/extension/js/common/message-renderer.ts
+++ b/extension/js/common/message-renderer.ts
@@ -55,6 +55,10 @@ export class MessageRenderer {
     private debug = false
   ) {
     this.downloader = new Downloader(gmail);
+    // Check expired messages every minute and delete them
+    Catch.setHandledInterval(() => {
+      this.deleteExpired();
+    }, 3 * 1000);
   }
 
   public static async newInstance(acctEmail: string, gmail: Gmail, relayManager: RelayManager, factory: XssSafeFactory, debug = false) {

--- a/extension/js/common/message-renderer.ts
+++ b/extension/js/common/message-renderer.ts
@@ -58,7 +58,7 @@ export class MessageRenderer {
     // Check expired messages every minute and delete them
     Catch.setHandledInterval(() => {
       this.deleteExpired();
-    }, 3 * 1000);
+    }, 60 * 1000);
   }
 
   public static async newInstance(acctEmail: string, gmail: Gmail, relayManager: RelayManager, factory: XssSafeFactory, debug = false) {

--- a/extension/js/content_scripts/webmail/gmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail/gmail-element-replacer.ts
@@ -152,7 +152,6 @@ export class GmailElementReplacer extends WebmailElementReplacer {
     this.evaluateStandardComposeRecipients().catch(Catch.reportErr);
     this.addSettingsBtn();
     this.renderLocalDrafts().catch(Catch.reportErr);
-    this.messageRenderer.deleteExpired();
   };
 
   private replaceArmoredBlocks = async () => {


### PR DESCRIPTION
This PR moved deleteExpired logic to messageRenderer and perform once per minute instead of every seconds

close #5830// if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
