### PR TITLE
#6031 Use https://mail.google.com/mail as URL for content script errors

### DIFF
--- a/extension/js/common/platform/catch.ts
+++ b/extension/js/common/platform/catch.ts
@@ -261,7 +261,9 @@ export class Catch {
     return {
       name: exception.name.substring(0, 50),
       message: Catch.groupSimilarReports(exception.message.substring(0, 200)),
-      url: Catch.groupSimilarReports(location.href.split('?')[0]),
+      // Use https://mail.google.com/mail as URL for content script errors
+      // https://github.com/FlowCrypt/flowcrypt-browser/issues/6031
+      url: Catch.RUNTIME_ENVIRONMENT === 'ex:s:gmail' ? 'https://mail.google.com/mail' : Catch.groupSimilarReports(location.href.split('?')[0]),
       line: line || 1,
       col: col || 1,
       trace: Catch.groupSimilarReports(exception.stack || ''),


### PR DESCRIPTION
This PR uses https://mail.google.com/mail as URL for content script errors

close #6031 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
