### PR TITLE
#6240 Improve checksum mismatch validation

### DIFF
--- a/extension/js/common/core/crypto/key.ts
+++ b/extension/js/common/core/crypto/key.ts
@@ -495,13 +495,12 @@ export class KeyUtil {
     return keys.map(k => ({ id: k.id, emails: k.users.map(u => u.email).filter((e): e is string => !!e), armored: KeyUtil.armor(k), family: k.family }));
   }
 
-  public static validateChecksum(armoredText: string): boolean {
+  public static isChecksumMismatch(armoredText: string): boolean {
     // Regex to capture any PGP armor block, e.g. SIGNATURE, MESSAGE, etc.
     // It captures: the block type in group (1), and the content in group (2)
     const pgpBlockRegex = /-----BEGIN PGP ([A-Z ]+)-----([\s\S]*?)-----END PGP \1-----/g;
 
     let match: RegExpExecArray | null;
-    let validFound = false;
 
     // Iterate over all PGP blocks in the text
     while ((match = pgpBlockRegex.exec(armoredText))) {
@@ -553,12 +552,12 @@ export class KeyUtil {
       const rawData = decodedChunks.join('');
       // eslint-disable-next-line @typescript-eslint/no-misused-spread
       const dataBytes = new Uint8Array([...rawData].map(c => c.charCodeAt(0)));
-      if (KeyUtil.crc24(dataBytes) === providedCRC) {
-        validFound = true;
+      if (KeyUtil.crc24(dataBytes) !== providedCRC) {
+        return true;
       }
     }
 
-    return validFound;
+    return false;
   }
 
   private static crc24 = (dataBytes: Uint8Array): number => {

--- a/extension/js/common/message-renderer.ts
+++ b/extension/js/common/message-renderer.ts
@@ -774,7 +774,7 @@ export class MessageRenderer {
         renderModule,
         this.getRetryVerification(signerEmail, verificationPubs => MessageRenderer.decryptFunctionToVerifyRes(() => decrypt(verificationPubs))),
         plainSubject,
-        !KeyUtil.validateChecksum(encryptedData.toString())
+        typeof encryptedData === 'string' && KeyUtil.isChecksumMismatch(encryptedData)
       );
     } else if (result.error.type === DecryptErrTypes.format) {
       if (fallbackToPlainText) {

--- a/test/source/tests/unit-node.ts
+++ b/test/source/tests/unit-node.ts
@@ -85,6 +85,20 @@ Something wrong with this key`),
         }
       );
     });
+    test(`[unit][KeyUtil.isChecksumMismatch] detects only present checksum mismatches`, t => {
+      const armoredWithValidChecksum = `-----BEGIN PGP MESSAGE-----
+
+aGVsbG8=
+=R/WK
+-----END PGP MESSAGE-----`;
+      const armoredWithInvalidChecksum = armoredWithValidChecksum.replace('=R/WK', '=AAAA');
+      const armoredWithoutChecksum = armoredWithValidChecksum.replace('\n=R/WK', '');
+
+      expect(KeyUtil.isChecksumMismatch(armoredWithValidChecksum)).to.equal(false);
+      expect(KeyUtil.isChecksumMismatch(armoredWithInvalidChecksum)).to.equal(true);
+      expect(KeyUtil.isChecksumMismatch(armoredWithoutChecksum)).to.equal(false);
+      t.pass();
+    });
     test(`[unit][OpenPGPKey.parse] throws on invalid input`, async t => {
       await t.throwsAsync(
         () =>


### PR DESCRIPTION
This PR fixes false `incorrect checksum` warnings for decrypted PGP messages. Previously, valid PGP messages without an armor checksum line were incorrectly reported as checksum failures. It happened with messages generated by openpgpjs v6, where the CRC24 armor checksum is optional and commonly omitted.

close #6240

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
