### PR TITLE
update release-step-2-upload

### DIFF
--- a/tooling/release-step-2-upload
+++ b/tooling/release-step-2-upload
@@ -88,4 +88,5 @@ for filepath in replace_version_in_web_files:
   with open(filepath, 'w') as wp:
     wp.write(replaced)
 
-os.system('cd ../flowcrypt-web && git pull && git commit -a --message=\'firefox v%s links updated\' && git push && cd ../flowcrypt-browser' % version)
+os.system('cd ../flowcrypt-web && git pull && git checkout -b release-%s && git commit -a --message=\'firefox v%s links updated\' && git push origin release-%s && cd ../flowcrypt-browser' % dashed_version, version, dashed_version))
+


### PR DESCRIPTION
This PR updates `release-step-2-upload` to create new branch before pushing changes to `flowcrypt-web`, as pushing directly to `master` is forbidden.

no issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
