### PR TITLE
#5913 Add encrypted attachment to password protected message

### DIFF
--- a/extension/chrome/elements/compose-modules/formatters/encrypted-mail-msg-formatter.ts
+++ b/extension/chrome/elements/compose-modules/formatters/encrypted-mail-msg-formatter.ts
@@ -85,7 +85,7 @@ export class EncryptedMsgMailFormatter extends BaseMailFormatter {
       );
     }
     // rich text: PGP/MIME - https://tools.ietf.org/html/rfc3156#section-4
-    const attachments = this.formatEncryptedMimeDataAsPgpMimeMetaAttachments(encrypted);
+    const attachments = await this.formatEncryptedMimeDataAsPgpMimeMetaAttachments(encrypted, pubkeys);
     return await SendableMsg.createPgpMime(this.acctEmail, this.headers(newMsg), attachments, {
       isDraft: this.isDraft,
     });
@@ -191,7 +191,7 @@ export class EncryptedMsgMailFormatter extends BaseMailFormatter {
       this.acctEmail,
       this.headers(newMsg),
       emailIntroAndLinkBody,
-      this.formatEncryptedMimeDataAsPgpMimeMetaAttachments(pubEncryptedNoAttachments),
+      await this.formatEncryptedMimeDataAsPgpMimeMetaAttachments(pubEncryptedNoAttachments, pubs),
       { isDraft: this.isDraft, externalId }
     );
   };
@@ -212,8 +212,8 @@ export class EncryptedMsgMailFormatter extends BaseMailFormatter {
     });
   };
 
-  private formatEncryptedMimeDataAsPgpMimeMetaAttachments = (data: Uint8Array) => {
-    const attachments: Attachment[] = [];
+  private formatEncryptedMimeDataAsPgpMimeMetaAttachments = async (data: Uint8Array, pubkeys: PubkeyResult[]) => {
+    const attachments: Attachment[] = await this.view.attachmentsModule.attachment.collectEncryptAttachments(pubkeys);
     attachments.push(
       new Attachment({
         data: Buf.fromUtfStr('Version: 1'),

--- a/test/source/mock/google/strategies/send-message-strategy.ts
+++ b/test/source/mock/google/strategies/send-message-strategy.ts
@@ -30,7 +30,7 @@ const checkForAbsenceofBase64InAttachments = async (attachments: Attachment[]) =
     if (typeof encoding !== 'string') {
       throw new HttpClientErr(`Error: Content-Transfer-Encoding isn't present in one of the attachments`);
     }
-    if (!['7bit', 'quoted-printable'].includes(encoding)) {
+    if (!['7bit', 'quoted-printable', 'base64'].includes(encoding)) {
       throw new HttpClientErr(`Error: Unexpected Content-Transfer-Encoding: ${encoding}`);
     }
   }

--- a/test/source/mock/google/strategies/send-message-strategy.ts
+++ b/test/source/mock/google/strategies/send-message-strategy.ts
@@ -452,8 +452,6 @@ export class TestBySubjectStrategyContext {
       this.strategy = new PwdAndPubkeyEncryptedMessagesWithFlowCryptComApiTestStrategy();
     } else if (subject.includes('PWD encrypted message with FES - ID TOKEN')) {
       this.strategy = new PwdEncryptedMessageWithFesIdTokenTestStrategy();
-    } else if (subject.includes('attachment included correctly in PWD encrypted message')) {
-      this.strategy = new SaveMessageInStorageStrategy();
     } else if (subject.includes('PWD encrypted message with FES - Reply rendering')) {
       this.strategy = new PwdEncryptedMessageWithFesReplyRenderingTestStrategy();
     } else if (subject.includes('PWD encrypted message with FES - pubkey recipient in bcc')) {

--- a/test/source/mock/google/strategies/send-message-strategy.ts
+++ b/test/source/mock/google/strategies/send-message-strategy.ts
@@ -30,7 +30,7 @@ const checkForAbsenceofBase64InAttachments = async (attachments: Attachment[]) =
     if (typeof encoding !== 'string') {
       throw new HttpClientErr(`Error: Content-Transfer-Encoding isn't present in one of the attachments`);
     }
-    if (!['7bit', 'quoted-printable', 'base64'].includes(encoding)) {
+    if (!['7bit', 'quoted-printable'].includes(encoding)) {
       throw new HttpClientErr(`Error: Unexpected Content-Transfer-Encoding: ${encoding}`);
     }
   }

--- a/test/source/mock/google/strategies/send-message-strategy.ts
+++ b/test/source/mock/google/strategies/send-message-strategy.ts
@@ -452,6 +452,8 @@ export class TestBySubjectStrategyContext {
       this.strategy = new PwdAndPubkeyEncryptedMessagesWithFlowCryptComApiTestStrategy();
     } else if (subject.includes('PWD encrypted message with FES - ID TOKEN')) {
       this.strategy = new PwdEncryptedMessageWithFesIdTokenTestStrategy();
+    } else if (subject.includes('attachment included correctly in PWD encrypted message')) {
+      this.strategy = new SaveMessageInStorageStrategy();
     } else if (subject.includes('PWD encrypted message with FES - Reply rendering')) {
       this.strategy = new PwdEncryptedMessageWithFesReplyRenderingTestStrategy();
     } else if (subject.includes('PWD encrypted message with FES - pubkey recipient in bcc')) {

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -205,6 +205,24 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
     );
 
     test(
+      'compose - attachment included correctly in PWD encrypted message',
+      testWithBrowser(async (t, browser) => {
+        const acctEmail = 'ci.tests.gmail@flowcrypt.test';
+        await BrowserRecipe.setupCommonAcctWithAttester(t, browser, 'ci.tests.gmail');
+        const subject = 'attachment included correctly in PWD encrypted message';
+        const composePage = await ComposePageRecipe.openStandalone(t, browser, acctEmail);
+        await ComposePageRecipe.fillMsg(composePage, { to: 'test@email.com' }, subject, 'test');
+        const fileInput = (await composePage.target.$('input[type=file]'))!;
+        await fileInput.uploadFile('test/samples/small.txt');
+        await composePage.waitAndType('@input-password', 'gO0d-pwd');
+        await composePage.waitAndClick('@action-send', { delay: 1 });
+        await ComposePageRecipe.closed(composePage);
+        const sentMsgs = (await GoogleData.withInitializedData(acctEmail)).searchMessagesBySubject(subject);
+        expect(sentMsgs[0]?.payload?.parts?.find(part => part.filename?.includes('small.txt'))).to.not.be.undefined;
+      })
+    );
+
+    test(
       'user@key-manager-disabled-password-message.flowcrypt.test - disabled flowcrypt hosted password protected messages',
       testWithBrowser(async (t, browser) => {
         const acct = 'user@key-manager-disabled-password-message.flowcrypt.test';

--- a/test/source/tests/compose.ts
+++ b/test/source/tests/compose.ts
@@ -205,24 +205,6 @@ export const defineComposeTests = (testVariant: TestVariant, testWithBrowser: Te
     );
 
     test(
-      'compose - attachment included correctly in PWD encrypted message',
-      testWithBrowser(async (t, browser) => {
-        const acctEmail = 'ci.tests.gmail@flowcrypt.test';
-        await BrowserRecipe.setupCommonAcctWithAttester(t, browser, 'ci.tests.gmail');
-        const subject = 'attachment included correctly in PWD encrypted message';
-        const composePage = await ComposePageRecipe.openStandalone(t, browser, acctEmail);
-        await ComposePageRecipe.fillMsg(composePage, { to: 'test@email.com' }, subject, 'test');
-        const fileInput = (await composePage.target.$('input[type=file]'))!;
-        await fileInput.uploadFile('test/samples/small.txt');
-        await composePage.waitAndType('@input-password', 'gO0d-pwd');
-        await composePage.waitAndClick('@action-send', { delay: 1 });
-        await ComposePageRecipe.closed(composePage);
-        const sentMsgs = (await GoogleData.withInitializedData(acctEmail)).searchMessagesBySubject(subject);
-        expect(sentMsgs[0]?.payload?.parts?.find(part => part.filename?.includes('small.txt'))).to.not.be.undefined;
-      })
-    );
-
-    test(
       'user@key-manager-disabled-password-message.flowcrypt.test - disabled flowcrypt hosted password protected messages',
       testWithBrowser(async (t, browser) => {
         const acct = 'user@key-manager-disabled-password-message.flowcrypt.test';


### PR DESCRIPTION
This PR adds encrypted attachment to password protected messages so that attachment can be seen in password protected messages.

close #5913 // if this PR closes an issue
close #4702 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test(The current mock Gmail environment doesn't support decrypting sent messages. In a live Gmail test, we would need to use a real non-public key email recipient, which could be inconvenient as it requires sending actual messages to that recipient.)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
