### PR TITLE
# 5576 Add TrustedHTML flag in DomPurify

### DIFF
--- a/extension/js/common/platform/xss.ts
+++ b/extension/js/common/platform/xss.ts
@@ -82,13 +82,15 @@ export class Xss {
   public static htmlSanitize = (dirtyHtml: string, tagCheck = false): string => {
     Xss.throwIfNotSupported();
     /* eslint-disable @typescript-eslint/naming-convention */
-    return DOMPurify.sanitize(dirtyHtml, {
+    const sanitized = DOMPurify.sanitize(dirtyHtml, {
       ADD_ATTR: Xss.ADD_ATTR,
+      RETURN_TRUSTED_TYPE: true,
       FORBID_ATTR: Xss.FORBID_ATTR,
       ...(tagCheck && { ALLOWED_TAGS: Xss.ALLOWED_HTML_TAGS }),
       ALLOWED_URI_REGEXP: Xss.sanitizeHrefRegexp(),
     });
     /* eslint-enable @typescript-eslint/naming-convention */
+    return sanitized as unknown as string;
   };
 
   /**

--- a/extension/types/purify.d.ts
+++ b/extension/types/purify.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="trusted-types"/>
+import { TrustedHTML } from 'trusted-types';
 
 export as namespace DOMPurify;
 export = DOMPurify;
@@ -24,7 +24,7 @@ interface createDOMPurifyI extends DOMPurify.DOMPurifyI {
 declare namespace DOMPurify {
     interface DOMPurifyI {
         sanitize(source: string | Node): string;
-        // sanitize(source: string | Node, config: Config & { RETURN_TRUSTED_TYPE: true }): TrustedHTML;
+        sanitize(source: string | Node, config: Config & { RETURN_TRUSTED_TYPE: true }): TrustedHTML;
         sanitize(
             source: string | Node,
             config: Config & { RETURN_DOM_FRAGMENT?: false | undefined; RETURN_DOM?: false | undefined },

--- a/extension/types/trusted-types.d.ts
+++ b/extension/types/trusted-types.d.ts
@@ -1,3 +1,64 @@
-interface Window {
-  trustedTypes: any;
+// The main type definitions. Packages that do not want to pollute the global
+// scope with Trusted Types (e.g. libraries whose users may not be using Trusted
+// Types) can import the types directly from 'trusted-types/lib'.
+
+export type FnNames = keyof TrustedTypePolicyOptions;
+export type Args<Options extends TrustedTypePolicyOptions, K extends FnNames> = Parameters<NonNullable<Options[K]>>;
+
+export class TrustedHTML {
+    private constructor(); // To prevent instantiting with 'new'.
+    private brand: true; // To prevent structural typing.
+}
+
+export class TrustedScript {
+    private constructor(); // To prevent instantiting with 'new'.
+    private brand: true; // To prevent structural typing.
+}
+
+export class TrustedScriptURL {
+    private constructor(); // To prevent instantiting with 'new'.
+    private brand: true; // To prevent structural typing.
+}
+
+export abstract class TrustedTypePolicyFactory {
+    createPolicy<Options extends TrustedTypePolicyOptions>(
+        policyName: string,
+        policyOptions?: Options,
+    ): Pick<TrustedTypePolicy<Options>, "name" | Extract<keyof Options, FnNames>>;
+    isHTML(value: unknown): value is TrustedHTML;
+    isScript(value: unknown): value is TrustedScript;
+    isScriptURL(value: unknown): value is TrustedScriptURL;
+    readonly emptyHTML: TrustedHTML;
+    readonly emptyScript: TrustedScript;
+    getAttributeType(tagName: string, attribute: string, elementNs?: string, attrNs?: string): string | null;
+    getPropertyType(tagName: string, property: string, elementNs?: string): string | null;
+    readonly defaultPolicy: TrustedTypePolicy | null;
+}
+
+export abstract class TrustedTypePolicy<Options extends TrustedTypePolicyOptions = TrustedTypePolicyOptions> {
+    readonly name: string;
+    createHTML(...args: Args<Options, "createHTML">): TrustedHTML;
+    createScript(...args: Args<Options, "createScript">): TrustedScript;
+    createScriptURL(...args: Args<Options, "createScriptURL">): TrustedScriptURL;
+}
+
+export interface TrustedTypePolicyOptions {
+    createHTML?: ((input: string, ...arguments: any[]) => string) | undefined;
+    createScript?: ((input: string, ...arguments: any[]) => string) | undefined;
+    createScriptURL?: ((input: string, ...arguments: any[]) => string) | undefined;
+}
+
+// The Window object is augmented with the following properties in browsers that
+// support Trusted Types. Users of the 'trusted-types/lib' entrypoint can cast
+// window as TrustedTypesWindow to access these properties.
+export interface TrustedTypesWindow {
+    // `trustedTypes` is left intentionally optional to make sure that
+    // people handle the case when their code is running in a browser not
+    // supporting trustedTypes.
+    trustedTypes?: TrustedTypePolicyFactory | undefined;
+    TrustedHTML: typeof TrustedHTML;
+    TrustedScript: typeof TrustedScript;
+    TrustedScriptURL: typeof TrustedScriptURL;
+    TrustedTypePolicyFactory: typeof TrustedTypePolicyFactory;
+    TrustedTypePolicy: typeof TrustedTypePolicy;
 }


### PR DESCRIPTION
This PR added `RETURN_TRUSTED_TYPE` flag in `DomPurfify.sanitize()` applicable functions.

close #5576

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
