### PR TITLE
#5886 Fix: failed to execute json on response error in console on message send

### DIFF
--- a/extension/js/common/api/shared/api.ts
+++ b/extension/js/common/api/shared/api.ts
@@ -246,7 +246,14 @@ export class Api {
       } else if (resFmt === 'json') {
         try {
           const transformed = transformResponseWithProgressAndTimeout();
-          return (await Promise.all([transformed.response.json(), transformed.pipe()]))[0] as FetchResult<T, RT>;
+          return (
+            await Promise.all([
+              transformed.response.text().then(text => {
+                return (text ? JSON.parse(text) : {}) as T; // Handle empty response body
+              }),
+              transformed.pipe(),
+            ])
+          )[0] as FetchResult<T, RT>;
         } catch (e) {
           // handle empty response https://github.com/FlowCrypt/flowcrypt-browser/issues/5601
           if (e instanceof SyntaxError && (e.message === 'Unexpected end of JSON input' || e.message.startsWith('JSON.parse: unexpected end of data'))) {


### PR DESCRIPTION
This PR fixed failed to execute json on response error in console on message send 

close #5886 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test (Can't simulate this in CI environment)
- 
--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
