### PR TITLE
#5838 Added checks for RichText() before initializing squire in Secure Reply message box

### DIFF
--- a/extension/chrome/elements/compose-modules/compose-input-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-input-module.ts
@@ -40,7 +40,9 @@ export class ComposeInputModule extends ViewModule<ComposeView> {
       'click',
       this.view.setHandler(el => this.actionAddIntroHandler(el), this.view.errModule.handle(`add intro`))
     );
-    this.initSquire(this.isRichText());
+    if (this.isRichText()) {
+      this.initSquire(true);
+    }
     // Set lastDraftBody to current empty squire content ex: <div><br></div>)
     // https://github.com/FlowCrypt/flowcrypt-browser/issues/5184
     this.view.draftModule.setLastDraftBody(this.squire.getHTML());

--- a/extension/chrome/elements/compose-modules/compose-input-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-input-module.ts
@@ -36,13 +36,11 @@ export class ComposeInputModule extends ViewModule<ComposeView> {
   }
 
   public setHandlers = () => {
+    this.toggleRichTextFormatting();
     this.view.S.cached('add_intro').on(
       'click',
       this.view.setHandler(el => this.actionAddIntroHandler(el), this.view.errModule.handle(`add intro`))
     );
-    if (this.isRichText()) {
-      this.initSquire(true);
-    }
     // Set lastDraftBody to current empty squire content ex: <div><br></div>)
     // https://github.com/FlowCrypt/flowcrypt-browser/issues/5184
     this.view.draftModule.setLastDraftBody(this.squire.getHTML());
@@ -105,6 +103,14 @@ export class ComposeInputModule extends ViewModule<ComposeView> {
     const currentLength = targetInputField.innerText.trim().length;
     const isInputLimitExceeded = currentLength - toBeRemoved + textToPaste.length > limit;
     return isInputLimitExceeded;
+  };
+
+  private toggleRichTextFormatting = () => {
+    if (this.isRichText()) {
+      this.addRichTextFormatting();
+    } else {
+      this.removeRichTextFormatting();
+    }
   };
 
   private initSquire = (addLinks: boolean, removeExistingLinks = false) => {

--- a/extension/chrome/elements/compose-modules/compose-input-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-input-module.ts
@@ -54,7 +54,7 @@ export class ComposeInputModule extends ViewModule<ComposeView> {
   };
 
   public removeRichTextFormatting = () => {
-    if (this.view.inputModule.isRichText()) {
+    if (this.isRichText()) {
       this.initSquire(false, true);
     }
   };

--- a/extension/chrome/elements/compose-modules/compose-input-module.ts
+++ b/extension/chrome/elements/compose-modules/compose-input-module.ts
@@ -36,7 +36,7 @@ export class ComposeInputModule extends ViewModule<ComposeView> {
   }
 
   public setHandlers = () => {
-    this.toggleRichTextFormatting();
+    this.configureRichTextFormatting();
     this.view.S.cached('add_intro').on(
       'click',
       this.view.setHandler(el => this.actionAddIntroHandler(el), this.view.errModule.handle(`add intro`))
@@ -105,7 +105,7 @@ export class ComposeInputModule extends ViewModule<ComposeView> {
     return isInputLimitExceeded;
   };
 
-  private toggleRichTextFormatting = () => {
+  private configureRichTextFormatting = () => {
     if (this.isRichText()) {
       this.addRichTextFormatting();
     } else {

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -1686,7 +1686,7 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
         expect(await composePage.read('.swal2-html-container')).to.include('Send empty message?');
         await composePage.waitAndClick('.swal2-cancel');
         const footer = await composePage.read('@input-body');
-        expect(footer).to.eq('\n\n\n\n--\n\nflowcrypt.compatibility test footer with an img\n\nand second line\n');
+        expect(footer).to.eq('\n\n\n--\nflowcrypt.compatibility test footer with an img\nand second line');
         await composePage.waitAndClick(`@action-send`);
         expect(await composePage.read('.swal2-html-container')).to.include('Send empty message?');
         await composePage.waitAndClick('.swal2-cancel');


### PR DESCRIPTION
This PR fixes squire initialization for secure compose message box where newlines gets injected above the current line when `Enter` is pressed.

close #5838 

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
