### PR TITLE
Fix email encoding for path segments

### DIFF
--- a/extension/js/common/api/flowcrypt-website.ts
+++ b/extension/js/common/api/flowcrypt-website.ts
@@ -3,6 +3,7 @@
 
 import { Api } from './shared/api.js';
 import { Browser } from '../browser/browser.js';
+import { Url } from '../core/common.js';
 import { CatchHelper } from '../platform/catch-helper.js';
 
 namespace FlowCryptWebsiteRes {
@@ -11,7 +12,7 @@ namespace FlowCryptWebsiteRes {
 
 export class FlowCryptWebsite extends Api {
   public static pubKeyUrl = (resource: string) => {
-    return `https://flowcrypt.com/pub/${encodeURIComponent(resource)}`;
+    return `https://flowcrypt.com/pub/${Url.encodeEmailAddressForPathSegment(resource)}`;
   };
 
   public static retrieveBlogPosts = async (): Promise<FlowCryptWebsiteRes.FcBlogPost[]> => {

--- a/extension/js/common/api/key-server/attester.ts
+++ b/extension/js/common/api/key-server/attester.ts
@@ -3,7 +3,7 @@
 'use strict';
 
 import { Api } from './../shared/api.js';
-import { Dict, Str } from '../../core/common.js';
+import { Dict, Str, Url } from '../../core/common.js';
 import { PubkeysSearchResult } from './../pub-lookup.js';
 import { AjaxErr, ApiErr } from '../shared/api-error.js';
 import { ClientConfiguration } from '../../client-configuration';
@@ -74,7 +74,7 @@ export class Attester extends Api {
     if (!this.clientConfiguration.canSubmitPubToAttester()) {
       throw new Error('Cannot replace pubkey at attester because your organisation rules forbid it');
     }
-    await this.pubCall(`pub/${encodeURIComponent(email)}`, pubkey, { authorization: `Bearer ${idToken}` });
+    await this.pubCall(`pub/${Url.encodeEmailAddressForPathSegment(email)}`, pubkey, { authorization: `Bearer ${idToken}` });
   };
 
   /**
@@ -86,7 +86,7 @@ export class Attester extends Api {
     if (!this.clientConfiguration.canSubmitPubToAttester()) {
       throw new Error('Cannot replace pubkey at attester because your organisation rules forbid it');
     }
-    return await this.pubCall(`pub/${encodeURIComponent(email)}`, pubkey);
+    return await this.pubCall(`pub/${Url.encodeEmailAddressForPathSegment(email)}`, pubkey);
   };
 
   public welcomeMessage = async (email: string, pubkey: string, idToken: string | undefined): Promise<{ sent: boolean }> => {
@@ -110,7 +110,7 @@ export class Attester extends Api {
 
   private doLookup = async (email: string): Promise<PubkeysSearchResult> => {
     try {
-      const r = await this.pubCall(`pub/${encodeURIComponent(email)}`);
+      const r = await this.pubCall(`pub/${Url.encodeEmailAddressForPathSegment(email)}`);
       return await this.getPubKeysSearchResult(r);
     } catch (e) {
       if (ApiErr.isNotFound(e)) {

--- a/extension/js/common/core/common.ts
+++ b/extension/js/common/core/common.ts
@@ -471,6 +471,10 @@ export class Url {
     return link;
   };
 
+  public static encodeEmailAddressForPathSegment = (email: string) => {
+    return encodeURIComponent(email).replace(/%40/gi, '@');
+  };
+
   public static removeParamsFromUrl = (url: string, paramsToDelete: string[]) => {
     const urlParts = url.split('?');
     if (!urlParts[1]) {


### PR DESCRIPTION
This PR fixes issue caused by https://github.com/FlowCrypt/flowcrypt-browser/pull/6237, which incorrectly encoded email addresses for some requests

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
