### PR TITLE
#5900 Fix delay issue when adding secure messaging action buttons on Gmail context menu

### DIFF
--- a/extension/js/content_scripts/webmail/gmail/gmail-element-replacer.ts
+++ b/extension/js/content_scripts/webmail/gmail/gmail-element-replacer.ts
@@ -291,10 +291,12 @@ export class GmailElementReplacer extends WebmailElementReplacer {
   };
 
   private replaceActionsMenu = () => {
-    if ($('.action_menu_message_button').length <= 0) {
-      this.addMenuButton('reply', '#r');
-      this.addMenuButton('forward', '#r3');
-    }
+    $(this.sel.msgActionsBtn).on('click', () => {
+      if ($('.action_menu_message_button').length <= 0) {
+        this.addMenuButton('reply', '#r');
+        this.addMenuButton('forward', '#r3');
+      }
+    });
   };
 
   private replaceConvoBtns = (force = false) => {


### PR DESCRIPTION
This PR fixes the delay issue when the extension tried to add the secure messaging action buttons on Gmail context menu.

close #5900

Screen recording of the propose fix:

https://github.com/user-attachments/assets/14f69919-c81c-4b58-bba5-f7f3b950cd41

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
