### PR TITLE
Reduce GlobalStore accounts in addition to sessionStorage removal

### DIFF
--- a/extension/js/common/platform/store/global-store.ts
+++ b/extension/js/common/platform/store/global-store.ts
@@ -94,12 +94,10 @@ export class GlobalStore extends AbstractStore {
     }
   }
 
-  public static async acctEmailsRemove(acctEmail: string, openUninstallUrl = true): Promise<void> {
+  public static async acctEmailsRemove(acctEmail: string): Promise<void> {
     // todo: concurrency issues with another tab loaded at the same time
     const acctEmails = await GlobalStore.acctEmailsGet();
     await GlobalStore.set({ account_emails: JSON.stringify(Value.arr.withoutVal(acctEmails, acctEmail)) }); // eslint-disable-line @typescript-eslint/naming-convention
-    if (openUninstallUrl) {
-      BrowserMsg.send.bg.updateUninstallUrl();
-    }
+    BrowserMsg.send.bg.updateUninstallUrl();
   }
 }

--- a/extension/js/common/platform/store/global-store.ts
+++ b/extension/js/common/platform/store/global-store.ts
@@ -94,10 +94,12 @@ export class GlobalStore extends AbstractStore {
     }
   }
 
-  public static async acctEmailsRemove(acctEmail: string): Promise<void> {
+  public static async acctEmailsRemove(acctEmail: string, softReset = false): Promise<void> {
     // todo: concurrency issues with another tab loaded at the same time
     const acctEmails = await GlobalStore.acctEmailsGet();
     await GlobalStore.set({ account_emails: JSON.stringify(Value.arr.withoutVal(acctEmails, acctEmail)) }); // eslint-disable-line @typescript-eslint/naming-convention
-    BrowserMsg.send.bg.updateUninstallUrl();
+    if (!softReset) {
+      BrowserMsg.send.bg.updateUninstallUrl();
+    }
   }
 }

--- a/extension/js/common/platform/store/global-store.ts
+++ b/extension/js/common/platform/store/global-store.ts
@@ -94,11 +94,11 @@ export class GlobalStore extends AbstractStore {
     }
   }
 
-  public static async acctEmailsRemove(acctEmail: string, softReset = false): Promise<void> {
+  public static async acctEmailsRemove(acctEmail: string, openUninstallUrl = true): Promise<void> {
     // todo: concurrency issues with another tab loaded at the same time
     const acctEmails = await GlobalStore.acctEmailsGet();
     await GlobalStore.set({ account_emails: JSON.stringify(Value.arr.withoutVal(acctEmails, acctEmail)) }); // eslint-disable-line @typescript-eslint/naming-convention
-    if (!softReset) {
+    if (openUninstallUrl) {
       BrowserMsg.send.bg.updateUninstallUrl();
     }
   }

--- a/extension/js/common/settings.ts
+++ b/extension/js/common/settings.ts
@@ -87,9 +87,8 @@ export class Settings {
     const acctEmails = await GlobalStore.acctEmailsGet();
     if (!acctEmails.includes(acctEmail)) {
       throw new Error(`"${acctEmail}" is not a known account_email in "${JSON.stringify(acctEmails)}"`);
-    } else {
-      await GlobalStore.acctEmailsRemove(acctEmail, false);
     }
+    await GlobalStore.acctEmailsRemove(acctEmail);
     const storageIndexesToRemove: AccountIndex[] = [];
     const filter = AbstractStore.singleScopeRawIndex(acctEmail, '');
     if (!filter) {
@@ -192,7 +191,6 @@ export class Settings {
       }
     }
     await Settings.acctStorageReset(oldAcctEmail);
-    await GlobalStore.acctEmailsRemove(oldAcctEmail);
   }
 
   public static async renderPrvCompatFixUiAndWaitTilSubmittedByUser(

--- a/extension/js/common/settings.ts
+++ b/extension/js/common/settings.ts
@@ -87,6 +87,8 @@ export class Settings {
     const acctEmails = await GlobalStore.acctEmailsGet();
     if (!acctEmails.includes(acctEmail)) {
       throw new Error(`"${acctEmail}" is not a known account_email in "${JSON.stringify(acctEmails)}"`);
+    } else {
+      await GlobalStore.acctEmailsRemove(acctEmail, true);
     }
     const storageIndexesToRemove: AccountIndex[] = [];
     const filter = AbstractStore.singleScopeRawIndex(acctEmail, '');

--- a/extension/js/common/settings.ts
+++ b/extension/js/common/settings.ts
@@ -88,7 +88,7 @@ export class Settings {
     if (!acctEmails.includes(acctEmail)) {
       throw new Error(`"${acctEmail}" is not a known account_email in "${JSON.stringify(acctEmails)}"`);
     } else {
-      await GlobalStore.acctEmailsRemove(acctEmail, true);
+      await GlobalStore.acctEmailsRemove(acctEmail, false);
     }
     const storageIndexesToRemove: AccountIndex[] = [];
     const filter = AbstractStore.singleScopeRawIndex(acctEmail, '');


### PR DESCRIPTION
This PR updates the data from `GlobalStore` storage making it syncronized when accounts from sessionStorage is removed. This update helps determining unconnected accounts in an event of account reset. 

close #5797 

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
