### PR TITLE
#6172 Mark RSA 2048 as legacy

### DIFF
--- a/extension/chrome/elements/shared/create_key.template.htm
+++ b/extension/chrome/elements/shared/create_key.template.htm
@@ -52,10 +52,10 @@
     <label>
       Encryption key type:
       <select class="key_type" data-test="input-step2bmanualcreate-key-type">
-        <option value="curve25519">ECC Curve25519</option>
-        <option value="rsa2048">RSA 2048bit</option>
+        <option value="curve25519" selected>ECC Curve25519</option>
         <option value="rsa3072">RSA 3072bit</option>
         <option value="rsa4096">RSA 4096bit</option>
+        <option value="rsa2048">RSA 2048bit (legacy)</option>
       </select>
     </label>
   </div>


### PR DESCRIPTION
This PR labeled RSA 20248 as "legacy" to indicate that it's only there for legacy support and that 3072 and above is slightly better.

close #6172 

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
