### PR TITLE
#5032 Show clearer error message why key is not usable

### DIFF
--- a/extension/chrome/elements/pgp_pubkey.htm
+++ b/extension/chrome/elements/pgp_pubkey.htm
@@ -14,7 +14,7 @@
     <div id="pgp_block" class="pgp_pubkey" data-test="container-pgp-pubkey">
       <div class="line error_container hidden">
         <div class="error_info">
-          <span data-test="error-introduce-label">This OpenPGP key is not usable.</span>
+          <span class="error_introduce_label" data-test="error-introduce-label">This OpenPGP key is not usable.</span>
           <input class="input_error_email" disabled data-test="error-email-input" />
         </div>
 

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -1629,6 +1629,10 @@ td {
   display: none;
 }
 
+#pgp_block.pgp_pubkey .action_show_full {
+  width: 118px;
+}
+
 #pgp_block .three_dots {
   text-align: center;
   width: 25px;

--- a/extension/css/cryptup.css
+++ b/extension/css/cryptup.css
@@ -1446,6 +1446,10 @@ td {
   align-items: flex-start;
 }
 
+.pgp_neutral .error_container .error_info .error_introduce_label {
+  white-space: pre-line;
+}
+
 .pgp_neutral .error_container .error_info span {
   color: #a44;
   font-size: 14px;

--- a/extension/js/common/core/crypto/pgp/openpgp-key.ts
+++ b/extension/js/common/core/crypto/pgp/openpgp-key.ts
@@ -428,6 +428,19 @@ export class OpenPGPKey {
     return nonDummyPrvPackets.every(p => p.isDecrypted());
   }
 
+  public static async checkPublicKeyError(pubkey: Key): Promise<string | undefined> {
+    try {
+      const key = await OpenPGPKey.extractExternalLibraryObjFromKey(pubkey);
+      await opgp.encrypt({
+        message: await opgp.createMessage({ text: OpenPGPKey.encryptionText }),
+        encryptionKeys: key.toPublic(),
+        format: 'armored',
+      });
+      return undefined;
+    } catch (err) {
+      return String(err);
+    }
+  }
   public static isFullyEncrypted(key: OpenPGP.PrivateKey): boolean {
     const nonDummyPrvPackets = OpenPGPKey.getPrvPackets(key);
     return nonDummyPrvPackets.every(p => !p.isDecrypted());

--- a/test/source/tests/settings.ts
+++ b/test/source/tests/settings.ts
@@ -382,6 +382,7 @@ export const defineSettingsTests = (testVariant: TestVariant, testWithBrowser: T
         const firstFrameId = /frameId=.*?&/s.exec(framesUrls[0])![0];
         const errorFrame = await contactsFrame.getFrame(['pgp_pubkey.htm', firstFrameId]);
         await errorFrame.waitForContent('@error-introduce-label', 'This OpenPGP key is not usable.');
+        await errorFrame.waitForContent('@error-introduce-label', 'Could not verify primary key: dsa keys are considered too weak');
         await errorFrame.waitForInputValue('@error-email-input', 'dsa@flowcrypt.test');
       })
     );


### PR DESCRIPTION
This PR implemented fix to show clearer error message why key is not usable

close #5032 // if this PR closes an issue

![image](https://github.com/user-attachments/assets/f1d96060-d88f-4a4a-91e0-9ce210c896ef)


----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
