### PR TITLE
#5888 Update border for Secure Compose button

### DIFF
--- a/extension/css/webmail.css
+++ b/extension/css/webmail.css
@@ -5,7 +5,7 @@
   display: inline-flex;
   align-items: center;
   width: auto;
-  height: 48px;
+  height: 56px;
   margin: 0;
   padding: 0 24px 0 0;
   transition: box-shadow 0.15s cubic-bezier(0.4, 0, 0.2, 1);
@@ -15,7 +15,7 @@
   line-height: 32px;
   background-color: #fff;
   border: none;
-  border-radius: 24px;
+  border-radius: 16px;
   box-shadow:
     0 1px 2px 0 rgb(60 64 67 / 30%),
     0 1px 3px 1px rgb(60 64 67 / 15%);
@@ -65,7 +65,7 @@
 .bhZ:not(.bym) #flowcrypt_secure_compose_button_icon {
   width: 56px;
   height: 56px;
-  border-radius: 28px;
+  border-radius: 16px;
   font-size: 0;
   padding: 0;
 }


### PR DESCRIPTION
This PR only updates the CSS for FlowCrypt's secure compose to have identical UI with Gmail's compose button.

The UI does not affect any other existing CSS plus 3 secure compose UI locations we're perfectly aligned. Even the 3rd case where it still matches for slightly rounded Gmail buttons.

Screenshots:

<img width="249" alt="image" src="https://github.com/user-attachments/assets/02a92e4a-c4fc-4ab3-bad5-c2381c1341c3" />

<img width="206" alt="image" src="https://github.com/user-attachments/assets/bd8196e1-a583-4702-b202-7d921bc75681" />

<img width="240" alt="image" src="https://github.com/user-attachments/assets/dff473d4-aa20-415c-89e0-0b2a7944bde6" />

close #5888

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
