### PR TITLE
#6267 Fix Firefox content script sandbox bug

### DIFF
--- a/extension/lib/streams-firefox-fix.js
+++ b/extension/lib/streams-firefox-fix.js
@@ -1,0 +1,23 @@
+// ©️ 2016 - present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
+// Firefox content-script sandbox workaround.
+//
+// In the Firefox content-script isolated world, `ReadableStream`/`TransformStream` are Xray
+// wrappers of the page's native implementations. Constructing them with a source object from
+// the sandbox realm throws `Permission denied to access property "autoAllocateChunkSize"`
+// (https://bugzilla.mozilla.org/show_bug.cgi?id=1757836), which broke openpgp.js's compressed
+// packet (zip/zlib) decompression with `MalformedPacketError: Parsing CompressedDataPacket failed`.
+//
+// This script must run BEFORE the web-streams-polyfill script (both loaded before /lib/openpgp.js):
+// 1. It hides the native CompressionStream/DecompressionStream globals so that openpgp.js
+//    (loaded next) selects its bundled fflate JS fallback instead of
+//    `stream.pipeThrough(native DecompressionStream)`, which fails the web-streams-polyfill's
+//    brand checks.
+// 2. The web-streams-polyfill script then installs its own same-realm ReadableStream/
+//    WritableStream/TransformStream implementations on the sandbox global, so all stream objects
+//    created by openpgp.js and web-stream-tools live in a single realm and work as expected.
+if (typeof globalThis.CompressionStream !== 'undefined') {
+  globalThis.CompressionStream = undefined;
+}
+if (typeof globalThis.DecompressionStream !== 'undefined') {
+  globalThis.DecompressionStream = undefined;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "linkifyjs": "4.3.3",
         "node-forge": "1.4.0",
         "squire-rte": "2.4.8",
-        "sweetalert2": "11.26.25"
+        "sweetalert2": "11.26.25",
+        "web-streams-polyfill": "3.3.3"
       },
       "devDependencies": {
         "@openpgp/web-stream-tools": "0.3.1",
@@ -10757,7 +10758,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "linkifyjs": "4.3.3",
     "node-forge": "1.4.0",
     "squire-rte": "2.4.8",
-    "sweetalert2": "11.26.25"
+    "sweetalert2": "11.26.25",
+    "web-streams-polyfill": "3.3.3"
   },
   "scripts": {
     "build": "npm run symlink-core && node ./scripts/build.js",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -67,6 +67,9 @@ const copyDependencies = async () => {
     // Reference: https://github.com/mozilla/pdf.js/issues/18006#issuecomment-2078739672
     ['pdfjs-dist/legacy/build/pdf.min.mjs', 'lib/pdf.min.mjs'],
     ['pdfjs-dist/legacy/build/pdf.worker.min.mjs', 'lib/pdf.worker.min.mjs'],
+    // polyfill Web Streams in the Firefox content-script sandbox, see
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1757836
+    ['web-streams-polyfill/dist/polyfill.min.js', 'lib/web-streams-polyfill.min.js'],
     ['bootstrap/dist/js/bootstrap.min.js', 'lib/bootstrap/bootstrap.min.js'],
     ['bootstrap/dist/css/bootstrap.min.css', 'lib/bootstrap/bootstrap.min.css'],
   ];

--- a/tooling/build-types-and-manifests.ts
+++ b/tooling/build-types-and-manifests.ts
@@ -36,6 +36,15 @@ addManifest('firefox-consumer', manifest => {
       strict_min_version: '112.0', // eslint-disable-line @typescript-eslint/naming-convention
     },
   };
+  // Web Streams are broken in the Firefox content-script sandbox (Permission denied to access
+  // property "autoAllocateChunkSize" - https://bugzilla.mozilla.org/show_bug.cgi?id=1757836).
+  // Load the streams-fix shim + web-streams-polyfill BEFORE openpgp.js, so that stream objects
+  // created by openpgp.js / web-stream-tools live in a single (sandbox) realm.
+  // This is only needed in the content script: extension pages and the service worker are
+  // privileged and keep using the native implementations.
+  for (const csDef of manifest.content_scripts ?? []) {
+    csDef.js = ['/lib/streams-firefox-fix.js', '/lib/web-streams-polyfill.min.js', ...(csDef.js ?? [])];
+  }
   manifest.background = {
     type: 'module',
     scripts: ['/js/service_worker/background.js'],


### PR DESCRIPTION
This PR attempts to fix the Mozilla Firefox content script sandbox bug where `Permission denied to access property "autoAllocateChunkSize"` error occurs.

close #6267

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
