### PR TITLE
#5999 Add fingerprint when rendering private backups

### DIFF
--- a/extension/chrome/elements/backup.ts
+++ b/extension/chrome/elements/backup.ts
@@ -11,6 +11,7 @@ import { Url, Str } from '../../js/common/core/common.js';
 import { View } from '../../js/common/view.js';
 import { initPassphraseToggle } from '../../js/common/ui/passphrase-ui.js';
 import { KeyStore } from '../../js/common/platform/store/key-store.js';
+import { Xss } from '../../js/common/platform/xss.js';
 
 View.run(
   class BackupView extends View {
@@ -49,12 +50,12 @@ View.run(
       [this.storedPrvWithMatchingLongid] = await KeyStore.get(this.acctEmail, [fingerprint]);
       if (this.storedPrvWithMatchingLongid) {
         $('.line .private_key_status').html(
-          `This private key with fingerprint <span class="green">${Str.spaced(fingerprint)}</span> has already been imported.`
+          `This private key with fingerprint <span class="green">${Xss.escape(Str.spaced(fingerprint))}</span> has already been imported.`
         );
       } else {
         $('.line .private_key_status')
           .html(
-            `The private key <span class="green">${Str.spaced(fingerprint)}</span> has not been imported yet. \n` +
+            `The private key <span class="green">${Xss.escape(Str.spaced(fingerprint))}</span> has not been imported yet. \n` +
               `We recommend importing all backups to ensure you can read all incoming encrypted emails.`
           )
           .after('<div class="line"><button class="button green" id="action_import_key">Import Missing Private Key</button></div>'); // xss-direct

--- a/extension/chrome/elements/backup.ts
+++ b/extension/chrome/elements/backup.ts
@@ -48,10 +48,15 @@ View.run(
       }
       [this.storedPrvWithMatchingLongid] = await KeyStore.get(this.acctEmail, [fingerprint]);
       if (this.storedPrvWithMatchingLongid) {
-        $('.line .private_key_status').text('This Private Key is already imported.');
+        $('.line .private_key_status').html(
+          `This private key with fingerprint <span class="green">${Str.spaced(fingerprint)}</span> has already been imported.`
+        );
       } else {
         $('.line .private_key_status')
-          .text('This private key was not imported yet. We suggest to import all backups so that you can read all incoming encrypted emails.')
+          .html(
+            `The private key <span class="green">${Str.spaced(fingerprint)}</span> has not been imported yet. \n` +
+              `We recommend importing all backups to ensure you can read all incoming encrypted emails.`
+          )
           .after('<div class="line"><button class="button green" id="action_import_key">Import Missing Private Key</button></div>'); // xss-direct
       }
       this.sendResizeMsg();

--- a/test/source/tests/decrypt.ts
+++ b/test/source/tests/decrypt.ts
@@ -111,7 +111,7 @@ export const defineDecryptTests = (testVariant: TestVariant, testWithBrowser: Te
           await gmailPage.getFrame(['backup.htm'])
         ).waitForContent(
           '@private-key-status',
-          'This private key with fingerprint 5520 CACE 2CB6 1EA7 13E5 B005 7FDE 6855 48AE A788 has already been imported.'
+          'This private key with fingerprint E8F0 517B A6D7 DAB6 081C 96E4 ADAC 279C 9509 3207 has already been imported.'
         );
         await gmailPage.close();
       })

--- a/test/source/tests/decrypt.ts
+++ b/test/source/tests/decrypt.ts
@@ -72,11 +72,21 @@ export const defineDecryptTests = (testVariant: TestVariant, testWithBrowser: Te
         const { acctEmail, authHdr } = await BrowserRecipe.setupCommonAcctWithAttester(t, browser, 'compatibility');
         const inboxPage = await browser.newExtensionPage(t, `chrome/settings/inbox/inbox.htm?acctEmail=${acctEmail}&threadId=${threadId}`);
         await inboxPage.waitForSelTestState('ready');
-        await (await inboxPage.getFrame(['backup.htm'])).waitForContent('@private-key-status', 'This Private Key is already imported.');
+        await (
+          await inboxPage.getFrame(['backup.htm'])
+        ).waitForContent(
+          '@private-key-status',
+          'This private key with fingerprint 5520 CACE 2CB6 1EA7 13E5 B005 7FDE 6855 48AE A788 has already been imported.'
+        );
         await inboxPage.close();
         const gmailPage = await browser.newPage(t, `${t.context.urls?.mockGmailUrl()}/${threadId}`, undefined, authHdr);
         await gmailPage.waitAll('iframe');
-        await (await gmailPage.getFrame(['backup.htm'])).waitForContent('@private-key-status', 'This Private Key is already imported.');
+        await (
+          await gmailPage.getFrame(['backup.htm'])
+        ).waitForContent(
+          '@private-key-status',
+          'This private key with fingerprint 5520 CACE 2CB6 1EA7 13E5 B005 7FDE 6855 48AE A788 has already been imported.'
+        );
         await gmailPage.close();
       })
     );

--- a/test/source/tests/decrypt.ts
+++ b/test/source/tests/decrypt.ts
@@ -98,11 +98,21 @@ export const defineDecryptTests = (testVariant: TestVariant, testWithBrowser: Te
         const { acctEmail, authHdr } = await BrowserRecipe.setupCommonAcctWithAttester(t, browser, 'compatibility');
         const inboxPage = await browser.newExtensionPage(t, `chrome/settings/inbox/inbox.htm?acctEmail=${acctEmail}&threadId=${threadId}`);
         await inboxPage.waitForSelTestState('ready');
-        await (await inboxPage.getFrame(['backup.htm'])).waitForContent('@private-key-status', 'This Private Key is already imported.');
+        await (
+          await inboxPage.getFrame(['backup.htm'])
+        ).waitForContent(
+          '@private-key-status',
+          'This private key with fingerprint E8F0 517B A6D7 DAB6 081C 96E4 ADAC 279C 9509 3207 has already been imported.'
+        );
         await inboxPage.close();
         const gmailPage = await browser.newPage(t, `${t.context.urls?.mockGmailUrl()}/${threadId}`, undefined, authHdr);
         await gmailPage.waitAll('iframe');
-        await (await gmailPage.getFrame(['backup.htm'])).waitForContent('@private-key-status', 'This Private Key is already imported.');
+        await (
+          await gmailPage.getFrame(['backup.htm'])
+        ).waitForContent(
+          '@private-key-status',
+          'This private key with fingerprint 5520 CACE 2CB6 1EA7 13E5 B005 7FDE 6855 48AE A788 has already been imported.'
+        );
         await gmailPage.close();
       })
     );


### PR DESCRIPTION
This PR adds the key's fingerprint when rendering the private key backups in Gmail for easier recognition of keys, useful when removing unnecessary keys permanently.

Closes #5999

Screenshots:

For already imported keys:
![loaded](https://github.com/user-attachments/assets/90939728-4662-470f-89f2-62d3812f1eac)

For unimported keys:
![unloaded](https://github.com/user-attachments/assets/c4d4a154-51df-4c37-984d-8678897809da)

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
